### PR TITLE
Send reminder to users who have never submitted - Finishes #1075

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -5,7 +5,7 @@ class UserMailer < ApplicationMailer
   end
 
   def no_submissions_reminder(user)
-    send_reminder! user, t(:we_miss_you), "no_submissions_reminder"
+    send_reminder! user, t(:start_using_mumuki), "no_submissions_reminder"
   end
 
   private

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,15 +1,24 @@
 class UserMailer < ApplicationMailer
 
   def we_miss_you_reminder(user, cycles)
+    send_reminder! user, t(:we_miss_you), "#{cycles.ordinalize}_reminder"
+  end
+
+  def no_submissions_reminder(user)
+    send_reminder! user, t(:we_miss_you), "no_submissions_reminder"
+  end
+
+  private
+
+  def send_reminder!(user, subject, template_name)
     @user = user
     @unsubscribe_code = User.unsubscription_verifier.generate(user.id)
     @organization = user.last_organization
 
     I18n.with_locale(@organization.locale) do
       mail to: user.email,
-           subject: t(:we_miss_you),
-           template_name: "#{cycles.ordinalize}_reminder"
+           subject: subject,
+           template_name: template_name
     end
   end
-
 end

--- a/app/models/concerns/with_reminders.rb
+++ b/app/models/concerns/with_reminders.rb
@@ -11,6 +11,16 @@ module WithReminders
     update! last_reminded_date: Time.now
   end
 
+  def should_send_reminder?
+    remider_due? && (has_no_submissions? || has_no_recent_submission?)
+  end
+
+  def remind!
+    send_reminder! if should_send_reminder?
+  end
+
+  private
+
   def cycles_since(time)
     ((Date.current - time.to_date) / Rails.configuration.reminder_frequency).to_i
   end
@@ -19,20 +29,16 @@ module WithReminders
     last_reminded_date.nil? || cycles_since(last_reminded_date) >= 1
   end
 
+  def can_still_remind?(date)
+    cycles_since(date).between?(1, 3)
+  end
+
   def has_no_submissions?
-    last_submission_date.nil? && cycles_since(created_at).between?(1, 3)
+    last_submission_date.nil? && can_still_remind?(created_at)
   end
 
   def has_no_recent_submission?
-    !last_submission_date.nil? && cycles_since(last_submission_date).between?(1, 3)
-  end
-
-  def should_send_reminder?
-    remider_due? && (has_no_submissions? || has_no_recent_submission?)
-  end
-
-  def remind!
-    send_reminder! if should_send_reminder?
+    !last_submission_date.nil? && can_still_remind?(last_submission_date)
   end
 
 end

--- a/app/models/concerns/with_reminders.rb
+++ b/app/models/concerns/with_reminders.rb
@@ -1,7 +1,9 @@
 module WithReminders
 
   def build_reminder
-    UserMailer.new.we_miss_you_reminder(self, cycles_since(last_submission_date))
+    last_submission_date.nil? ?
+      UserMailer.new.no_submissions_reminder(self) :
+      UserMailer.new.we_miss_you_reminder(self, cycles_since(last_submission_date))
   end
 
   def send_reminder!
@@ -17,8 +19,12 @@ module WithReminders
     last_reminded_date.nil? || cycles_since(last_reminded_date) >= 1
   end
 
+  def has_no_recent_submission?
+    last_submission_date.nil? || cycles_since(last_submission_date).between?(1, 3)
+  end
+
   def should_send_reminder?
-    remider_due? && cycles_since(last_submission_date).between?(1, 3)
+    remider_due? && has_no_recent_submission?
   end
 
   def remind!

--- a/app/models/concerns/with_reminders.rb
+++ b/app/models/concerns/with_reminders.rb
@@ -8,7 +8,7 @@ module WithReminders
 
   def send_reminder!
     build_reminder.deliver
-    update! last_reminded: Time.now
+    update! last_reminded_date: Time.now
   end
 
   def cycles_since(time)

--- a/app/models/concerns/with_reminders.rb
+++ b/app/models/concerns/with_reminders.rb
@@ -19,12 +19,16 @@ module WithReminders
     last_reminded_date.nil? || cycles_since(last_reminded_date) >= 1
   end
 
+  def has_no_submissions?
+    last_submission_date.nil? && cycles_since(created_at).between?(1, 3)
+  end
+
   def has_no_recent_submission?
-    last_submission_date.nil? || cycles_since(last_submission_date).between?(1, 3)
+    !last_submission_date.nil? && cycles_since(last_submission_date).between?(1, 3)
   end
 
   def should_send_reminder?
-    remider_due? && has_no_recent_submission?
+    remider_due? && (has_no_submissions? || has_no_recent_submission?)
   end
 
   def remind!

--- a/app/models/concerns/with_reminders.rb
+++ b/app/models/concerns/with_reminders.rb
@@ -28,7 +28,7 @@ module WithReminders
   private
 
   def cycles_since(time)
-    ((Date.current - time.to_date) / Rails.configuration.reminder_frequency).to_i
+    ((Date.current - time.to_date) / self.class.reminder_frequency).to_i
   end
 
   def reminder_due?
@@ -49,7 +49,12 @@ module WithReminders
 
   module ClassMethods
     def remindable
-      where('accepts_reminders and (last_submission_date < ? or last_submission_date is null)', Rails.configuration.remainder_frequency.days.ago)
+      where('accepts_reminders and (last_submission_date < ? or last_submission_date is null)', reminder_frequency.days.ago)
+    end
+
+    # The frequency of reminders, expressed in days
+    def reminder_frequency
+      Rails.configuration.reminder_frequency
     end
   end
 end

--- a/app/models/concerns/with_reminders.rb
+++ b/app/models/concerns/with_reminders.rb
@@ -2,9 +2,10 @@ module WithReminders
   extend ActiveSupport::Concern
 
   def build_reminder
+    mailer = UserMailer.new
     last_submission_date.nil? ?
-      UserMailer.new.no_submissions_reminder(self) :
-      UserMailer.new.we_miss_you_reminder(self, cycles_since(last_submission_date))
+      mailer.no_submissions_reminder(self) :
+      mailer.we_miss_you_reminder(self, cycles_since(last_submission_date))
   end
 
   def send_reminder!

--- a/app/models/concerns/with_reminders.rb
+++ b/app/models/concerns/with_reminders.rb
@@ -12,7 +12,7 @@ module WithReminders
   end
 
   def should_send_reminder?
-    remider_due? && (has_no_submissions? || has_no_recent_submission?)
+    reminder_due? && (has_no_submissions? || has_no_recent_submission?)
   end
 
   def remind!
@@ -25,7 +25,7 @@ module WithReminders
     ((Date.current - time.to_date) / Rails.configuration.reminder_frequency).to_i
   end
 
-  def remider_due?
+  def reminder_due?
     last_reminded_date.nil? || cycles_since(last_reminded_date) >= 1
   end
 

--- a/app/views/user_mailer/no_submissions_reminder.html.erb
+++ b/app/views/user_mailer/no_submissions_reminder.html.erb
@@ -1,0 +1,349 @@
+<span class="muMailPreviewText" style="display:none; font-size:0px; line-height:0px; max-height:0px; max-width:0px; opacity:0; overflow:hidden; visibility:hidden; mso-hide:all;"><%= t :dont_leave_us %></span><!--<![endif]-->
+<center>
+  <table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="bodyTable">
+    <tbody><tr>
+      <td align="center" valign="top" id="bodyCell">
+        <!-- BEGIN TEMPLATE // -->
+        <table border="0" cellpadding="0" cellspacing="0" width="100%">
+          <tbody><tr>
+            <td align="center" valign="top" id="templateHeader" data-template-container="">
+              <!--[if (gte mso 9)|(IE)]>
+              <table align="center" border="0" cellspacing="0" cellpadding="0" width="600" style="width:600px;">
+                <tr>
+                  <td align="center" valign="top" width="600" style="width:600px;">
+              <![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" class="templateContainer">
+                <tbody><tr>
+                  <td valign="top" class="headerContainer"><table border="0" cellpadding="0" cellspacing="0" width="100%" class="muMailTextBlock" style="min-width:100%;">
+                    <tbody class="muMailTextBlockOuter">
+                    <tr>
+                      <td valign="top" class="muMailTextBlockInner" style="padding-top:9px;">
+                        <!--[if mso]>
+                        <table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+                          <tr>
+                        <![endif]-->
+
+                        <!--[if mso]>
+                        <td valign="top" width="600" style="width:600px;">
+                        <![endif]-->
+                        <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width:100%; min-width:100%;" width="100%" class="muMailTextContentContainer">
+                          <tbody><tr>
+
+                            <td valign="top" class="muMailTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
+
+                              <h1><span style="color:#FFFFFF"><%= t :we_miss_you %></span></h1>
+
+                            </td>
+                          </tr>
+                          </tbody></table>
+                        <!--[if mso]>
+                        </td>
+                        <![endif]-->
+
+                        <!--[if mso]>
+                        </tr>
+                        </table>
+                        <![endif]-->
+                      </td>
+                    </tr>
+                    </tbody>
+                  </table></td>
+                </tr>
+                </tbody></table>
+              <!--[if (gte mso 9)|(IE)]>
+              </td>
+              </tr>
+              </table>
+              <![endif]-->
+            </td>
+          </tr>
+          <tr>
+            <td align="center" valign="top" id="templateBody" data-template-container="">
+              <!--[if (gte mso 9)|(IE)]>
+              <table align="center" border="0" cellspacing="0" cellpadding="0" width="600" style="width:600px;">
+                <tr>
+                  <td align="center" valign="top" width="600" style="width:600px;">
+              <![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" class="templateContainer">
+                <tbody><tr>
+                  <td valign="top" class="bodyContainer"><table border="0" cellpadding="0" cellspacing="0" width="100%" class="muMailCaptionBlock">
+                    <tbody class="muMailCaptionBlockOuter">
+                    <tr>
+                      <td class="muMailCaptionBlockInner" valign="top" style="padding:9px;">
+
+
+
+
+                        <table border="0" cellpadding="0" cellspacing="0" class="muMailCaptionRightContentOuter" width="100%">
+                          <tbody><tr>
+                            <td valign="top" class="muMailCaptionRightContentInner" style="padding:0 9px ;">
+                              <table align="left" border="0" cellpadding="0" cellspacing="0" class="muMailCaptionRightImageContentContainer" width="264">
+                                <tbody><tr>
+                                  <td class="muMailCaptionRightImageContent" align="center" valign="top">
+
+
+
+                                    <img alt="" src="https://gallery.mailchimp.com/046b6c670d9f80ebd6c5d075b/images/225fe60f-780a-451e-90aa-afb01f88a1b4.png" width="159" style="max-width:159px;" class="muMailImage">
+
+
+
+                                  </td>
+                                </tr>
+                                </tbody></table>
+                              <table class="muMailCaptionRightTextContentContainer" align="right" border="0" cellpadding="0" cellspacing="0" width="264">
+                                <tbody><tr>
+                                  <td valign="top" class="muMailTextContent">
+                                    <h3 class="null" style="text-align: center;"><br>
+                                      <span style="font-size:24px"><%= t :you_never_submitted_solutions %></span></h3>
+
+                                    <div style="text-align: center;"><br>
+                                      <span style="font-size:16px"><%= t :dont_leave_us %></span></div>
+
+                                  </td>
+                                </tr>
+                                </tbody></table>
+                            </td>
+                          </tr>
+                          </tbody></table>
+
+
+
+
+                      </td>
+                    </tr>
+                    </tbody>
+                  </table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="muMailButtonBlock" style="min-width:100%;">
+                    <tbody class="muMailButtonBlockOuter">
+                    <tr>
+                      <td style="padding-top:0; padding-right:18px; padding-bottom:18px; padding-left:18px;" valign="top" align="center" class="muMailButtonBlockInner">
+                        <table border="0" cellpadding="0" cellspacing="0" class="muMailButtonContentContainer" style="border-collapse: separate !important;border-radius: 3px;background-color: #FF5B81;">
+                          <tbody>
+                          <tr>
+                            <td align="center" valign="middle" class="muMailButtonContent" style="font-family: Helvetica; font-size: 18px; padding: 18px;">
+                              <a class="muMailButton " title=<%= t :keep_learning %> href=<%= Mumukit::Platform.laboratory.organic_url @user.last_organization %> target="_self" style="font-weight: bold;letter-spacing: -0.5px;line-height: 100%;text-align: center;text-decoration: none;color: #FFFFFF;"><%= t :keep_learning %></a>
+                            </td>
+                          </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                    </tbody>
+                  </table></td>
+                </tr>
+                </tbody></table>
+              <!--[if (gte mso 9)|(IE)]>
+              </td>
+              </tr>
+              </table>
+              <![endif]-->
+            </td>
+          </tr>
+          <tr>
+            <td align="center" valign="top" id="templateFooter" data-template-container="">
+              <!--[if (gte mso 9)|(IE)]>
+              <table align="center" border="0" cellspacing="0" cellpadding="0" width="600" style="width:600px;">
+                <tr>
+                  <td align="center" valign="top" width="600" style="width:600px;">
+              <![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" class="templateContainer">
+                <tbody><tr>
+                  <td valign="top" class="footerContainer"><table border="0" cellpadding="0" cellspacing="0" width="100%" class="muMailFollowBlock" style="min-width:100%;">
+                    <tbody class="muMailFollowBlockOuter">
+                    <tr>
+                      <td align="center" valign="top" style="padding:9px" class="muMailFollowBlockInner">
+                        <table border="0" cellpadding="0" cellspacing="0" width="100%" class="muMailFollowContentContainer" style="min-width:100%;">
+                          <tbody><tr>
+                            <td align="center" style="padding-left:9px;padding-right:9px;">
+                              <table border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width:100%;" class="muMailFollowContent">
+                                <tbody><tr>
+                                  <td align="center" valign="top" style="padding-top:9px; padding-right:9px; padding-left:9px;">
+                                    <table align="center" border="0" cellpadding="0" cellspacing="0">
+                                      <tbody><tr>
+                                        <td align="center" valign="top">
+                                          <!--[if mso]>
+                                          <table align="center" border="0" cellspacing="0" cellpadding="0">
+                                            <tr>
+                                          <![endif]-->
+
+                                          <!--[if mso]>
+                                          <td align="center" valign="top">
+                                          <![endif]-->
+
+
+                                          <table align="left" border="0" cellpadding="0" cellspacing="0" style="display:inline;">
+                                            <tbody><tr>
+                                              <td valign="top" style="padding-right:10px; padding-bottom:9px;" class="muMailFollowContentItemContainer">
+                                                <table border="0" cellpadding="0" cellspacing="0" width="100%" class="muMailFollowContentItem">
+                                                  <tbody><tr>
+                                                    <td align="left" valign="middle" style="padding-top:5px; padding-right:10px; padding-bottom:5px; padding-left:9px;">
+                                                      <table align="left" border="0" cellpadding="0" cellspacing="0" width="">
+                                                        <tbody><tr>
+
+                                                          <td align="center" valign="middle" width="24" class="muMailFollowIconContent">
+                                                            <a href="http://www.facebook.com/MumukiProject" target="_blank"><img src="https://cdn-images.mailchimp.com/icons/social-block-v2/outline-light-facebook-48.png" style="display:block;" height="24" width="24" class=""></a>
+                                                          </td>
+
+
+                                                        </tr>
+                                                        </tbody></table>
+                                                    </td>
+                                                  </tr>
+                                                  </tbody></table>
+                                              </td>
+                                            </tr>
+                                            </tbody></table>
+
+                                          <!--[if mso]>
+                                          </td>
+                                          <![endif]-->
+
+                                          <!--[if mso]>
+                                          <td align="center" valign="top">
+                                          <![endif]-->
+
+
+                                          <table align="left" border="0" cellpadding="0" cellspacing="0" style="display:inline;">
+                                            <tbody><tr>
+                                              <td valign="top" style="padding-right:10px; padding-bottom:9px;" class="muMailFollowContentItemContainer">
+                                                <table border="0" cellpadding="0" cellspacing="0" width="100%" class="muMailFollowContentItem">
+                                                  <tbody><tr>
+                                                    <td align="left" valign="middle" style="padding-top:5px; padding-right:10px; padding-bottom:5px; padding-left:9px;">
+                                                      <table align="left" border="0" cellpadding="0" cellspacing="0" width="">
+                                                        <tbody><tr>
+
+                                                          <td align="center" valign="middle" width="24" class="muMailFollowIconContent">
+                                                            <a href="http://www.twitter.com/MumukiProject" target="_blank"><img src="https://cdn-images.mailchimp.com/icons/social-block-v2/outline-light-twitter-48.png" style="display:block;" height="24" width="24" class=""></a>
+                                                          </td>
+
+
+                                                        </tr>
+                                                        </tbody></table>
+                                                    </td>
+                                                  </tr>
+                                                  </tbody></table>
+                                              </td>
+                                            </tr>
+                                            </tbody></table>
+
+                                          <!--[if mso]>
+                                          </td>
+                                          <![endif]-->
+
+                                          <!--[if mso]>
+                                          <td align="center" valign="top">
+                                          <![endif]-->
+
+
+                                          <table align="left" border="0" cellpadding="0" cellspacing="0" style="display:inline;">
+                                            <tbody><tr>
+                                              <td valign="top" style="padding-right:0; padding-bottom:9px;" class="muMailFollowContentItemContainer">
+                                                <table border="0" cellpadding="0" cellspacing="0" width="100%" class="muMailFollowContentItem">
+                                                  <tbody><tr>
+                                                    <td align="left" valign="middle" style="padding-top:5px; padding-right:10px; padding-bottom:5px; padding-left:9px;">
+                                                      <table align="left" border="0" cellpadding="0" cellspacing="0" width="">
+                                                        <tbody><tr>
+
+                                                          <td align="center" valign="middle" width="24" class="muMailFollowIconContent">
+                                                            <a href="https://www.youtube.com/channel/UCQmkknsaTT2TDLT_-MDSGvQ" target="_blank"><img src="https://cdn-images.mailchimp.com/icons/social-block-v2/outline-light-youtube-48.png" style="display:block;" height="24" width="24" class=""></a>
+                                                          </td>
+
+
+                                                        </tr>
+                                                        </tbody></table>
+                                                    </td>
+                                                  </tr>
+                                                  </tbody></table>
+                                              </td>
+                                            </tr>
+                                            </tbody></table>
+
+                                          <!--[if mso]>
+                                          </td>
+                                          <![endif]-->
+
+                                          <!--[if mso]>
+                                          </tr>
+                                          </table>
+                                          <![endif]-->
+                                        </td>
+                                      </tr>
+                                      </tbody></table>
+                                  </td>
+                                </tr>
+                                </tbody></table>
+                            </td>
+                          </tr>
+                          </tbody></table>
+
+                      </td>
+                    </tr>
+                    </tbody>
+                  </table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="muMailDividerBlock" style="min-width:100%;">
+                    <tbody class="muMailDividerBlockOuter">
+                    <tr>
+                      <td class="muMailDividerBlockInner" style="min-width:100%; padding:18px;">
+                        <table class="muMailDividerContent" border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width: 100%;border-top: 2px solid #505050;">
+                          <tbody><tr>
+                            <td>
+                              <span></span>
+                            </td>
+                          </tr>
+                          </tbody></table>
+                        <!--
+                                        <td class="muMailDividerBlockInner" style="padding: 18px;">
+                                        <hr class="muMailDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+                        -->
+                      </td>
+                    </tr>
+                    </tbody>
+                  </table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="muMailTextBlock" style="min-width:100%;">
+                    <tbody class="muMailTextBlockOuter">
+                    <tr>
+                      <td valign="top" class="muMailTextBlockInner" style="padding-top:9px;">
+                        <!--[if mso]>
+                        <table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+                          <tr>
+                        <![endif]-->
+
+                        <!--[if mso]>
+                        <td valign="top" width="600" style="width:600px;">
+                        <![endif]-->
+                        <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width:100%; min-width:100%;" width="100%" class="muMailTextContentContainer">
+                          <tbody><tr>
+
+                            <td valign="top" class="muMailTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
+
+                              © Copyright 2015-2018&nbsp;<a href="https://mumuki.org/home/">Mumuki Project</a><em>.</em><br>
+                              <br>
+                              <%= t :stop_emails? %><br>
+                              <%= link_to t(:cancel_subscription), @organization.url_for("/user/unsubscribe?id=#{@unsubscribe_code}"), target: :_blank %>
+                            </td>
+                          </tr>
+                          </tbody></table>
+                        <!--[if mso]>
+                        </td>
+                        <![endif]-->
+
+                        <!--[if mso]>
+                        </tr>
+                        </table>
+                        <![endif]-->
+                      </td>
+                    </tr>
+                    </tbody>
+                  </table></td>
+                </tr>
+                </tbody></table>
+              <!--[if (gte mso 9)|(IE)]>
+              </td>
+              </tr>
+              </table>
+              <![endif]-->
+            </td>
+          </tr>
+          </tbody></table>
+        <!-- // END TEMPLATE -->
+      </td>
+    </tr>
+    </tbody></table>
+</center>

--- a/app/views/user_mailer/no_submissions_reminder.text.erb
+++ b/app/views/user_mailer/no_submissions_reminder.text.erb
@@ -1,0 +1,13 @@
+<%= t :we_miss_you %>
+
+
+<%= t :you_never_submitted_solutions %>
+
+<%= t :dont_leave_us %>
+<%= t :keep_learning %>
+
+
+© Copyright 2015-2018 Mumuki Project.
+
+<%= t :stop_emails? %>
+<%= t :cancel_subscription %>

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -185,6 +185,7 @@ en:
   working: "Working"
   wrong_answer: The answer is wrong
   you_must_sign_in_before_submitting: You must sign in before submitting your solutions
+  you_never_submitted_solutions: It seems that you've never submitted solutions since you created your account.
   fullscreen: "Fullscreen"
   get_messages: "View messages"
   task: Task

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -154,6 +154,7 @@ en:
   something_went_wrong_explanation: Something is broken in Mumuki.
   start_lesson: Start this lesson!
   start_practicing: Start Practicing!
+  start_using_mumuki: Start using Mumuki!
   stats: Some stats
   status: Status
   stay_here: I want to stay here

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -170,6 +170,7 @@ es:
   something_went_wrong_explanation: Algo no anduvo como se esperaba.
   start_lesson: ¡Comenzá esta lección!
   start_practicing: ¡Empezá ahora!
+  start_using_mumuki: ¡Empezá a usar Mumuki!
   stats: Tu Progreso
   status: Estado
   stay_here: No, quiero quedarme acá

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -203,6 +203,7 @@ es:
   working: "Procesando"
   wrong_answer: La respuesta no es correcta
   you_must_sign_in_before_submitting: Tenés que iniciar sesión antes de empezar a enviar tus soluciones
+  you_never_submitted_solutions: Parece que nunca has enviado soluciones desde que creaste tu cuenta.
   fullscreen: "Pantalla completa"
   get_messages: "Ver mensajes"
   task: Consigna

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -204,7 +204,7 @@ es:
   working: "Procesando"
   wrong_answer: La respuesta no es correcta
   you_must_sign_in_before_submitting: Tenés que iniciar sesión antes de empezar a enviar tus soluciones
-  you_never_submitted_solutions: Parece que nunca has enviado soluciones desde que creaste tu cuenta.
+  you_never_submitted_solutions: Parece que nunca enviaste soluciones desde que creaste tu cuenta.
   fullscreen: "Pantalla completa"
   get_messages: "Ver mensajes"
   task: Consigna

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -2,7 +2,7 @@ namespace :users do
 
   task notify_reminder: :environment do
     if ApplicationMailer.environment_variables_set?
-      User.where.not(accepts_reminders: false).each { |user| user.remind! }
+      User.where(accepts_reminders: true).each { |user| user.remind! }
     end
   end
 

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -2,7 +2,7 @@ namespace :users do
 
   task notify_reminder: :environment do
     if ApplicationMailer.environment_variables_set?
-      User.where.not(last_submission_date: nil, accepts_reminders: false).each { |user| user.remind! }
+      User.where.not(accepts_reminders: false).each { |user| user.remind! }
     end
   end
 

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,15 +1,14 @@
 namespace :users do
 
   task notify_reminder: :environment do
-    BATCH_SIZE = ENV["MUMUKI_JOB_BATCH_SIZE"]&.to_i || 1000
+    BATCH_SIZE = ENV['MUMUKI_JOB_BATCH_SIZE']&.to_i || 1000
 
     if ApplicationMailer.environment_variables_set?
       User
-        .where(accepts_reminders: true)
+        .where('accepts_reminders and (last_submission_date < ? or last_submission_date is null)', Rails.configuration.remainder_frequency.days.ago)
         .find_each(batch_size: BATCH_SIZE) do |user|
-          user.with_lock do
-            user.remind!
-          end
+          user.with_lock('for update nowait') { user.remind! } rescue nil
+        end
       end
     end
   end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,8 +1,16 @@
 namespace :users do
 
   task notify_reminder: :environment do
+    BATCH_SIZE = ENV["MUMUKI_JOB_BATCH_SIZE"]&.to_i || 1000
+
     if ApplicationMailer.environment_variables_set?
-      User.where(accepts_reminders: true).each { |user| user.remind! }
+      User
+        .where(accepts_reminders: true)
+        .find_each(batch_size: BATCH_SIZE) do |user|
+          user.with_lock do
+            user.remind!
+          end
+      end
     end
   end
 

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -3,14 +3,8 @@ namespace :users do
   task notify_reminder: :environment do
     BATCH_SIZE = ENV['MUMUKI_JOB_BATCH_SIZE']&.to_i || 1000
 
-    if ApplicationMailer.environment_variables_set?
-      User
-        .where('accepts_reminders and (last_submission_date < ? or last_submission_date is null)', Rails.configuration.remainder_frequency.days.ago)
-        .find_each(batch_size: BATCH_SIZE) do |user|
-          user.with_lock('for update nowait') { user.remind! } rescue nil
-        end
-      end
-    end
+    User.remindable.find_each(batch_size: BATCH_SIZE) do |user|
+      user.try_remind_with_lock!
+    end if ApplicationMailer.environment_variables_set?
   end
-
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -66,4 +66,30 @@ RSpec.describe UserMailer, type: :mailer do
       end
     end
   end
+
+  describe "no_submissions_reminder" do
+    let(:reminder) { user.build_reminder }
+    let(:central) { create(:organization, name: 'central') }
+    let(:user) { build :user, last_organization: central, last_submission_date: nil, last_reminded_date: days_since_last_reminded.days.ago }
+
+    let(:days_since_last_reminded) { 8 }
+
+    it "renders the headers" do
+      expect(reminder.subject).to eq("Start using Mumuki!")
+      expect(reminder.to).to eq([user.email])
+      expect(reminder.from).to eq(["support@mumuki.org"])
+    end
+
+    context 'last reminded over 1 week ago' do
+      let(:days_since_last_reminded) { 8 }
+
+      it { expect(user.should_send_reminder?).to be true }
+    end
+
+    context 'last reminded this week' do
+      let(:days_since_last_reminded) { 2 }
+
+      it { expect(user.should_send_reminder?).to be false }
+    end
+  end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -70,9 +70,10 @@ RSpec.describe UserMailer, type: :mailer do
   describe "no_submissions_reminder" do
     let(:reminder) { user.build_reminder }
     let(:central) { create(:organization, name: 'central') }
-    let(:user) { build :user, last_organization: central, last_submission_date: nil, last_reminded_date: days_since_last_reminded.days.ago }
+    let(:user) { build :user, last_organization: central, last_submission_date: nil, last_reminded_date: days_since_last_reminded.days.ago, created_at: days_since_user_creation.days.ago }
 
     let(:days_since_last_reminded) { 8 }
+    let(:days_since_user_creation) { 8 }
 
     it "renders the headers" do
       expect(reminder.subject).to eq("Start using Mumuki!")
@@ -83,7 +84,36 @@ RSpec.describe UserMailer, type: :mailer do
     context 'last reminded over 1 week ago' do
       let(:days_since_last_reminded) { 8 }
 
-      it { expect(user.should_send_reminder?).to be true }
+      context "registered this week" do
+        let(:days_since_user_creation) { 3 }
+
+        it { expect(user.should_send_reminder?).to be false }
+      end
+
+      context "registered 1 week ago" do
+        it { expect(user.should_send_reminder?).to be true }
+        it { expect(reminder.body.encoded).to include("you've never submitted solutions") }
+      end
+
+      context "last submission 2 weeks ago" do
+        let(:days_since_user_creation) { 16 }
+
+        it { expect(user.should_send_reminder?).to be true }
+        it { expect(reminder.body.encoded).to include("you've never submitted solutions") }
+      end
+
+      context "last submission 3 weeks ago" do
+        let(:days_since_user_creation) { 26 }
+
+        it { expect(user.should_send_reminder?).to be true }
+        it { expect(reminder.body.encoded).to include("you've never submitted solutions") }
+      end
+
+      context "last submission 4 weeks ago" do
+        let(:days_since_user_creation) { 30 }
+
+        it { expect(user.should_send_reminder?).to be false }
+      end
     end
 
     context 'last reminded this week' do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -59,32 +59,32 @@ RSpec.describe UserMailer, type: :mailer do
       context "last submission this week" do
         let(:days_since_last_submission) { 3 }
 
-        it { expect(user.should_send_reminder?).to be false }
+        it { expect(user.should_remind?).to be false }
       end
 
       context "last submission 1 week ago" do
-        it { expect(user.should_send_reminder?).to be true }
+        it { expect(user.should_remind?).to be true }
         it { expect(reminder.body.encoded).to include("Keep learning") }
       end
 
       context "last submission 2 weeks ago" do
         let(:days_since_last_submission) { 16 }
 
-        it { expect(user.should_send_reminder?).to be true }
+        it { expect(user.should_remind?).to be true }
         it { expect(reminder.body.encoded).to include("Keep learning") }
       end
 
       context "last submission 3 weeks ago" do
         let(:days_since_last_submission) { 26 }
 
-        it { expect(user.should_send_reminder?).to be true }
+        it { expect(user.should_remind?).to be true }
         it { expect(reminder.body.encoded).to include("Keep learning") }
       end
 
       context "last submission 4 weeks ago" do
         let(:days_since_last_submission) { 30 }
 
-        it { expect(user.should_send_reminder?).to be false }
+        it { expect(user.should_remind?).to be false }
       end
     end
 
@@ -94,11 +94,11 @@ RSpec.describe UserMailer, type: :mailer do
       context "last submission this week" do
         let(:days_since_last_submission) { 3 }
 
-        it { expect(user.should_send_reminder?).to be false }
+        it { expect(user.should_remind?).to be false }
       end
 
       context "last submission 1 week ago" do
-        it { expect(user.should_send_reminder?).to be false }
+        it { expect(user.should_remind?).to be false }
       end
     end
   end
@@ -125,39 +125,39 @@ RSpec.describe UserMailer, type: :mailer do
       context "registered this week" do
         let(:days_since_user_creation) { 3 }
 
-        it { expect(user.should_send_reminder?).to be false }
+        it { expect(user.should_remind?).to be false }
       end
 
       context "registered 1 week ago" do
-        it { expect(user.should_send_reminder?).to be true }
+        it { expect(user.should_remind?).to be true }
         it { expect(reminder.body.encoded).to include("you've never submitted solutions") }
       end
 
       context "last submission 2 weeks ago" do
         let(:days_since_user_creation) { 16 }
 
-        it { expect(user.should_send_reminder?).to be true }
+        it { expect(user.should_remind?).to be true }
         it { expect(reminder.body.encoded).to include("you've never submitted solutions") }
       end
 
       context "last submission 3 weeks ago" do
         let(:days_since_user_creation) { 26 }
 
-        it { expect(user.should_send_reminder?).to be true }
+        it { expect(user.should_remind?).to be true }
         it { expect(reminder.body.encoded).to include("you've never submitted solutions") }
       end
 
       context "last submission 4 weeks ago" do
         let(:days_since_user_creation) { 30 }
 
-        it { expect(user.should_send_reminder?).to be false }
+        it { expect(user.should_remind?).to be false }
       end
     end
 
     context 'last reminded this week' do
       let(:days_since_last_reminded) { 2 }
 
-      it { expect(user.should_send_reminder?).to be false }
+      it { expect(user.should_remind?).to be false }
     end
   end
 end


### PR DESCRIPTION
Finishes #1075

*spanish-mode*

Esto manda la segunda, tercer y cuarta semana después de haberse registrado mails si el alumno no envió ninguna solución.

@flbulgarelli también había dicho que estaría bueno intentar evitar que si la tarea rake se ejecuta al mismo tiempo desde N servers, se manden N mails a la misma persona. Se me ocurre que podría haber una entidad singleton en la db que guarde la última vez que corrió la tarea de remind, y antes de hacer la búsqueda de usuarios hacerle un [with_lock](https://apidock.com/rails/ActiveRecord/Locking/Pessimistic/with_lock) para gantizar que se manden una sola vez (la segunda lectura darían todos los `should_send_reminder?` falsos). ¿Se les ocurre alguna otra opción mejor?