### PR TITLE
Issue #1033 remove deprecated gobstones specific js methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,14 +177,20 @@ which are granted to be safe and stable.
 ### Methods
 
 * `mumuki.bridge.Laboratory`
-* `mumuki.kids.registerBlocksAreaScaler`
-* `mumuki.kids.registerStateScaler`
-* `mumuki.kids.restart`
-* `mumuki.kids.scaleBlocksArea`
-* `mumuki.kids.scaleState`
-* `mumuki.kids.showResult`
+  * `.runTests`
+* `mumuki.kids`
+  * `registerBlocksAreaScaler`
+  * `registerStateScaler`
+  * `restart`
+  * `scaleBlocksArea`
+  * `scaleState`
+  * `showResult`
 * `mumuki.locale`
 * `mumuki.MultipleScenarios`
+  * `scenarios`
+  * `currentScenarioIndex`
+  * `resetIndicators`
+  * `updateIndicators`
 * `mumuki.version`
 
 ### Kids Call order

--- a/app/assets/javascripts/application/bridge.js
+++ b/app/assets/javascripts/application/bridge.js
@@ -37,16 +37,28 @@ var mumuki = mumuki || {};
   });
 
   Laboratory.prototype = {
-    runLocalTests: function (solution) {
+
+    // ==========
+    // Public API
+    // ==========
+
+    // Runs tests for the current exercise using the given submission
+    // content.
+    runTests: function(content) {
+      return this._submitSolution({ solution: content });
+    },
+
+    // ===========
+    // Private API
+    // ===========
+
+    _submitSolution: function (solution) {
       if(lastSubmissionFinishedSuccessfully() && sameAsLastSolution(solution)){
         return $.Deferred().resolve(lastSubmission.result);
       } else {
         return sendNewSolution(solution);
       }
     },
-    runTests: function(content) {
-      return this.runLocalTests({ solution: content });
-    }
   };
 
   mumuki.bridge = {

--- a/app/assets/javascripts/application/submission.js
+++ b/app/assets/javascripts/application/submission.js
@@ -90,7 +90,7 @@ var mumuki = mumuki || {};
       mumuki.editor.syncContent();
       var solution = getContent();
 
-      bridge.runLocalTests(solution).done(function (data) {
+      bridge._submitSolution(solution).done(function (data) {
         resultsBox.success(data, submitButton);
       }).fail(function () {
         resultsBox.error(submitButton);


### PR DESCRIPTION
Fixes #1033

Please notice that  `shoẁKidsResult` has already been removed in  53c7d90aac1f32cbbd586a1fe146b76cb45047be (https://github.com/mumuki/mumuki-laboratory/pull/1287)