### PR TITLE
only showing need help dropdown when it has options

### DIFF
--- a/app/helpers/exercise_input_helper.rb
+++ b/app/helpers/exercise_input_helper.rb
@@ -43,6 +43,10 @@ module ExerciseInputHelper
     exercise.is_a?(Problem) && !exercise.hidden? && organization.raise_hand_enabled?
   end
 
+  def should_render_need_help_dropdown?(assignment, organization = Organization.current)
+    !assignment.passed? && organization.ask_for_help_enabled?
+  end
+
   def render_submit_button(exercise)
     options = submit_button_options(exercise)
     text = t(options.t) if options.t.present?

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -92,6 +92,10 @@ class Organization < ApplicationRecord
     central? ? 'mumuki' : name
   end
 
+  def ask_for_help_enabled?
+    report_issue_enabled? || community_link.present? || forum_enabled?
+  end
+
   private
 
   def ensure_consistent_public_login

--- a/app/views/exercise_solutions/_results.html.erb
+++ b/app/views/exercise_solutions/_results.html.erb
@@ -7,7 +7,7 @@
   <%= manual_evaluation_comment assignment %>
   <% unless assignment.manual_evaluation_comment? %>
     <%= render partial: 'exercise_solutions/contextualization_results', locals: {contextualization: assignment} %>
-    <% unless assignment.passed? %>
+    <% if should_render_need_help_dropdown?(assignment) %>
       <div class="notify-problem-box">
         <div class="dropdown">
           <%= link_to fa_icon(:'question-circle', text: t(:need_help)), "", {'data-toggle': 'dropdown'} %>

--- a/spec/helpers/exercise_input_helper_spec.rb
+++ b/spec/helpers/exercise_input_helper_spec.rb
@@ -24,6 +24,31 @@ describe ApplicationHelper, organization_workspace: :test do
     end
   end
 
+  describe 'should_render_need_help_dropdown?' do
+    let(:assignment) { create(:assignment) }
+
+    context 'when the orga has a community link' do
+      let(:organization) { create(:organization, name: 'myorg', community_link: 'com_link') }
+      it { expect(should_render_need_help_dropdown? assignment, organization).to be true }
+    end
+    context 'when report issue enabled' do
+      let(:organization) { create(:organization, name: 'myorg', report_issue_enabled: true) }
+      it { expect(should_render_need_help_dropdown? assignment, organization).to be true }
+    end
+    context 'when forum enabled' do
+      let(:organization) { create(:organization, name: 'myorg', forum_enabled: true) }
+      it { expect(should_render_need_help_dropdown? assignment, organization).to be true }
+    end
+    context 'when ask for help is not enabled' do
+      it { expect(should_render_need_help_dropdown? assignment).to be false }
+    end
+    context 'when assignment passed' do
+      let(:organization) { create(:organization, name: 'myorg', forum_enabled: true) }
+      let(:assignment) { create(:assignment, status: :passed) }
+      it { expect(should_render_need_help_dropdown? assignment, organization).to be false }
+    end
+  end
+
   describe 'should_render_problem_tabs?' do
     let(:student) { create(:user) }
 


### PR DESCRIPTION
Resolves #1113 
@flbulgarelli  I've added the ask_for_help_enabled? method in labo, but i could move it to platform if you think it'll be used elsewhere