### PR TITLE
Removing automatic content generation when using multiple files

### DIFF
--- a/app/models/concerns/with_assignments.rb
+++ b/app/models/concerns/with_assignments.rb
@@ -14,7 +14,6 @@ module WithAssignments
     language
       .directives_sections
       .split_sections(assignment_for(user)&.solution || default_content_for(user))
-      .select { |name| Mumuki::Laboratory::File.valid_filename? name }
       .map { |name, content| Mumuki::Laboratory::File.new name, content }
   end
 

--- a/app/models/concerns/with_assignments.rb
+++ b/app/models/concerns/with_assignments.rb
@@ -14,7 +14,7 @@ module WithAssignments
     language
       .directives_sections
       .split_sections(assignment_for(user)&.solution || default_content_for(user))
-      .except('content')
+      .select { |name| Mumuki::Laboratory::File.valid_filename? name }
       .map { |name, content| Mumuki::Laboratory::File.new name, content }
   end
 

--- a/lib/mumuki/laboratory/file.rb
+++ b/lib/mumuki/laboratory/file.rb
@@ -2,6 +2,10 @@ module Mumuki::Laboratory
   class File
     attr_reader :name, :content
 
+    def self.valid_filename?(name)
+      name.include? '.'
+    end
+
     def initialize(name, content)
       @name = name
       @content = content

--- a/lib/mumuki/laboratory/file.rb
+++ b/lib/mumuki/laboratory/file.rb
@@ -2,10 +2,6 @@ module Mumuki::Laboratory
   class File
     attr_reader :name, :content
 
-    def self.valid_filename?(name)
-      name.include? '.'
-    end
-
     def initialize(name, content)
       @name = name
       @content = content

--- a/lib/mumuki/laboratory/mumukit/directives.rb
+++ b/lib/mumuki/laboratory/mumukit/directives.rb
@@ -1,15 +1,16 @@
 require 'mumukit/directives'
 
 class Mumukit::Directives::Sections < Mumukit::Directives::Directive
-  def build(section, content)
-    "#{comment_type.comment "<#{section}#"}#{content}#{comment_type.comment "##{section}>"}"
-  end
-
   def join(sections)
     file_declarations, file_references = sections.map do |section, content|
       [build(section, content), interpolate(section)]
     end.transpose
-    "#{file_declarations.join "\n"}\n#{build 'content', file_references.join("\n")}"
+
+    file_declarations.join "\n"
+  end
+
+  def build(section, content)
+    "#{comment_type.comment "<#{section}#"}#{content}#{comment_type.comment "##{section}>"}"
   end
 
   def interpolate(section)

--- a/spec/controllers/exercise_solutions_controller_spec.rb
+++ b/spec/controllers/exercise_solutions_controller_spec.rb
@@ -28,7 +28,7 @@ describe ExerciseSolutionsController, organization_workspace: :test do
     let(:files) { problem.files_for(user) }
 
     it { expect(response.status).to eq 200 }
-    it { expect(Assignment.last.solution).to eq("/*<a_file.css#*/a css content/*#a_file.css>*/\n/*<a_file.js#*/a js content/*#a_file.js>*/\n/*<content#*//*...a_file.css...*/\n/*...a_file.js...*//*#content>*/") }
+    it { expect(Assignment.last.solution).to eq("/*<a_file.css#*/a css content/*#a_file.css>*/\n/*<a_file.js#*/a js content/*#a_file.js>*/") }
     it { expect(files.count).to eq 2 }
     it { expect(files[0]).to have_attributes(name: 'a_file.css', content: 'a css content') }
     it { expect(files[0].highlight_mode).to eq 'css' }


### PR DESCRIPTION
Saqué este comportamiento de concatenar automáticamente los files porque por lo que necesitamos ahora no nos servía de nada.