### PR TITLE
Displaying organization description

### DIFF
--- a/app/views/book/show.html.erb
+++ b/app/views/book/show.html.erb
@@ -7,6 +7,8 @@
 
     <% unless Organization.current.central? %>
       <h3>
+        <small><%= Organization.current.description %></small>
+        <br>
         <small><%= raw t :powered_by_mumuki %></small>
       </h3>
     <% end %>

--- a/spec/factories/organization_factory.rb
+++ b/spec/factories/organization_factory.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
 
   factory :organization do
     contact_email { Faker::Internet.email }
+    description 'a great org'
     settings {}
     book
   end

--- a/spec/features/home_private_flow_spec.rb
+++ b/spec/features/home_private_flow_spec.rb
@@ -57,7 +57,9 @@ feature 'private org' do
       visit '/'
 
       expect(student.reload.last_organization).to eq Organization.current
-      expect(page).to have_text('mumuki private powered by mumuki')
+      expect(page).to have_text('powered by mumuki')
+      expect(page).to have_text(Organization.current.description)
+      expect(page).to have_text(Organization.current.book.description)
     end
 
     scenario 'teacher should access' do
@@ -66,7 +68,9 @@ feature 'private org' do
       visit '/'
 
       expect(teacher.reload.last_organization).to eq Organization.current
-      expect(page).to have_text('mumuki private powered by mumuki')
+      expect(page).to have_text('powered by mumuki')
+      expect(page).to have_text(Organization.current.description)
+      expect(page).to have_text(Organization.current.book.description)
     end
   end
 end


### PR DESCRIPTION
Fixes #874 

This is how it look like in a **non-central** organization: 

![image](https://user-images.githubusercontent.com/677436/34322026-472a4e8c-e7fb-11e7-99ff-f9b141cb0a3c.png)
