### PR TITLE
Chore rails 5 defaults

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -6,7 +6,7 @@ class Chapter < ApplicationRecord
 
   include TopicContainer
 
-  belongs_to :book
+  belongs_to :book, optional: true
   belongs_to :topic
 
   include SiblingsNavigation

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,6 +1,6 @@
 class Message < ApplicationRecord
 
-  belongs_to :assignment, foreign_key: :submission_id, primary_key: :submission_id
+  belongs_to :assignment, foreign_key: :submission_id, primary_key: :submission_id, optional: true
   has_one :exercise, through: :assignment
 
   validates_presence_of :submission_id, :content, :sender

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,8 +17,8 @@ class User < ApplicationRecord
            class_name: 'Exercise',
            source: :exercise
 
-  belongs_to :last_exercise, class_name: 'Exercise'
-  belongs_to :last_organization, class_name: 'Organization'
+  belongs_to :last_exercise, class_name: 'Exercise', optional: true
+  belongs_to :last_organization, class_name: 'Organization', optional: true
 
   has_one :last_guide, through: :last_exercise, source: :guide
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,8 @@ Bundler.require(*Rails.groups)
 
 module Mumuki
   class Application < Rails::Application
+    config.load_defaults 5.1
+
     config.generators.stylesheets = false
     config.generators.javascripts = false
     config.generators.test_framework = :rspec

--- a/spec/features/profile_flow_spec.rb
+++ b/spec/features/profile_flow_spec.rb
@@ -6,8 +6,8 @@ feature 'Standard Flow' do
   let(:haskell) { create(:haskell) }
   let!(:chapter) {
     create(:chapter, name: 'Functional Programming', lessons: [
-        create(:lesson, name: 'Values and Functions', language: haskell, description: 'Values are everywhere...', exercises: [
-            create(:exercise, name: 'The Basic Values', description: "Let's say we want to declare a variable...")
+        build(:lesson, name: 'Values and Functions', language: haskell, description: 'Values are everywhere...', exercises: [
+            build(:exercise, name: 'The Basic Values', description: "Let's say we want to declare a variable...")
         ])
     ]) }
   let(:problem) { create :problem}

--- a/spec/models/usage_spec.rb
+++ b/spec/models/usage_spec.rb
@@ -8,16 +8,16 @@ describe Usage, clean: true do
   let!(:logic_programming) { create(:topic) }
 
   let!(:programming) { create(:book, chapters: [
-      create(:chapter, topic: fundamentals),
-      create(:chapter, topic: functional_programming),
-      create(:chapter, topic: oop),
-      create(:chapter, topic: logic_programming),
+      build(:chapter, topic: fundamentals),
+      build(:chapter, topic: functional_programming),
+      build(:chapter, topic: oop),
+      build(:chapter, topic: logic_programming),
   ]) }
 
   let!(:paradigms) { create(:book, chapters: [
-      create(:chapter, topic: functional_programming),
-      create(:chapter, topic: logic_programming),
-      create(:chapter, topic: oop),
+      build(:chapter, topic: functional_programming),
+      build(:chapter, topic: logic_programming),
+      build(:chapter, topic: oop),
   ]) }
 
   let!(:central) { create(:organization, name: 'central', book: programming) }


### PR DESCRIPTION
Rails 5 changed some defaults - particularly the semantics of `belongs_to`. 

Laboratory was migrated from rails 4.1, so it was using the old defaults. With this PR we are keeping its semantics up-to-date. 