### PR TITLE
Fixing exercises with nil tests

### DIFF
--- a/app/models/concerns/with_assignments.rb
+++ b/app/models/concerns/with_assignments.rb
@@ -31,7 +31,7 @@ module WithAssignments
   end
 
   def test_for(user)
-    interpolate_for user, test
+    test && interpolate_for(user, test)
   end
 
   def replace_content_reference(user, interpolee)

--- a/app/models/submission/submission.rb
+++ b/app/models/submission/submission.rb
@@ -29,6 +29,7 @@ class Submission
   def evaluate!(assignment)
     try_evaluate! assignment
   rescue => e
+    Rails.logger.error "Evaluation failed: #{e} \n#{e.backtrace.join("\n")}"
     {status: :errored, result: e.message}
   end
 

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -281,6 +281,12 @@ describe Exercise, organization_workspace: :test do
 
           it { expect(exercise.test_for(user)).to eq "<div>Hola Orlo</div>" }
         end
+
+        context 'and test is nil'  do
+          let(:exercise) { create(:exercise, test: nil, expectations: [{}]) }
+
+          it { expect(exercise.test_for(user)).to eq nil }
+        end
       end
       context 'when interpolation is in extra' do
         describe 'right previous content' do


### PR DESCRIPTION
Probando cosas en el runner de HTML me di cuenta que introduje un bug en https://github.com/mumuki/mumuki-laboratory/pull/1132, que causaba que trate de interpolar los tests incluso cuando los :test era nil, y pinchaba con el peor error del mundo :(

Este PR arregla eso.