### PR TITLE
Fix codemirror requires

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,26 +23,7 @@
 //= require jquery-console
 
 //= require codemirror.min
-//= require codemirror-modes/clike.min.js
-//= require codemirror-modes/closebrackets.min.js
-//= require codemirror-modes/css.min.js
-//= require codemirror-modes/css-hint.min.js
-//= require codemirror-modes/haskell.min.js
-//= require codemirror-modes/html-hint.min.js
-//= require codemirror-modes/htmlmixed.min.js
-//= require codemirror-modes/javascript.min.js
-//= require codemirror-modes/javascript-hint.min
-//= require codemirror-modes/markdown.min
-//= require codemirror-modes/matchbrackets.min
-//= require codemirror-modes/placeholder.min
-//= require codemirror-modes/python.min
-//= require codemirror-modes/ruby.min
-//= require codemirror-modes/shell.min
-//= require codemirror-modes/show-hint.min
-//= require codemirror-modes/sql.min
-//= require codemirror-modes/sql-hint.min
-//= require codemirror-modes/xml.min
-//= require codemirror-modes/xml-hint.min
+//= require_tree ../../../vendor/assets/javascripts/codemirror-modes
 //= require analytics
 //= require hotjar
 //= require facebook


### PR DESCRIPTION
Last pull request was missing the require necessary for the files that were moved from app/assets/javascript/application/codemirror-modes to vendor/assets/javascript/codemirror-modes