### PR TITLE
Fix dont loose choices checked values

### DIFF
--- a/domain/app/models/assignment.rb
+++ b/domain/app/models/assignment.rb
@@ -65,7 +65,7 @@ class Assignment < ApplicationRecord
 
   def content=(content)
     if content.present?
-      self.solution = exercise.single_choice? ? exercise.choices_values.index(content) : content
+      self.solution = exercise.single_choice? ? exercise.choice_index_for(content) : content
     end
   end
 

--- a/domain/app/models/assignment.rb
+++ b/domain/app/models/assignment.rb
@@ -65,7 +65,7 @@ class Assignment < ApplicationRecord
 
   def content=(content)
     if content.present?
-      self.solution = exercise.single_choice? ? exercise.choices.index(content) : content
+      self.solution = exercise.single_choice? ? exercise.choices_values.index(content) : content
     end
   end
 

--- a/domain/app/models/concerns/with_editor.rb
+++ b/domain/app/models/concerns/with_editor.rb
@@ -15,7 +15,7 @@ module WithEditor
   end
 
   def pretty_choices
-    choices.each_with_index.map do |choice, index|
+    choice_values.each_with_index.map do |choice, index|
       struct id: "content_choice_#{index}",
              index: index,
              value: choice,

--- a/domain/app/models/exercise.rb
+++ b/domain/app/models/exercise.rb
@@ -85,7 +85,7 @@ class Exercise < ApplicationRecord
     reset!
 
     attrs = whitelist_attributes(resource_h, except: [:type, :id])
-    attrs[:choices] = resource_h[:choices]&.map { |choice| choice[:value] }.to_a
+    attrs[:choices] = resource_h[:choices].to_a
     attrs[:bibliotheca_id] = resource_h[:id]
     attrs[:number] = number
     attrs[:manual_evaluation] ||= false
@@ -93,6 +93,10 @@ class Exercise < ApplicationRecord
 
     assign_attributes(attrs)
     save!
+  end
+
+  def choice_values
+    choices.map { |it| it.indifferent_get :value }
   end
 
   def to_resource_h

--- a/domain/app/models/exercise.rb
+++ b/domain/app/models/exercise.rb
@@ -19,6 +19,7 @@ class Exercise < ApplicationRecord
   belongs_to :guide
   defaults { self.submissions_count = 0 }
 
+  serialize :choices, Array
   validates_presence_of :submissions_count,
                         :guide, :bibliotheca_id
 
@@ -96,7 +97,7 @@ class Exercise < ApplicationRecord
   end
 
   def choice_values
-    choices.map { |it| it.is_a?(String) ? it : it.indifferent_get(:value) }
+    self[:choice_values].presence || choices.map { |it| it.indifferent_get(:value) }
   end
 
   def to_resource_h

--- a/domain/app/models/exercise.rb
+++ b/domain/app/models/exercise.rb
@@ -100,6 +100,10 @@ class Exercise < ApplicationRecord
     self[:choice_values].presence || choices.map { |it| it.indifferent_get(:value) }
   end
 
+  def choice_index_for(value)
+    choice_values.index(value)
+  end
+
   def to_resource_h
     language_resource_h = language.to_embedded_resource_h if language != guide.language
     as_json(only: %i(name layout editor description corollary teacher_info hint test manual_evaluation locale extra

--- a/domain/app/models/exercise.rb
+++ b/domain/app/models/exercise.rb
@@ -96,7 +96,7 @@ class Exercise < ApplicationRecord
   end
 
   def choice_values
-    choices.map { |it| it.indifferent_get :value }
+    choices.map { |it| it.is_a?(String) ? it : it.indifferent_get(:value) }
   end
 
   def to_resource_h

--- a/domain/db/migrate/20181121165956_rename_choices_column.rb
+++ b/domain/db/migrate/20181121165956_rename_choices_column.rb
@@ -1,0 +1,6 @@
+class RenameChoicesColumn < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :exercises, :choices, :choice_values
+    add_column :exercises, :choices, :text
+  end
+end

--- a/domain/mumuki-domain.gemspec
+++ b/domain/mumuki-domain.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'mumukit-assistant', '~> 0.1'
   s.add_dependency 'mumukit-bridge', '~> 3.8'
   s.add_dependency 'mumukit-content-type', '~> 1.5'
-  s.add_dependency 'mumukit-core', '~> 1.10'
+  s.add_dependency 'mumukit-core', '~> 1.11'
   s.add_dependency 'mumukit-directives', '~> 0.5'
   s.add_dependency 'mumukit-inspection', '~> 3.5'
   s.add_dependency 'mumukit-randomizer', '~> 1.0'

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181117190241) do
+ActiveRecord::Schema.define(version: 20181121165956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -158,7 +158,7 @@ ActiveRecord::Schema.define(version: 20181117190241) do
     t.boolean "new_expectations", default: false
     t.boolean "manual_evaluation", default: false
     t.integer "editor", default: 0, null: false
-    t.string "choices", default: [], null: false, array: true
+    t.string "choice_values", default: [], null: false, array: true
     t.text "goal"
     t.string "initial_state"
     t.string "final_state"
@@ -166,6 +166,7 @@ ActiveRecord::Schema.define(version: 20181117190241) do
     t.text "randomizations"
     t.text "free_form_editor_source"
     t.text "teacher_info"
+    t.text "choices"
     t.index ["guide_id"], name: "index_exercises_on_guide_id"
     t.index ["language_id"], name: "index_exercises_on_language_id"
   end

--- a/spec/features/exercise_flow_spec.rb
+++ b/spec/features/exercise_flow_spec.rb
@@ -12,7 +12,7 @@ feature 'Exercise Flow', organization_workspace: :test do
   let!(:problem_4) { build(:problem, name: 'Succ4', description: 'Description of Succ4', layout: :input_bottom, extra: 'x = 2') }
   let!(:problem_5) { build(:problem, name: 'Succ5', description: 'Description of Succ5', layout: :input_right, editor: :upload, hint: 'lele', language: gobstones) }
   let!(:problem_6) { build(:problem, name: 'Succ6', description: 'Description of Succ6', layout: :input_right, editor: :hidden, language: haskell) }
-  let!(:problem_7) { build(:problem, name: 'Succ7', description: 'Description of Succ7', choices: ['some choice']) }
+  let!(:problem_7) { build(:problem, name: 'Succ7', description: 'Description of Succ7', choices: [{value: 'some choice', checked: true}]) }
   let!(:playground_1) { build(:playground, name: 'Succ5', description: 'Description of Succ4', layout: :input_right) }
   let!(:playground_2) { build(:playground, name: 'Succ6', description: 'Description of Succ4', layout: :input_right, extra: 'x = 4') }
   let!(:reading) { build(:reading, name: 'Reading about Succ', description: 'Lets understand succ history') }

--- a/spec/helpers/with_choices_spec.rb
+++ b/spec/helpers/with_choices_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe ChoicesHelper do
   helper ChoicesHelper
 
-  context 'exercise width choices' do
+  context 'exercise with choices' do
     let(:checked_content) { struct id: '1', index: 0, value: 'foo', text: 'bar' }
     let(:unchecked_content) { struct id: '3', index: 2, value: 'baz', text: 'lorem' }
     let(:content) { '0:1' }

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -7,9 +7,10 @@ describe Exercise, organization_workspace: :test do
   describe '#choice_values' do
     context 'when choices are in 5.0 format' do
       let(:choice_values) { %w(1492 1453 1773)  }
-      let(:exercise) { build(:exercise, description: 'when did byzantine empire fall?', choices: choice_values) }
+      let(:exercise) { build(:exercise, description: 'when did byzantine empire fall?', choice_values: choice_values) }
 
-      it { expect(exercise.choices).to eq choice_values }
+      it { expect(exercise.choices).to be_blank }
+      it { expect(exercise[:choice_values]).to eq choice_values }
       it { expect(exercise.choice_values).to eq choice_values }
     end
 
@@ -18,6 +19,7 @@ describe Exercise, organization_workspace: :test do
       let(:exercise) { build(:exercise, description: 'when did byzantine empire fall?', choices: choices) }
 
       it { expect(exercise.choices).to eq choices }
+      it { expect(exercise[:choice_values]).to be_blank }
       it { expect(exercise.choice_values).to eq %w(1492 1453 1773) }
     end
   end

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -4,6 +4,24 @@ describe Exercise, organization_workspace: :test do
   let(:exercise) { create(:exercise) }
   let(:user) { create(:user, first_name: 'Orlo') }
 
+  describe '#choice_values' do
+    context 'when choices are in 5.0 format' do
+      let(:choice_values) { %w(1492 1453 1773)  }
+      let(:exercise) { build(:exercise, description: 'when did byzantine empire fall?', choices: choice_values) }
+
+      it { expect(exercise.choices).to eq choice_values }
+      it { expect(exercise.choice_values).to eq choice_values }
+    end
+
+    context 'when choices are in 6.0 format' do
+      let(:choices) { [{value: '1492', checked: false}, {value: '1453', checked: true}, {value: '1773', checked: false}] }
+      let(:exercise) { build(:exercise, description: 'when did byzantine empire fall?', choices: choices) }
+
+      it { expect(exercise.choices).to eq choices }
+      it { expect(exercise.choice_values).to eq %w(1492 1453 1773) }
+    end
+  end
+
   describe '#slug' do
     let(:guide) { create(:guide, slug: 'foo/bar') }
     let(:exercise) { create(:exercise, guide: guide, bibliotheca_id: 4) }

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -12,6 +12,8 @@ describe Exercise, organization_workspace: :test do
       it { expect(exercise.choices).to be_blank }
       it { expect(exercise[:choice_values]).to eq choice_values }
       it { expect(exercise.choice_values).to eq choice_values }
+      it { expect(exercise.choice_index_for '1492').to eq 0 }
+      it { expect(exercise.choice_index_for '1773').to eq 2 }
     end
 
     context 'when choices are in 6.0 format' do
@@ -21,6 +23,8 @@ describe Exercise, organization_workspace: :test do
       it { expect(exercise.choices).to eq choices }
       it { expect(exercise[:choice_values]).to be_blank }
       it { expect(exercise.choice_values).to eq %w(1492 1453 1773) }
+      it { expect(exercise.choice_index_for '1492').to eq 0 }
+      it { expect(exercise.choice_index_for '1773').to eq 2 }
     end
   end
 

--- a/spec/models/guide_import_spec.rb
+++ b/spec/models/guide_import_spec.rb
@@ -148,7 +148,8 @@ describe Guide do
       it { expect(guide.exercises.second.language).to eq haskell }
       it { expect(guide.exercises.second.default_content).to eq 'a default content' }
       it { expect(guide.exercises.second.extra_visible).to be true }
-      it { expect(guide.exercises.fourth.choices).to eq ['foo', 'bar'] }
+      it { expect(guide.exercises.fourth.choices).to eq [{value: 'foo', checked: true}, {value: 'bar', checked: false}] }
+      it { expect(guide.exercises.fourth.choice_values).to eq ['foo', 'bar'] }
 
       it { expect(guide.exercises.third.expectations.first['binding']).to eq 'foo' }
 

--- a/spec/models/guide_import_spec.rb
+++ b/spec/models/guide_import_spec.rb
@@ -55,7 +55,7 @@ describe Guide do
           extra: '',
           language: { name: 'text' },
           test: "---\nequal: '1'\n",
-          choices: [{value: 'foo', checked: false}, {value: 'bar', chekced: true}],
+          choices: [{value: 'foo', checked: false}, {value: 'bar', checked: true}],
           extra_visible: false,
           id: 8},
          {type: 'reading',
@@ -148,7 +148,7 @@ describe Guide do
       it { expect(guide.exercises.second.language).to eq haskell }
       it { expect(guide.exercises.second.default_content).to eq 'a default content' }
       it { expect(guide.exercises.second.extra_visible).to be true }
-      it { expect(guide.exercises.fourth.choices).to eq [{value: 'foo', checked: true}, {value: 'bar', checked: false}] }
+      it { expect(guide.exercises.fourth.choices).to eq [{'value' => 'foo', 'checked' => false}, {'value' => 'bar', 'checked' => true}] }
       it { expect(guide.exercises.fourth.choice_values).to eq ['foo', 'bar'] }
 
       it { expect(guide.exercises.third.expectations.first['binding']).to eq 'foo' }


### PR DESCRIPTION
Currently there is a big bug in 6.0 series: it is using the old structure of `choices` from labo, but domain  should keep all the information - that is, the choices values and they `checked` attribute. 

This PR adds this information with a database-backward-compatible migration. 