### PR TITLE
Randomize default content too

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -20,7 +20,7 @@ class Exercise < ApplicationRecord
   validates_presence_of :submissions_count,
                         :guide
 
-  randomize :description, :hint, :extra, :test
+  randomize :description, :hint, :extra, :test, :default_content
 
   def console?
     queriable?

--- a/lib/mumuki/laboratory/mumukit/randomizer.rb
+++ b/lib/mumuki/laboratory/mumukit/randomizer.rb
@@ -1,24 +1,15 @@
 module Mumukit
   class Randomizer
-    attr_accessor :randomizations
-
     def initialize(randomizations)
       @randomizations = randomizations
     end
 
     def with_seed(seed)
-      acumulated_size = 1
-      resulting_hash = {}
-
-      randomizations.each do |key, value|
-        resulting_hash.merge! key => value.get(seed / acumulated_size)
-        acumulated_size += value.size - 1
-      end
-      resulting_hash
+      @randomizations.each_with_index.map { |(key, value), index| [key, value.get(seed + index)] }
     end
 
     def randomize!(field, seed)
-      with_seed(seed).inject(field) { |result, (replacee, replacer)| result.gsub "$#{replacee}", replacer }
+      with_seed(seed).inject(field) { |result, (replacee, replacer)| result.gsub "$#{replacee}", replacer.to_s }
     end
 
     def self.parse(randomizations)

--- a/spec/models/randomizer_spec.rb
+++ b/spec/models/randomizer_spec.rb
@@ -7,12 +7,12 @@ describe Mumukit::Randomizer do
     before { Mumukit::Randomizer::Randomization::Base.any_instance.stub(:modulo) { |_, value, range| value % range.size + range.first } }
     let(:randomizer) { Mumukit::Randomizer.parse(some_string: { type: :oneOf, value: %w(some string) }, some_number: { type: :range, value: [1, 3] } ) }
 
-    it { expect(randomizer.with_seed 0).to eq('some_string' => 'some',    'some_number' => 1) }
-    it { expect(randomizer.with_seed 1).to eq('some_string' => 'string',  'some_number' => 1) }
-    it { expect(randomizer.with_seed 2).to eq('some_string' => 'some',    'some_number' => 2) }
-    it { expect(randomizer.with_seed 3).to eq('some_string' => 'string',  'some_number' => 2) }
-    it { expect(randomizer.with_seed 4).to eq('some_string' => 'some',    'some_number' => 3) }
-    it { expect(randomizer.with_seed 5).to eq('some_string' => 'string',  'some_number' => 3) }
-    it { expect(randomizer.with_seed 6).to eq('some_string' => 'some',    'some_number' => 1) }
+    it { expect(randomizer.with_seed 0).to eq([['some_string', 'some'],    ['some_number', 2]]) }
+    it { expect(randomizer.with_seed 1).to eq([['some_string', 'string'],  ['some_number', 3]]) }
+    it { expect(randomizer.with_seed 2).to eq([['some_string', 'some'],    ['some_number', 1]]) }
+    it { expect(randomizer.with_seed 3).to eq([['some_string', 'string'],  ['some_number', 2]]) }
+    it { expect(randomizer.with_seed 4).to eq([['some_string', 'some'],    ['some_number', 3]]) }
+    it { expect(randomizer.with_seed 5).to eq([['some_string', 'string'],  ['some_number', 1]]) }
+    it { expect(randomizer.with_seed 6).to eq([['some_string', 'some'],    ['some_number', 2]]) }
   end
 end


### PR DESCRIPTION
also improve randomization logic for slightly better performance

Sorry, I know it's a holiday. I was bored.

I noticed I forgot to add default_content to the exercise's randomizations, and that since we started using Random for accessing the randomization array/range, the randomization logic didn't need to be that complex, so I dumbed it down a little.

Also, gsub was failing for replacing with numbers so I'm converting the replacer value to strings previously too.