### PR TITLE
Fix fonts not showing

### DIFF
--- a/app/assets/stylesheets/mumuki_laboratory/application.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application.scss
@@ -1,6 +1,6 @@
-$icon-font-path: '../assets/bootstrap/';
-$fa-font-path: '../assets';
-$da-font-path: '../assets';
+$icon-font-path: asset-path('assets/bootstrap');
+$fa-font-path: asset-path('assets');
+$da-font-path: asset-path('assets');
 
 @import "scss/mumuki-styles";
 @import "codemirror/codemirror.min";


### PR DESCRIPTION
This bug started appearing when the assets were moved to the `mumuki-laboratory` folder inside `assets`.

![Screenshot_2019-05-15 Mumuki - Mini Programadores - Aprendé a programar](https://user-images.githubusercontent.com/11304439/57798132-69da0500-7722-11e9-9292-5a362e42e973.png)
![Screenshot_2019-05-15 Un tablero de bolitas movedizas - Mumuki - Mini Programadores](https://user-images.githubusercontent.com/11304439/57798129-66467e00-7722-11e9-8ac0-3b4358b07f44.png)
![Screenshot_2019-05-15 Mumuki - Mini Programadores - Aprendé a programar(1)](https://user-images.githubusercontent.com/11304439/57798130-68104180-7722-11e9-98c1-13ba74624743.png)

While writing something like

```
$fa-font-path: asset-path('../../assets');
```

fixes it, I believe using `asset-path` should make it future-proof in case they're moved again.