### PR TITLE
Improve invitation and profile flow

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,9 +67,10 @@ class ApplicationController < ActionController::Base
   end
 
   def validate_user_profile!
-    return if !current_user.has_student_granted_organizations? || current_user.profile_completed?
-    flash.notice = I18n.t :please_fill_profile_data
-    redirect_to user_path
+    unless current_user.profile_completed?
+      flash.notice = I18n.t :please_fill_profile_data
+      redirect_to user_path
+    end
   end
 
   def set_locale!

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -2,6 +2,9 @@ class InvitationsController < ApplicationController
   before_action :authenticate!
   before_action :set_invitation!
 
+  skip_before_action :validate_user_profile!
+  skip_before_action :authorize_if_private!
+
   def show
     redirect_to_organization! if current_user.student_of? @invitation.course
   end
@@ -11,10 +14,6 @@ class InvitationsController < ApplicationController
     current_user.update! user_params
     current_user.notify!
     redirect_to_organization!
-  end
-
-  def authorize_if_private!
-    # This controller must never be authenticated
   end
 
   private

--- a/app/views/invitations/_invitation_form.html.erb
+++ b/app/views/invitations/_invitation_form.html.erb
@@ -19,14 +19,16 @@
       </div>
     </div>
   </div>
+  <% if @organization.terms_of_service.present? %>
+    <div>
+      <h3><%= t :terms_and_conditions %></h3>
+      <pre class="terms-of-service"><%= simple_format @organization.terms_of_service %></pre>
+      <div>
+        <input id="accept_terms" type="checkbox"> <span><%= t :accept_terms %></span>
+      </div>
+    </div>
+  <% end %>
   <div>
-    <h3><%= t :terms_and_conditions %></h3>
-    <pre class="terms-of-service"><%= simple_format @organization.terms_of_service %></pre>
-    <div class="col-md-10">
-      <input id="accept_terms" type="checkbox"> <span><%= t :accept_terms %></span>
-    </div>
-    <div class="col-md-1">
-      <%= f.submit t(:confirm), id: 'confirm_data', class: 'btn btn-success', disabled: true %>
-    </div>
+    <%= f.submit t(:confirm), id: 'confirm_data', class: 'btn btn-success', disabled: @organization.terms_of_service.present? %>
   </div>
 <% end %>

--- a/app/views/invitations/_invitation_form.html.erb
+++ b/app/views/invitations/_invitation_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_for current_user, method: 'post', url: {action: 'join'} do |f| %>
+  <div class="tab-content">
+    <div role="tabpanel" class="tab-pane active" id="info">
+      <div class="row mu-tab-body">
+        <div class="col-md-12">
+          <fieldset class="form-group">
+            <div><%= f.label(t :first_name) %></div>
+            <div><%= f.text_field :first_name, class: 'form-control' %></div>
+          </fieldset>
+          <fieldset class="form-group">
+            <div><%= f.label(t :last_name) %></div>
+            <div><%= f.text_field :last_name, class: 'form-control' %></div>
+          </fieldset>
+          <fieldset class="form-group">
+            <div><%= f.label(t :email) %></div>
+            <div><%= f.text_field :email, class: 'form-control' %></div>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <h3><%= t :terms_and_conditions %></h3>
+    <pre class="terms-of-service"><%= simple_format @organization.terms_of_service %></pre>
+    <div class="col-md-10">
+      <input id="accept_terms" type="checkbox"> <span><%= t :accept_terms %></span>
+    </div>
+    <div class="col-md-1">
+      <%= f.submit t(:confirm), id: 'confirm_data', class: 'btn btn-success', disabled: true %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/invitations/_invitation_form.html.erb
+++ b/app/views/invitations/_invitation_form.html.erb
@@ -3,18 +3,7 @@
     <div role="tabpanel" class="tab-pane active" id="info">
       <div class="row mu-tab-body">
         <div class="col-md-12">
-          <fieldset class="form-group">
-            <div><%= f.label(t :first_name) %></div>
-            <div><%= f.text_field :first_name, class: 'form-control' %></div>
-          </fieldset>
-          <fieldset class="form-group">
-            <div><%= f.label(t :last_name) %></div>
-            <div><%= f.text_field :last_name, class: 'form-control' %></div>
-          </fieldset>
-          <fieldset class="form-group">
-            <div><%= f.label(t :email) %></div>
-            <div><%= f.text_field :email, class: 'form-control' %></div>
-          </fieldset>
+          <%= render partial: 'users/profile_fields', locals: {form: f} %>
         </div>
       </div>
     </div>

--- a/app/views/invitations/show.html.erb
+++ b/app/views/invitations/show.html.erb
@@ -7,45 +7,7 @@
 <div>
   <span><%= t :please_validate %></span>
 </div>
-
-<%= form_for current_user, method: 'post', url: {action: 'join'} do |f| %>
-
-    <div class="tab-content">
-      <div role="tabpanel" class="tab-pane active" id="info">
-        <div class="row mu-tab-body">
-          <div class="col-md-12">
-            <fieldset class="form-group"> 
-              <div><%= f.label(t :first_name) %></div>
-              <div><%= f.text_field :first_name, class: 'form-control' %></div>
-            </fieldset>
-            <fieldset class="form-group"> 
-              <div><%= f.label(t :last_name) %></div>
-              <div><%= f.text_field :last_name, class: 'form-control' %></div>
-            </fieldset>
-            <fieldset class="form-group"> 
-              <div><%= f.label(t :email) %></div>
-              <div><%= f.text_field :email, class: 'form-control' %></div>
-            </fieldset>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div>
-      <h3><%= t :terms_and_conditions %></h3>
-
-      <pre class="terms-of-service"><%= simple_format @organization.terms_of_service %></pre>
-
-      <div class="col-md-10">
-        <input id="accept_terms" type="checkbox"> <span><%= t :accept_terms %></span>
-      </div>
-      <div class="col-md-1">
-        <%= f.submit t(:confirm), id: 'confirm_data', class: 'btn btn-success', disabled: true %>
-      </div>
-    </div>
-
-<% end %>
-
+<%= render partial: 'invitation_form' %>
 <script>
   $('#accept_terms').click(function () {
     $("#confirm_data").prop('disabled', function (i, value) {

--- a/app/views/users/_profile_fields.html.erb
+++ b/app/views/users/_profile_fields.html.erb
@@ -1,10 +1,10 @@
 <fieldset class="form-group">
   <div><%= form.label(t :first_name) %></div>
-  <div><%= form.text_field :first_name, class: 'form-control' %></div>
+  <div><%= form.text_field :first_name, required: true, class: 'form-control' %></div>
 </fieldset>
 <fieldset class="form-group">
   <div><%= form.label(t :last_name) %></div>
-  <div><%= form.text_field :last_name, class: 'form-control' %></div>
+  <div><%= form.text_field :last_name, required: true, class: 'form-control' %></div>
 </fieldset>
 <fieldset class="form-group">
   <div><%= form.label(t :email) %></div>

--- a/app/views/users/_profile_fields.html.erb
+++ b/app/views/users/_profile_fields.html.erb
@@ -1,0 +1,12 @@
+<fieldset class="form-group">
+  <div><%= form.label(t :first_name) %></div>
+  <div><%= form.text_field :first_name, class: 'form-control' %></div>
+</fieldset>
+<fieldset class="form-group">
+  <div><%= form.label(t :last_name) %></div>
+  <div><%= form.text_field :last_name, class: 'form-control' %></div>
+</fieldset>
+<fieldset class="form-group">
+  <div><%= form.label(t :email) %></div>
+  <div><%= form.text_field :email, readonly: true, class: 'form-control' %></div>
+</fieldset>

--- a/app/views/users/_user_form.html.erb
+++ b/app/views/users/_user_form.html.erb
@@ -4,18 +4,7 @@
       <%= image_tag @user.image_url, size: '250x250', class: 'img-circle' %>
     </div>
     <div class="col-md-8">
-      <fieldset class="form-group">
-        <div><%= f.label(t :first_name) %></div>
-        <div><%= f.text_field :first_name, class: 'form-control' %></div>
-      </fieldset>
-      <fieldset class="form-group">
-        <div><%= f.label(t :last_name) %></div>
-        <div><%= f.text_field :last_name, class: 'form-control' %></div>
-      </fieldset>
-      <fieldset class="form-group">
-        <div><%= f.label(t :email) %></div>
-        <div><%= f.text_field :email, readonly: true, class: 'form-control' %></div>
-      </fieldset>
+      <%= render partial: 'profile_fields', locals: {form: f} %>
       <div><%= f.submit t(:save), class: 'btn btn-success btn-block' %></div>
     </div>
   </div>

--- a/spec/features/profile_flow_spec.rb
+++ b/spec/features/profile_flow_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 feature 'Standard Flow', organization_workspace: :test do
   let!(:user) { create(:user, uid: 'mumuki@test.com', first_name: nil) }
-  let!(:user2) { create(:user, uid: 'johndoe@test.com') }
   let(:haskell) { create(:haskell) }
   let!(:chapter) {
     create(:chapter, name: 'Functional Programming', lessons: [
@@ -27,30 +26,32 @@ feature 'Standard Flow', organization_workspace: :test do
   end
 
   before do
+    OmniAuth.config.mock_auth[:developer] =
+    OmniAuth::AuthHash.new provider: 'developer',
+                           uid: user.uid,
+                           credentials: {},
+                           info: {}
+  end
+
+  before do
     visit '/'
   end
 
   scenario 'redirect to /user if profile uncompleted and has access to organizations' do
-    OmniAuth.config.mock_auth[:developer] =
-      OmniAuth::AuthHash.new provider: 'developer',
-                             uid: 'mumuki@test.com',
-                             credentials: {},
-                             info: {}
-
     user.update! permissions: {student: 'test/*'}
     click_on 'Sign in'
     expect(page).to have_text('Please complete your profile data to continue!')
   end
 
   scenario 'do not redirect to /user if profile is complete' do
-    user2.update! permissions: {student: 'test/*'}
+    user.update! first_name: 'Mercedes', last_name: 'Sosa'
     click_on 'Sign in'
     expect(page).not_to have_text('Please complete your profile data to continue!')
   end
 
-  scenario 'do not redirect to /user if user do not have organizations' do
+  scenario 'does redirect to /user even if user does not have organizations' do
     click_on 'Sign in'
-    expect(page).not_to have_text('Please complete your profile data to continue!')
+    expect(page).to have_text('Please complete your profile data to continue!')
   end
 
   context 'logged in user' do


### PR DESCRIPTION
This PR addresses several problems with the profile and invitation flows: 

* :heavy_check_mark: Avoid duplication between user and invitation forms
* :heavy_check_mark:  Makes profile fields actually required in the client-side
* :heavy_check_mark:  Avoids asking for TOS when not present
* :heavy_check_mark:  Always ask to update profile, regardless the user has been invited or not.

To sum up, the new proposed goes as follow: 

1. If user is logged in and profile is not completed, she is redirected to `/organization/user` to complete profile
2. If user is invited, user is redirected to a confirmation form, where she is asked to confirm and/or complete her profile data. 