### PR TITLE
Wrap chapter descriptions better

### DIFF
--- a/app/assets/stylesheets/application/_modules.scss
+++ b/app/assets/stylesheets/application/_modules.scss
@@ -1,3 +1,4 @@
+@import "modules/chapter_show";
 @import "modules/exercise_assignment";
 @import "modules/exercise_results";
 @import "modules/modal";

--- a/app/assets/stylesheets/application/modules/_chapter_show.scss
+++ b/app/assets/stylesheets/application/modules/_chapter_show.scss
@@ -1,0 +1,3 @@
+.chapter-description p {
+  display: inline-block;
+}

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -2,7 +2,7 @@
   <%= breadcrumbs @chapter %>
 <% end %>
 
-<div>
+<div class="chapter-description">
   <h1>
     <span class="hidden-xs"><%= t(:chapter_number, number: @chapter.number) %>:&nbsp;</span>
     <span><%= @chapter.name %></span>


### PR DESCRIPTION
Fixes #1158 

It turned out some chapter descriptions had hardcoded 'float:left' elements in them (they may include HTML) which messes all CSS up, so I made the container p an inline-block to contain its wrath. Let me know if you know of any other img's that may be floating around the app.

Now it looks like this instead
![image](https://user-images.githubusercontent.com/4081895/47898582-3f46ef80-de55-11e8-928a-448324b692d4.png)

Long text for comparison 
![image](https://user-images.githubusercontent.com/4081895/47898697-b54b5680-de55-11e8-9053-b46f690ccbac.png)



