### PR TITLE
Updating to sync 0.3

### DIFF
--- a/domain/app/models/concerns/with_slug.rb
+++ b/domain/app/models/concerns/with_slug.rb
@@ -15,7 +15,7 @@ module WithSlug
   ## Resource Protocol
 
   def sync_key
-    Mumukit::Sync.key self.class.name.underscore.to_sym, slug
+    Mumukit::Sync.key self.class, slug
   end
 
   ## Copy and Rebase

--- a/domain/app/models/exercise.rb
+++ b/domain/app/models/exercise.rb
@@ -132,7 +132,7 @@ class Exercise < ApplicationRecord
   end
 
   def reclassify!(type)
-    update!(type: Mumukit::Sync.classify(type))
+    update!(type: type)
     Exercise.find(id)
   end
 

--- a/domain/app/models/guide.rb
+++ b/domain/app/models/guide.rb
@@ -58,7 +58,7 @@ class Guide < Content
   end
 
   def import_from_resource_h!(resource_h)
-    self.assign_attributes whitelist_attributes(resource_h, except: [:id])
+    self.assign_attributes whitelist_attributes(resource_h)
     self.language = Language.for_name(resource_h.dig(:language, :name))
     self.save!
 
@@ -67,8 +67,8 @@ class Guide < Content
       exercise_type = e[:type] || 'problem'
 
       exercise = exercise ?
-          exercise.ensure_type!(exercise_type) :
-          Mumukit::Sync.constantize(exercise_type).new(guide_id: self.id, bibliotheca_id: e[:id])
+          exercise.ensure_type!(exercise_type.as_module_name) :
+          exercise_type.as_module.new(guide_id: self.id, bibliotheca_id: e[:id])
 
       exercise.import_from_resource_h! (i+1), e
     end

--- a/domain/mumuki-domain.gemspec
+++ b/domain/mumuki-domain.gemspec
@@ -20,11 +20,11 @@ Gem::Specification.new do |s|
   s.add_dependency 'mumukit-assistant', '~> 0.1'
   s.add_dependency 'mumukit-bridge', '~> 3.8'
   s.add_dependency 'mumukit-content-type', '~> 1.5'
-  s.add_dependency 'mumukit-core', '~> 1.11'
+  s.add_dependency 'mumukit-core', '~> 1.13'
   s.add_dependency 'mumukit-directives', '~> 0.5'
   s.add_dependency 'mumukit-inspection', '~> 3.5'
   s.add_dependency 'mumukit-randomizer', '~> 1.0'
   s.add_dependency 'mumukit-platform', '~> 3.0'
-  s.add_dependency 'mumukit-sync', '~> 0.1'
+  s.add_dependency 'mumukit-sync', '~> 0.3'
 
 end

--- a/lib/events.rb
+++ b/lib/events.rb
@@ -27,12 +27,9 @@ Mumukit::Nuntius::EventConsumer.handle do
 
   [Book, Topic, Guide].each do |it|
     event "#{it.name}Changed" do |data|
-      slug = data[:slug]
-      item = it.find_or_initialize_by(slug: slug)
-
       Mumukit::Sync::Syncer.new(
         Mumukit::Sync::Store::Bibliotheca.new(
-          Mumukit::Platform.bibliotheca_bridge)).import! item
+          Mumukit::Platform.bibliotheca_bridge)).locate_and_import! it, data[:slug]
     end
   end
 end


### PR DESCRIPTION
Stop using deprecated methods and stop locating content manually.