### PR TITLE
get assignment status only if assignment exists

### DIFF
--- a/app/views/layouts/_kids.html.erb
+++ b/app/views/layouts/_kids.html.erb
@@ -17,5 +17,5 @@
     <div class="description"><%= exercise.description_task %></div>
     <div class="hint" style="display: none"><%= exercise.hint_html %></div>
   </div>
-  <div class="mu-kids-character-speech-bubble-failed <%= @assignment.status %>" style="display: none"></div>
+  <div class="mu-kids-character-speech-bubble-failed <%= @assignment&.status %>" style="display: none"></div>
 </div>


### PR DESCRIPTION
Related to #1205.

This is a really lazy solution. Ideally, the loaded layouts should not have references to the assignment if the user isn't logged in (which is what we're doing for adults' exercises)

Also, the message is currently displayed where the editor would be, but it would be much better if it was actually displayed within the character's speech bubble.