### PR TITLE
using code mirror for message submission

### DIFF
--- a/app/assets/javascripts/application/codemirror-builder.js
+++ b/app/assets/javascripts/application/codemirror-builder.js
@@ -30,7 +30,7 @@ var mumuki = mumuki || {};
 
   CodeMirrorBuilder.prototype = {
     createEditor: function (customOptions) {
-      return CodeMirror.fromTextArea(this.textarea, Object.assign(codeMirrorDefaults, customOptions));
+      return CodeMirror.fromTextArea(this.textarea, Object.assign({}, codeMirrorDefaults, customOptions));
     },
     setupEditor: function () {
       this.editor = this.createEditor({
@@ -50,6 +50,7 @@ var mumuki = mumuki || {};
     },
     setupSimpleEditor: function () {
       this.editor = this.createEditor({
+        mode: 'text',
         extraKeys: {
           'Cmd-Enter': submitMessage,
           'Ctrl-Enter': submitMessage,

--- a/app/assets/javascripts/application/codemirror-builder.js
+++ b/app/assets/javascripts/application/codemirror-builder.js
@@ -13,18 +13,28 @@ var mumuki = mumuki || {};
     $('.btn-submit').click();
   }
 
+  function submitMessage() {
+    $('.discussion-new-message-button').click();
+  }
+
+  var codeMirrorDefaults = {
+    autofocus: false,
+    tabSize: 2,
+    cursorHeight: 1,
+    matchBrackets: true,
+    lineWiseCopyCut: true,
+    autoCloseBrackets: true,
+    showCursorWhenSelecting: true,
+    lineWrapping: true
+  };
+
   CodeMirrorBuilder.prototype = {
+    createEditor: function (customOptions) {
+      return CodeMirror.fromTextArea(this.textarea, Object.assign(codeMirrorDefaults, customOptions));
+    },
     setupEditor: function () {
-      this.editor = CodeMirror.fromTextArea(this.textarea, {
-        autofocus: false,
-        tabSize: 2,
+      this.editor = this.createEditor({
         lineNumbers: true,
-        lineWrapping: true,
-        cursorHeight: 1,
-        matchBrackets: true,
-        lineWiseCopyCut: true,
-        autoCloseBrackets: true,
-        showCursorWhenSelecting: true,
         extraKeys: {
           'Ctrl-Space': 'autocomplete',
           'Cmd-Enter': submit,
@@ -32,6 +42,17 @@ var mumuki = mumuki || {};
           'F11': function () {
             mumuki.editor.toggleFullscreen();
           },
+          'Tab': function (cm) {
+            mumuki.editor.indentWithSpaces(cm)
+          }
+        }
+      });
+    },
+    setupSimpleEditor: function () {
+      this.editor = this.createEditor({
+        extraKeys: {
+          'Cmd-Enter': submitMessage,
+          'Ctrl-Enter': submitMessage,
           'Tab': function (cm) {
             mumuki.editor.indentWithSpaces(cm)
           }

--- a/app/assets/javascripts/application/discussions.js
+++ b/app/assets/javascripts/application/discussions.js
@@ -14,6 +14,19 @@ mumuki.load(function () {
   var $subscriptionSpans = $('.discussion-subscription > span');
   var $upvoteSpans = $('.discussion-upvote > span');
 
+  function createNewMessageEditor() {
+    var $textarea = $("#new-discussion-message");
+    var textarea = $textarea[0];
+    if(!textarea) return;
+    var builder = new mumuki.editor.CodeMirrorBuilder(textarea);
+    builder.setupSimpleEditor();
+    builder.setupOptions($textarea.data('lines'));
+    builder.setupLanguage();
+    builder.build();
+  }
+
+  createNewMessageEditor();
+
   var Forum = {
     toggleButton: function (spans) {
       spans.toggleClass('hidden');

--- a/app/assets/javascripts/application/discussions.js
+++ b/app/assets/javascripts/application/discussions.js
@@ -21,7 +21,6 @@ mumuki.load(function () {
     var builder = new mumuki.editor.CodeMirrorBuilder(textarea);
     builder.setupSimpleEditor();
     builder.setupOptions($textarea.data('lines'));
-    builder.setupLanguage();
     builder.build();
   }
 

--- a/app/assets/stylesheets/application/modules/_discussion.scss
+++ b/app/assets/stylesheets/application/modules/_discussion.scss
@@ -250,8 +250,23 @@ $moderator-star-color: #dd9900;
 
 .discussion-new-message-content {
   resize: none;
+  min-height: 150px;
   border-radius: 0;
   border-color: transparent;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  .CodeMirror {
+    border: unset;
+    color: $brand-primary;
+    font-family: $font-family-sans-serif;
+    padding: 15px;
+  }
+  .CodeMirror-wrap,
+  .CodeMirror-scroll {
+    height: auto !important;
+    min-height: 100px !important;
+  }
   &:focus {
     border-color: white;
   }

--- a/app/views/discussions/_new_message.html.erb
+++ b/app/views/discussions/_new_message.html.erb
@@ -10,7 +10,7 @@
         <div class="container-fluid">
           <div class="row">
             <div class="discussion-new-message-content">
-              <%= f.editor :content, @discussion.language.name, { id: 'new-discussion-message', class: 'form-control', placeholder: t(:message)} %>
+              <%= f.editor :content, '', { id: 'new-discussion-message', class: 'form-control', placeholder: t(:message) } %>
             </div>
           </div>
         </div>

--- a/app/views/discussions/_new_message.html.erb
+++ b/app/views/discussions/_new_message.html.erb
@@ -9,7 +9,9 @@
       <div class="discussion-message-bubble-content">
         <div class="container-fluid">
           <div class="row">
-            <div><%= f.text_area :content, class: 'form-control discussion-new-message-content', placeholder: t(:message), required: true %></div>
+            <div class="discussion-new-message-content">
+              <%= f.editor :content, @discussion.language.name, { id: 'new-discussion-message', class: 'form-control', placeholder: t(:message)} %>
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/discussions/show.html.erb
+++ b/app/views/discussions/show.html.erb
@@ -56,7 +56,9 @@
 
   <% if @discussion.has_messages? %>
     <div class="discussion-messages">
-      <%= render partial: 'discussions/description_message', locals: {discussion: @discussion} %>
+      <% if @discussion.description.present? %>
+        <%= render partial: 'discussions/description_message', locals: {discussion: @discussion} %>
+      <% end %>
       <% @discussion.messages.each do |message| %>
         <%= render partial: 'discussions/message', locals: {user: message.sender_user, message: message} %>
       <% end %>


### PR DESCRIPTION
This is part of the enhancements in message formatting.
I'm using code mirror to be consistent with tabbing and shortcuts.

Ideally this component will be replaced with @fedescarpa's, but in the meantime i think it's a heavy improvement on a plain textarea.

I'm not sure if i should keep language settings or not:

![screenshot-2018-7-31 sdfdsfds - mumuki](https://user-images.githubusercontent.com/11860076/43481492-752ed6fc-94dc-11e8-87fe-dea2b44e1f97.png)

Take into account that this will apply only when entering new messages. When seeing other people messages, it will keep code formatting, but it won't highlight language specific words:

![screenshot-2018-7-31 sdfdsfds - mumuki 1](https://user-images.githubusercontent.com/11860076/43481583-ba4b5c56-94dc-11e8-92a5-d62194cd6f8b.png)

So i'm not sure if i should: 

1) Keep it this way
2) Modify it so in both places language words are highlighted
3) Avoid highlighting everything until Fede's component is ready and the user can select which part it's code

:warning: Don't review the code yet! :warning: 