### PR TITLE
Unifying ACE and Markdown themes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'yaml_db'
 gem 'bunny'
 
 gem 'mumukit-content-type', git: 'https://github.com/mumuki/mumukit-content-type', require: 'mumukit/content_type'
-gem 'rouge', git: 'https://github.com/mumuki/rouge'
+gem 'rouge', git: 'https://github.com/mumuki/rouge', ref: '5a8db3387f3a67232569969cd3da40ee04eb9dc3'
 
 gem 'mumukit-auth', '~> 6.0'
 gem 'mumukit-core', '~> 0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/mumuki/rouge
-  revision: 5b7f5cd3d17c6a54d93bf57a82a0dfc2e03b3ae3
+  revision: 5a8db3387f3a67232569969cd3da40ee04eb9dc3
+  ref: 5a8db3387f3a67232569969cd3da40ee04eb9dc3
   specs:
     rouge (2.0.7)
 

--- a/app/assets/stylesheets/application/modules/_highlight.scss
+++ b/app/assets/stylesheets/application/modules/_highlight.scss
@@ -1,12 +1,77 @@
+/* See https://github.com/jneen/rouge/wiki/List-of-tokens */
+
+pre {
+  background-color: #f0f0f5;
+}
+
+/* identifier */
+.na, .nb, .nc, .no, .nd, .ni, .bp, .vc, .vg, .vi, .nx, .nv,
+.ace_function,
+.ace_variable,
+.ace_parameter,
+.ace_identifier,
+.ne,
+.nf,
+.nl {
+  color: black !important;
+}
+
+/* keyword */
+.k, .kn, .kp, .kr, .kt, .kd, .ace_keyword, .ace_type {
+  color: $brand-info  !important;
+  font-weight: bold !important;
+}
+
+/* literal */
+.m, .mf, .mh, .mi, .mo,
+.s, .sb, .sc, .sd, .s2, .se, .sh, .sx, .sr, .s1, .ss,
+.kc,
+.il, .ace_boolean, .ace_numeric, .ace_string {
+  color: #369434 !important;
+}
+
+/* operator */
+.ow, .o,
+.ace_operator,
+.ace_meta.ace_rule.ace_definition.ace_prolog {
+  color: $brand-complementary !important;
+  font-weight: bold !important;
+}
+
+/* comment */
+.ace_comment, .c, .cm, .cp, .c1, .cs {
+  color: grey !important;
+}
+
+/* Punctuation*/
+.ace_punctuation,
+.ace_paren,
+.p,
+.ace_keyword.ace_operator.ace_definition.ace_prolog,
+pre code {
+  color: black !important;
+  font-weight: normal !important;
+}
+
+/** Prolog Specific */
+
+/** Variables **/
+.ace_variable.ace_prolog,
+.prolog .nv {
+  color: $brand-info !important;
+  font-weight: normal !important;
+}
+
+/** Atoms */
+.ace_name.ace_prolog,
+.ace_atom.ace_prolog,
+.prolog .ss {
+  color: $brand-primary !important;
+  font-weight: normal !important;
+}
+
 .hll { background-color: #ffffcc }
-.c { color: #999988; font-style: italic } /* Comment */
 .err { color: #a61717; background-color: #e3d2d2 } /* Error */
-.k { color: #000000; font-weight: bold } /* Keyword */
-.o { color: #000000; font-weight: bold } /* Operator */
-.cm { color: #999988; font-style: italic } /* Comment.Multiline */
-.cp { color: #999999; font-weight: bold; font-style: italic } /* Comment.Preproc */
-.c1 { color: #999988; font-style: italic } /* Comment.Single */
-.cs { color: #999999; font-weight: bold; font-style: italic } /* Comment.Special */
 .gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
 .ge { color: #000000; font-style: italic } /* Generic.Emph */
 .gr { color: #aa0000 } /* Generic.Error */
@@ -17,45 +82,8 @@
 .gs { font-weight: bold } /* Generic.Strong */
 .gu { color: #aaaaaa } /* Generic.Subheading */
 .gt { color: #aa0000 } /* Generic.Traceback */
-.kc { color: #000000; font-weight: bold } /* Keyword.Constant */
-.kd { color: #000000; font-weight: bold } /* Keyword.Declaration */
-.kn { color: #000000; font-weight: bold } /* Keyword.Namespace */
-.kp { color: #000000; font-weight: bold } /* Keyword.Pseudo */
-.kr { color: #000000; font-weight: bold } /* Keyword.Reserved */
-.kt { color: #445588; font-weight: bold } /* Keyword.Type */
-.m { color: #009999 } /* Literal.Number */
-.s { color: #d01040 } /* Literal.String */
-.na { color: #008080 } /* Name.Attribute */
-.nb { color: #0086B3 } /* Name.Builtin */
-.nc { color: #445588; font-weight: bold } /* Name.Class */
-.no { color: #008080 } /* Name.Constant */
-.nd { color: #3c5d5d; font-weight: bold } /* Name.Decorator */
-.ni { color: #800080 } /* Name.Entity */
-.ne { color: #990000; font-weight: bold } /* Name.Exception */
-.nf { color: #990000; font-weight: bold } /* Name.Function */
-.nl { color: #990000; font-weight: bold } /* Name.Label */
 .nn { color: #555555 } /* Name.Namespace */
 .nt { color: #000080 } /* Name.Tag */
-.nv { color: #008080 } /* Name.Variable */
-.ow { color: #000000; font-weight: bold } /* Operator.Word */
 .w { color: #bbbbbb } /* Text.Whitespace */
-.mf { color: #009999 } /* Literal.Number.Float */
-.mh { color: #009999 } /* Literal.Number.Hex */
-.mi { color: #009999 } /* Literal.Number.Integer */
-.mo { color: #009999 } /* Literal.Number.Oct */
-.sb { color: #d01040 } /* Literal.String.Backtick */
-.sc { color: #d01040 } /* Literal.String.Char */
-.sd { color: #d01040 } /* Literal.String.Doc */
-.s2 { color: #d01040 } /* Literal.String.Double */
-.se { color: #d01040 } /* Literal.String.Escape */
-.sh { color: #d01040 } /* Literal.String.Heredoc */
 .si { color: #d01040 } /* Literal.String.Interpol */
-.sx { color: #d01040 } /* Literal.String.Other */
-.sr { color: #009926 } /* Literal.String.Regex */
-.s1 { color: #d01040 } /* Literal.String.Single */
-.ss { color: #990073 } /* Literal.String.Symbol */
-.bp { color: #999999 } /* Name.Builtin.Pseudo */
-.vc { color: #008080 } /* Name.Variable.Class */
-.vg { color: #008080 } /* Name.Variable.Global */
-.vi { color: #008080 } /* Name.Variable.Instance */
-.il { color: #009999 } /* Literal.Number.Integer.Long */
+

--- a/app/assets/stylesheets/application/modules/_highlight.scss
+++ b/app/assets/stylesheets/application/modules/_highlight.scss
@@ -26,7 +26,7 @@ pre {
 .m, .mf, .mh, .mi, .mo,
 .s, .sb, .sc, .sd, .s2, .se, .sh, .sx, .sr, .s1, .ss,
 .kc,
-.il, .ace_boolean, .ace_numeric, .ace_string {
+.il, .ace_boolean, .ace_numeric, .ace_string, .ace_symbol {
   color: #369434 !important;
 }
 
@@ -69,6 +69,9 @@ pre code {
   color: $brand-primary !important;
   font-weight: normal !important;
 }
+
+
+/** Misc **/
 
 .hll { background-color: #ffffcc }
 .err { color: #a61717; background-color: #e3d2d2 } /* Error */

--- a/app/assets/stylesheets/application/modules/_highlight.scss
+++ b/app/assets/stylesheets/application/modules/_highlight.scss
@@ -26,7 +26,11 @@ pre {
 .m, .mf, .mh, .mi, .mo,
 .s, .sb, .sc, .sd, .s2, .se, .sh, .sx, .sr, .s1, .ss,
 .kc,
-.il, .ace_boolean, .ace_numeric, .ace_string, .ace_symbol {
+.il,
+.ace_boolean, .ace_numeric,
+.ace_string, .ace_symbol,
+.ace_hexadecimal, .ace_character,
+.ace_decimal {
   color: #369434 !important;
 }
 

--- a/app/assets/stylesheets/application/modules/_highlight.scss
+++ b/app/assets/stylesheets/application/modules/_highlight.scss
@@ -6,6 +6,7 @@ pre {
 
 /* identifier */
 .na, .nb, .nc, .no, .nd, .ni, .bp, .vc, .vg, .vi, .nx, .nv,
+.nn, .nt,
 .ace_function,
 .ace_variable,
 .ace_parameter,
@@ -27,6 +28,7 @@ pre {
 .s, .sb, .sc, .sd, .s2, .se, .sh, .sx, .sr, .s1, .ss,
 .kc,
 .il,
+.l,
 .ace_boolean, .ace_numeric,
 .ace_string, .ace_symbol,
 .ace_hexadecimal, .ace_character,
@@ -74,23 +76,6 @@ pre code {
   font-weight: normal !important;
 }
 
-
-/** Misc **/
-
-.hll { background-color: #ffffcc }
-.err { color: #a61717; background-color: #e3d2d2 } /* Error */
-.gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
-.ge { color: #000000; font-style: italic } /* Generic.Emph */
-.gr { color: #aa0000 } /* Generic.Error */
-.gh { color: #999999 } /* Generic.Heading */
-.gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
-.go { color: #888888 } /* Generic.Output */
-.gp { color: #555555 } /* Generic.Prompt */
-.gs { font-weight: bold } /* Generic.Strong */
-.gu { color: #aaaaaa } /* Generic.Subheading */
-.gt { color: #aa0000 } /* Generic.Traceback */
-.nn { color: #555555 } /* Name.Namespace */
-.nt { color: #000080 } /* Name.Tag */
 .w { color: #bbbbbb } /* Text.Whitespace */
 .si { color: #d01040 } /* Literal.String.Interpol */
 


### PR DESCRIPTION
## Gobstones
> There are some inconsistencies, but most of them will be resolved after https://github.com/mumuki/mumuki-gobstones-runner/issues/1: 

![image](https://cloud.githubusercontent.com/assets/677436/23287213/cdd97d06-fa1a-11e6-851e-e2ca6ffa80bb.png)
![image](https://cloud.githubusercontent.com/assets/677436/23287235/e7a92b82-fa1a-11e6-96c5-78d2c81a95f2.png)

## JavaScript

![image](https://cloud.githubusercontent.com/assets/677436/23287295/480885f4-fa1b-11e6-9731-fca6951a555e.png)
![image](https://cloud.githubusercontent.com/assets/677436/23287300/619ab2b2-fa1b-11e6-92e2-49370f02864a.png)


## Haskell
> There are few inconsistencies, but it is still good enough

![image](https://cloud.githubusercontent.com/assets/677436/23287344/91850734-fa1b-11e6-9879-6d04fa4afc2b.png)
![image](https://cloud.githubusercontent.com/assets/677436/23287388/d091ede8-fa1b-11e6-9b56-f83112f4af98.png)


## Ruby
> There ar subtle inconsistencies regarding some operators and the rendering of constants. Methods with symbols are not properly parsed by the Ruby ACE lexer. 

![image](https://cloud.githubusercontent.com/assets/677436/23287403/eabe89ce-fa1b-11e6-8eb9-bd2b6cf7c93f.png)
![image](https://cloud.githubusercontent.com/assets/677436/23287417/01244d7a-fa1c-11e6-8c1b-7c011b2d0e53.png)
![image](https://cloud.githubusercontent.com/assets/677436/23287476/711541d4-fa1c-11e6-9266-793474f131f4.png)


