### PR TITLE
Adding css highlight tweaks - Fixes #1023

### DIFF
--- a/app/assets/stylesheets/application/modules/_highlight.scss
+++ b/app/assets/stylesheets/application/modules/_highlight.scss
@@ -134,3 +134,7 @@ $mu-color-highlight-prolog-atoms: $mu-color-primary;
   color: $mu-color-highlight-prolog-atoms !important;
   font-weight: normal !important;
 }
+
+.css .m { color: $mu-color-highlight-literal !important; }
+.css .nc { color: $mu-color-highlight-identifier !important; font-weight: bold !important; }
+.css .nl { color: $mu-color-highlight-keyword !important; }

--- a/app/assets/stylesheets/application/modules/_highlight.scss
+++ b/app/assets/stylesheets/application/modules/_highlight.scss
@@ -135,6 +135,10 @@ $mu-color-highlight-prolog-atoms: $mu-color-primary;
   font-weight: normal !important;
 }
 
+$mu-color-highlight-css-literal: #b96dba;
+
 .css .m { color: $mu-color-highlight-literal !important; }
 .css .nc { color: $mu-color-highlight-identifier !important; font-weight: bold !important; }
 .css .nl { color: $mu-color-highlight-keyword !important; }
+.css .n { color: $mu-color-highlight-css-literal !important; }
+.css .nb { color: $mu-color-highlight-css-literal !important; }


### PR DESCRIPTION
It was already supported, but the default classes were leaving almost all text in black.

![screenshot11](https://user-images.githubusercontent.com/1631752/38973389-f20e4a16-437b-11e8-831c-18f7baa93eb4.png)
