### PR TITLE
Authoring note when no collaborators contributed to a guide

### DIFF
--- a/app/helpers/authors_helper.rb
+++ b/app/helpers/authors_helper.rb
@@ -1,0 +1,10 @@
+module AuthorsHelper
+
+  def attribution_caption(guide)
+    if guide.collaborators.present?
+      t(:authoring_note_with_collaborators, authors: guide.authors, collaborators: "https://raw.githubusercontent.com/#{guide.slug}/master/COLLABORATORS.txt")
+    else
+      t(:authoring_note, authors: guide.authors)
+    end
+  end
+end

--- a/app/helpers/authors_helper.rb
+++ b/app/helpers/authors_helper.rb
@@ -2,9 +2,9 @@ module AuthorsHelper
 
   def attribution_caption(guide)
     if guide.collaborators.present?
-      t(:authoring_note_with_collaborators, authors: guide.authors, collaborators: "https://raw.githubusercontent.com/#{guide.slug}/master/COLLABORATORS.txt")
+      t(:authoring_note_with_collaborators_html, authors: guide.authors, collaborators: "https://raw.githubusercontent.com/#{guide.slug}/master/COLLABORATORS.txt")
     else
-      t(:authoring_note, authors: guide.authors)
+      t(:authoring_note_html, authors: guide.authors)
     end
   end
 end

--- a/app/views/layouts/_authoring.html.erb
+++ b/app/views/layouts/_authoring.html.erb
@@ -6,11 +6,7 @@
           <%= render partial: 'layouts/copyright' %> -
         </span>
       <% end %>
-      <% if guide.collaborators.present? %>
-        <%= raw t :authoring_note_with_collaborators, authors: guide.authors, collaborators: "https://raw.githubusercontent.com/#{guide.slug}/master/COLLABORATORS.txt" %>
-      <% else %>
-        <%= raw t :authoring_note, authors: guide.authors %>
-      <% end %>
+      <%= raw attribution_caption(guide) %>
     </p>
   <% end %>
 <% end %>

--- a/app/views/layouts/_authoring.html.erb
+++ b/app/views/layouts/_authoring.html.erb
@@ -6,7 +6,11 @@
           <%= render partial: 'layouts/copyright' %> -
         </span>
       <% end %>
-      <%= raw t :authoring_note, authors: guide.authors, collaborators: "https://raw.githubusercontent.com/#{guide.slug}/master/COLLABORATORS.txt" %>
+      <% if guide.collaborators.present? %>
+        <%= raw t :authoring_note_with_collaborators, authors: guide.authors, collaborators: "https://raw.githubusercontent.com/#{guide.slug}/master/COLLABORATORS.txt" %>
+      <% else %>
+        <%= raw t :authoring_note, authors: guide.authors %>
+      <% end %>
     </p>
   <% end %>
 <% end %>

--- a/app/views/layouts/_authoring.html.erb
+++ b/app/views/layouts/_authoring.html.erb
@@ -6,7 +6,7 @@
           <%= render partial: 'layouts/copyright' %> -
         </span>
       <% end %>
-      <%= raw attribution_caption(guide) %>
+      <%= attribution_caption(guide) %>
     </p>
   <% end %>
 <% end %>

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -20,7 +20,8 @@ en:
     other: '%{count} attempts remaining'
   author: Author
   authoring: "Authoring"
-  authoring_note: This guide's content was developed by %{authors} and <a href="%{collaborators}" target="_blank">many others</a>, under the terms of <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons License Share-Alike, 4.0</a>
+  authoring_note: This guide's content was developed by %{authors} under the terms of <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons License Share-Alike, 4.0</a>
+  authoring_note_with_collaborators: This guide's content was developed by %{authors} and <a href="%{collaborators}" target="_blank">many others</a>, under the terms of <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons License Share-Alike, 4.0</a>
   back_to_mumuki: Back to Mumuki!
   bibliotheca: Bibliotheca
   blocked_forum_explanation: You are not allowed to see this content. <br> Are you in the middle of an exam right now?

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -20,8 +20,8 @@ en:
     other: '%{count} attempts remaining'
   author: Author
   authoring: "Authoring"
-  authoring_note: This guide's content was developed by %{authors} under the terms of <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons License Share-Alike, 4.0</a>
-  authoring_note_with_collaborators: This guide's content was developed by %{authors} and <a href="%{collaborators}" target="_blank">many others</a>, under the terms of <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons License Share-Alike, 4.0</a>
+  authoring_note_html: This guide's content was developed by %{authors} under the terms of <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons License Share-Alike, 4.0</a>
+  authoring_note_with_collaborators_html: This guide's content was developed by %{authors} and <a href="%{collaborators}" target="_blank">many others</a>, under the terms of <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons License Share-Alike, 4.0</a>
   back_to_mumuki: Back to Mumuki!
   bibliotheca: Bibliotheca
   blocked_forum_explanation: You are not allowed to see this content. <br> Are you in the middle of an exam right now?

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -22,8 +22,8 @@ es:
     other: '%{count} intentos restantes'
   author: Autor
   authoring: "Autores"
-  authoring_note: Esta guía fue desarrollada por %{authors} bajo los términos de la <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Licencia Creative Commons Compartir-Igual, 4.0</a>.
-  authoring_note_with_collaborators: Esta guía fue desarrollada por %{authors} y <a href="%{collaborators}" target="_blank">muchas personas más</a>, bajo los términos de la <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Licencia Creative Commons Compartir-Igual, 4.0</a>.
+  authoring_note_html: Esta guía fue desarrollada por %{authors} bajo los términos de la <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Licencia Creative Commons Compartir-Igual, 4.0</a>.
+  authoring_note_with_collaborators_html: Esta guía fue desarrollada por %{authors} y <a href="%{collaborators}" target="_blank">muchas personas más</a>, bajo los términos de la <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Licencia Creative Commons Compartir-Igual, 4.0</a>.
   back_to_mumuki: ¡Volvé a Mumuki!
   bibliotheca: Biblioteca
   blocked_forum_explanation: Es decir que no tenés autorización para ver este contenido. <br> ¿Puede que estés en medio de un examen?

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -22,7 +22,8 @@ es:
     other: '%{count} intentos restantes'
   author: Autor
   authoring: "Autores"
-  authoring_note: Esta guía fue desarrollada por %{authors} y <a href="%{collaborators}" target="_blank">muchas personas más</a>, bajo los términos de la <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Licencia Creative Commons Compartir-Igual, 4.0</a>.
+  authoring_note: Esta guía fue desarrollada por %{authors} bajo los términos de la <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Licencia Creative Commons Compartir-Igual, 4.0</a>.
+  authoring_note_with_collaborators: Esta guía fue desarrollada por %{authors} y <a href="%{collaborators}" target="_blank">muchas personas más</a>, bajo los términos de la <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Licencia Creative Commons Compartir-Igual, 4.0</a>.
   back_to_mumuki: ¡Volvé a Mumuki!
   bibliotheca: Biblioteca
   blocked_forum_explanation: Es decir que no tenés autorización para ver este contenido. <br> ¿Puede que estés en medio de un examen?

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -21,8 +21,8 @@ pt:
     other: '%{count} tentativa restante'
   author: Autor
   authoring: Autores
-  authoring_note: 'Este guia foi desenvolvido por %{authors} nos termos do <a href = "https://creativecommons.org/licenses/by-sa/4.0/" target="_blank"> Creative Commons License Share-Equal, 4.0 </a>.'
-  authoring_note_with_collaborators: 'Este guia foi desenvolvido por %{authors} e <a href="%{collaborators}" target="_blank">muitas outras pessoas </a>, nos termos do <a href = "https://creativecommons.org/licenses/by-sa/4.0/" target="_blank"> Creative Commons License Share-Equal, 4.0 </a>.'
+  authoring_note_html: 'Este guia foi desenvolvido por %{authors} nos termos do <a href = "https://creativecommons.org/licenses/by-sa/4.0/" target="_blank"> Creative Commons License Share-Equal, 4.0 </a>.'
+  authoring_note_with_collaborators_html: 'Este guia foi desenvolvido por %{authors} e <a href="%{collaborators}" target="_blank">muitas outras pessoas </a>, nos termos do <a href = "https://creativecommons.org/licenses/by-sa/4.0/" target="_blank"> Creative Commons License Share-Equal, 4.0 </a>.'
   back_to_mumuki: Voltei para Mumuki!
   bibliotheca: Biblioteca
   blocked_forum_explanation: Você não tem permissão para ver este conteúdo. <br> Você está no meio de um exame agora?

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -21,7 +21,8 @@ pt:
     other: '%{count} tentativa restante'
   author: Autor
   authoring: Autores
-  authoring_note: 'Este guia foi desenvolvido por %{authors} e <a href="%{collaborators}" target="_blank"> muitas outras pessoas </a>, nos termos do <a href = "https://creativecommons.org/licenses/by-sa/4.0/" target="_blank"> Creative Commons License Share-Equal, 4.0 </a>.'
+  authoring_note: 'Este guia foi desenvolvido por %{authors} nos termos do <a href = "https://creativecommons.org/licenses/by-sa/4.0/" target="_blank"> Creative Commons License Share-Equal, 4.0 </a>.'
+  authoring_note_with_collaborators: 'Este guia foi desenvolvido por %{authors} e <a href="%{collaborators}" target="_blank">muitas outras pessoas </a>, nos termos do <a href = "https://creativecommons.org/licenses/by-sa/4.0/" target="_blank"> Creative Commons License Share-Equal, 4.0 </a>.'
   back_to_mumuki: Voltei para Mumuki!
   bibliotheca: Biblioteca
   blocked_forum_explanation: Você não tem permissão para ver este conteúdo. <br> Você está no meio de um exame agora?

--- a/spec/helpers/authors_helper_spec.rb
+++ b/spec/helpers/authors_helper_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe AuthorsHelper, organization_workspace: :test do
+  helper AuthorsHelper
+
+  describe 'authoring_notes' do
+    context 'with collaborators' do
+      let(:guide) { create(:guide, authors: 'Writer', collaborators: 'Collaborators') }
+      it { expect(attribution_caption(guide)).to include "many others" }
+    end
+    
+    context 'with no collaborators' do
+      let(:guide) { create(:guide, authors: 'Writer') }
+      it { expect(attribution_caption(guide)).not_to include "many others" }
+    end
+
+  end
+end


### PR DESCRIPTION
This is a very small, silly fix to prevent 404 links after clicking on `and many more` when there are no collaborators in a guide.

New footers with and without collaborators:
____

![image](https://user-images.githubusercontent.com/11304439/56251334-99e1aa00-6089-11e9-871f-de8c51804f00.png)
____
![image](https://user-images.githubusercontent.com/11304439/56251357-acf47a00-6089-11e9-8ae1-776611eec9b8.png)
____

Keys `authoring_note` and `authoring_note_with_collaborators` are unfortunately very similar since I found out [you can't call another I18n key in an I18n interpolation](https://stackoverflow.com/a/14306610/10560526) (for example, by creating a `:license` key to avoid duplication)

A downside to this PR is existing guides' authors might have to be changed (if we care) to an "A, B, C _and_ D" format to keep grammatical cohesion... as long as they don't have collaborators :grimacing: 

![image](https://user-images.githubusercontent.com/11304439/56251582-7a974c80-608a-11e9-9fbf-c189db41b332.png)
