### PR TITLE
Issue #656 generalize previous solution

### DIFF
--- a/app/models/concerns/with_assignments.rb
+++ b/app/models/concerns/with_assignments.rb
@@ -11,7 +11,9 @@ module WithAssignments
   end
 
   def default_content_for(user)
-    (default_content || '').gsub('/*...previousContent...*/') { previous.current_content_for(user) }
+    (default_content || '')
+      .gsub(/\/\*\.\.\.(previousContent|previousSolution)\.\.\.\*\//) { previous.current_content_for(user) }
+      .gsub(/\/\*\.\.\.(solution|content)\[(-?\d*)\]\.\.\.\*\//) { sibling_at($2.to_i).current_content_for(user) }
   end
 
   def messages_for(user)

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -52,7 +52,12 @@ class Exercise < ActiveRecord::Base
   end
 
   def previous
-    guide.exercises.find_by(number: number.pred)
+    sibling_at number.pred
+  end
+
+  def sibling_at(index)
+    index = number + index unless index.positive?
+    guide.exercises.find_by(number: index)
   end
 
   def search_tags

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -9,7 +9,7 @@ class Language < ActiveRecord::Base
 
   validates :name, presence: true, uniqueness: {case_sensitive: false}
 
-  markdown_on :test_syntax_hint, :description
+  markdown_on :description
 
   delegate :run_tests!, :run_query!, to: :bridge
 

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -179,22 +179,92 @@ describe Exercise do
       let!(:chapter) {
         create(:chapter, lessons: [
           create(:lesson, exercises: [
+            first_exercise,
+            second_exercise,
             previous_exercise,
             exercise
           ])]) }
 
+      let(:first_exercise) { create(:exercise) }
+      let(:second_exercise) { create(:exercise) }
       let(:previous_exercise) { create(:exercise) }
-      let(:exercise) { create(:exercise, default_content: '/*...previousContent...*/') }
 
       before { reindex_current_organization! }
 
-      context 'has previous submission' do
-        before { previous_exercise.submit_solution!(user, content: 'foobar') }
-        it { expect(exercise.current_content_for(user)).to eq 'foobar' }
+      describe 'right previous content' do
+        let(:exercise) { create(:exercise, default_content: interpolation) }
+
+        context 'using previousContent' do
+          let(:interpolation) { '/*...previousContent...*/' }
+
+          context 'has previous submission' do
+            before { previous_exercise.submit_solution!(user, content: 'foobar') }
+            it { expect(exercise.current_content_for(user)).to eq 'foobar' }
+          end
+
+          context 'does not have previous submission' do
+            it { expect(exercise.current_content_for(user)).to eq '' }
+          end
+        end
+        context 'using previousSolution' do
+          let(:interpolation) { '/*...previousSolution...*/' }
+
+          context 'has previous submission' do
+            before { previous_exercise.submit_solution!(user, content: 'foobar') }
+            it { expect(exercise.current_content_for(user)).to eq 'foobar' }
+          end
+
+          context 'does not have previous submission' do
+            it { expect(exercise.current_content_for(user)).to eq '' }
+          end
+        end
       end
 
-      context 'does not have previous submission' do
-        it { expect(exercise.current_content_for(user)).to eq '' }
+      describe 'indexed previous content' do
+        context '-2 index' do
+          let(:exercise) { create(:exercise, default_content: '/*...solution[-2]...*/') }
+
+          context 'has previous submission' do
+            before { second_exercise.submit_solution!(user, content: 'foobar') }
+            it { expect(exercise.current_content_for(user)).to eq 'foobar' }
+          end
+        end
+        context '-1 index' do
+          let(:exercise) { create(:exercise, default_content: '/*...solution[-1]...*/') }
+
+          context 'has previous submission' do
+            before { previous_exercise.submit_solution!(user, content: 'foobar') }
+            it { expect(exercise.current_content_for(user)).to eq 'foobar' }
+          end
+
+          context 'does not have previous submission' do
+            it { expect(exercise.current_content_for(user)).to eq '' }
+          end
+        end
+        context '1 index' do
+          let(:exercise) { create(:exercise, default_content: '/*...solution[1]...*/') }
+
+          context 'has previous submission' do
+            before { first_exercise.submit_solution!(user, content: 'foobar') }
+            it { expect(exercise.current_content_for(user)).to eq 'foobar' }
+          end
+        end
+        context '2 index' do
+          let(:exercise) { create(:exercise, default_content: '/*...solution[2]...*/') }
+
+          context 'has previous submission' do
+            before { second_exercise.submit_solution!(user, content: 'foobar') }
+            it { expect(exercise.current_content_for(user)).to eq 'foobar' }
+          end
+        end
+        context '3 index' do
+          let(:exercise) { create(:exercise, default_content: '/*...solution[3]...*/') }
+
+          context 'has previous submission' do
+            before { previous_exercise.submit_solution!(user, content: 'foobar') }
+            it { expect(exercise.current_content_for(user)).to eq 'foobar' }
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Allowing `previousContent` to reference absolute and relative exercises.

Also, adding `previousSolution` as an alias, since it `previousContent` was not an obvious name. 

With this PR, content-editors will be able to place the following directives like the following into default code: 

## Previous solution

* `/*...previousSolution...*/` or `/*...previousContent...*/` 

## Indexed solution, using relative indexes

* `/*...solution[-1]...*/` or `/*...content[-1]...*/`, an equivalent for `previousContent`
* `/*...solution[-2]...*/` or `/*...content[-2]...*/`, two exercises back
* `/*...solution[-3]...*/` or `/*...content[-3]...*/`, three exercises back, etc.

## Indexed solution, using absolute indexes

* `/*...solution[1]...*/` or `/*...content[1]...*/`, the first exercise solution
* `/*...solution[2]...*/` or `/*...content[2]...*/`, the second exercise solution
* `/*...solution[3]...*/` or `/*...content[3]...*/`, the third exercise solution, etc.

