### PR TITLE
slice for attribute names before updates

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -77,4 +77,7 @@ class ApplicationRecord < ActiveRecord::Base
     obj
   end
 
+  def whitelist_attributes(a_hash, options)
+    a_hash.slice(*attribute_names).except(*options[:except])
+  end
 end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -82,7 +82,7 @@ class Exercise < ApplicationRecord
 
     reset!
 
-    attrs = json.slice(*attribute_names).except 'type', 'id'
+    attrs = whitelist_attributes(json, except: %w(type id))
     attrs['choices'] = json['choices'].map { |choice| choice['value'] } if json['choices'].present?
     attrs['bibliotheca_id'] = json['id']
     attrs['number'] = number

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -82,7 +82,7 @@ class Exercise < ApplicationRecord
 
     reset!
 
-    attrs = json.except('type', 'id', 'solution', 'language', 'teacher_info', 'choices')
+    attrs = json.slice(*attribute_names).except 'type', 'id'
     attrs['choices'] = json['choices'].map { |choice| choice['value'] } if json['choices'].present?
     attrs['bibliotheca_id'] = json['id']
     attrs['number'] = number

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -58,7 +58,7 @@ class Guide < Content
   end
 
   def import_from_json!(json)
-    self.assign_attributes json.slice(*attribute_names).except 'id'
+    self.assign_attributes whitelist_attributes(json, except: ['id'])
     self.language = Language.for_name(json['language'])
     self.save!
 

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -58,7 +58,7 @@ class Guide < Content
   end
 
   def import_from_json!(json)
-    self.assign_attributes json.except('exercises', 'language', 'id_format', 'id', 'teacher_info', 'collaborators', 'private')
+    self.assign_attributes json.slice(*attribute_names).except 'id'
     self.language = Language.for_name(json['language'])
     self.save!
 


### PR DESCRIPTION
Fixes #1169.

This is a pretty lazy implementation tbh.

Rather than explicitly writing the list I opted for using the attribute_names to avoid having to update the list every time the model changes.

I still needed to except some fields because both laboratory and bibliotheca export them but with different meanings.