### PR TITLE
"always" callback should be executed lastly

### DIFF
--- a/app/assets/javascripts/application/submission.js
+++ b/app/assets/javascripts/application/submission.js
@@ -70,13 +70,13 @@ var mumuki = mumuki || {};
       mumuki.editor.syncContent();
       var solution = getContent();
 
-      bridge.runLocalTests(solution).always(function () {
-        $(document).renderMuComponents();
-        resultsBox.done();
-      }).done(function (data) {
+      bridge.runLocalTests(solution).done(function (data) {
         resultsBox.success(data, submitButton);
       }).fail(function () {
         resultsBox.error(submitButton);
+      }).always(function () {
+        $(document).renderMuComponents();
+        resultsBox.done();
       });
     });
 


### PR DESCRIPTION
This PR fix the problem that mu components are not being rendered after submitting a solution.