### PR TITLE
Chore refactor link to profile

### DIFF
--- a/app/helpers/menu_bar_helper.rb
+++ b/app/helpers/menu_bar_helper.rb
@@ -1,6 +1,7 @@
 module MenuBarHelper
   def menu_bar_links
     [
+      link_to_profile,
       link_to_classroom,
       link_to_bibliotheca,
       solve_discussions_link,

--- a/app/helpers/menu_bar_helper.rb
+++ b/app/helpers/menu_bar_helper.rb
@@ -9,7 +9,15 @@ module MenuBarHelper
   end
 
   def menu_bar_list_items
-    menu_bar_links.compact.map { |link| "<li>#{link}<li>" }.join.html_safe
+    menu_bar_links.compact.map { |link| list_item(link) }.join.html_safe
+  end
+
+  def list_item(link)
+    "<li>#{link}</li>"
+  end
+
+  def link_to_profile
+    list_item(menu_item 'user-o', :profile, user_path)
   end
 
   def link_to_classroom

--- a/app/helpers/menu_bar_helper.rb
+++ b/app/helpers/menu_bar_helper.rb
@@ -10,15 +10,15 @@ module MenuBarHelper
   end
 
   def menu_bar_list_items
-    menu_bar_links.compact.map { |link| list_item(link) }.join.html_safe
+    menu_bar_links.compact.map { |link| li_tag(link) }.join.html_safe
   end
 
-  def list_item(link)
-    "<li>#{link}</li>"
+  def li_tag(link)
+    content_tag :li, link
   end
 
   def link_to_profile
-    list_item(menu_item 'user-o', :profile, user_path)
+    li_tag menu_item('user-o', :profile, user_path)
   end
 
   def link_to_classroom

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,6 @@
               <%= profile_picture %>
             </span>
             <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="profileDropdown">
-              <%= link_to_profile %>
               <%= menu_bar_list_items %>
               <li class="divider"></li>
               <li><%= link_to(t(:sign_out), logout_path(origin: url_for), role: 'menuitem') %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,7 @@
               <%= profile_picture %>
             </span>
             <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="profileDropdown">
-              <li><%= link_to fixed_fa_icon('user-o', text: t(:profile)), user_path, role: 'menuitem' %></li>
+              <%= link_to_profile %>
               <%= menu_bar_list_items %>
               <li class="divider"></li>
               <li><%= link_to(t(:sign_out), logout_path(origin: url_for), role: 'menuitem') %></li>

--- a/spec/features/menu_bar_spec.rb
+++ b/spec/features/menu_bar_spec.rb
@@ -46,28 +46,31 @@ feature 'menu bar' do
     let(:janitor) { create(:user, permissions: {student: 'private/*', janitor: 'private/*'}) }
     let(:owner) { create(:user, permissions: {student: 'private/*', owner: 'private/*'}) }
 
-    scenario 'visitor should not see any app' do
+    scenario 'visitor should only see profile' do
       set_current_user! visitor
 
       visit '/'
+      expect(page).to have_text('Profile')
       expect(page).not_to have_text('Classroom')
       expect(page).not_to have_text('Bibliotheca')
     end
 
-    scenario 'teacher should see classroom' do
+    scenario 'teacher should see profile and classroom' do
       set_current_user! teacher
 
       visit '/'
 
+      expect(page).to have_text('Profile')
       expect(page).to have_text('Classroom')
       expect(page).not_to have_text('Bibliotheca')
     end
 
-    scenario 'writer should see bibliotheca' do
+    scenario 'writer should see profile and bibliotheca' do
       set_current_user! writer
 
       visit '/'
 
+      expect(page).to have_text('Profile')
       expect(page).not_to have_text('Classroom')
       expect(page).to have_text('Bibliotheca')
     end

--- a/spec/features/menu_bar_spec.rb
+++ b/spec/features/menu_bar_spec.rb
@@ -44,9 +44,19 @@ feature 'menu bar' do
     let(:teacher) { create(:user, permissions: {student: 'private/*', teacher: 'private/*'}) }
     let(:writer) { create(:user, permissions: {student: 'private/*', writer: 'private/*'}) }
     let(:janitor) { create(:user, permissions: {student: 'private/*', janitor: 'private/*'}) }
+    let(:admin) { create(:user, permissions: {student: 'private/*', admin: 'private/*'}) }
     let(:owner) { create(:user, permissions: {student: 'private/*', owner: 'private/*'}) }
 
     scenario 'visitor should only see profile' do
+      set_current_user! visitor
+
+      visit '/'
+      expect(page).to have_text('Profile')
+      expect(page).not_to have_text('Classroom')
+      expect(page).not_to have_text('Bibliotheca')
+    end
+
+    scenario 'student should only see profile' do
       set_current_user! visitor
 
       visit '/'
@@ -72,6 +82,36 @@ feature 'menu bar' do
 
       expect(page).to have_text('Profile')
       expect(page).not_to have_text('Classroom')
+      expect(page).to have_text('Bibliotheca')
+    end
+
+    scenario 'janitor should see profile and classroom' do
+      set_current_user! janitor
+
+      visit '/'
+
+      expect(page).to have_text('Profile')
+      expect(page).to have_text('Classroom')
+      expect(page).not_to have_text('Bibliotheca')
+    end
+
+    scenario 'admin should see profile, classroom and bibliotheca' do
+      set_current_user! admin
+
+      visit '/'
+
+      expect(page).to have_text('Profile')
+      expect(page).to have_text('Classroom')
+      expect(page).to have_text('Bibliotheca')
+    end
+
+    scenario 'owner should see profile, classroom and bibliotheca' do
+      set_current_user! owner
+
+      visit '/'
+
+      expect(page).to have_text('Profile')
+      expect(page).to have_text('Classroom')
       expect(page).to have_text('Bibliotheca')
     end
   end

--- a/spec/features/menu_bar_spec.rb
+++ b/spec/features/menu_bar_spec.rb
@@ -9,11 +9,32 @@ feature 'menu bar' do
   before { private_organization.switch! }
 
   context 'anonymous user' do
-    scenario 'should not see any app' do
-      visit '/'
+    context 'on organization without permissions' do
+      scenario 'should not see menu bar' do
+        OmniAuth.config.test_mode = false
 
-      expect(page).not_to have_text('Classroom')
-      expect(page).not_to have_text('Bibliotheca')
+        visit '/'
+
+        expect(page).not_to have_text('Profile')
+        expect(page).not_to have_text('Classroom')
+        expect(page).not_to have_text('Bibliotheca')
+      end
+    end
+
+    context 'on organization with permissions' do
+      let(:public_organization) { create(:public_organization, book: book) }
+      before { set_subdomain_host! public_organization.name }
+      before { public_organization.switch! }
+
+      scenario 'should not see menu bar' do
+        OmniAuth.config.test_mode = false
+
+        visit '/'
+
+        expect(page).not_to have_text('Profile')
+        expect(page).not_to have_text('Classroom')
+        expect(page).not_to have_text('Bibliotheca')
+      end
     end
   end
 

--- a/spec/features/menu_bar_spec.rb
+++ b/spec/features/menu_bar_spec.rb
@@ -9,10 +9,10 @@ feature 'menu bar' do
   before { private_organization.switch! }
 
   context 'anonymous user' do
+    before { set_automatic_login! false }
+
     context 'on organization without permissions' do
       scenario 'should not see menu bar' do
-        OmniAuth.config.test_mode = false
-
         visit '/'
 
         expect(page).not_to have_text('Profile')
@@ -27,8 +27,6 @@ feature 'menu bar' do
       before { public_organization.switch! }
 
       scenario 'should not see menu bar' do
-        OmniAuth.config.test_mode = false
-
         visit '/'
 
         expect(page).not_to have_text('Profile')

--- a/spec/features/profile_flow_spec.rb
+++ b/spec/features/profile_flow_spec.rb
@@ -51,7 +51,7 @@ feature 'Profile Flow', organization_workspace: :test do
 
     scenario 'is able to log out' do
       click_on 'Sign in'
-      OmniAuth.config.test_mode = false
+      set_automatic_login! false
 
       click_on 'Sign Out'
       expect(page).to_not have_text('Please complete your profile data to continue!')

--- a/spec/login_helper.rb
+++ b/spec/login_helper.rb
@@ -8,7 +8,6 @@ Mumukit::Login.configure do |config|
   config.mucookie_sign_salt = 'mucookie test sign salt'
 end
 
-OmniAuth.config.test_mode = true
 OmniAuth.config.mock_auth[:developer] =
   OmniAuth::AuthHash.new provider: 'developer',
                          uid: 'johndoe@test.com',
@@ -17,4 +16,8 @@ OmniAuth.config.mock_auth[:developer] =
 
 def set_current_user!(user)
   allow_any_instance_of(ApplicationController).to receive(:current_user_uid).and_return(user.uid)
+end
+
+def set_automatic_login!(test_mode)
+  OmniAuth.config.test_mode = test_mode
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,8 @@ require_relative './evaluation_helper'
 require_relative './login_helper'
 
 RSpec.configure do |config|
+  config.before(:each) { set_automatic_login! true }
+
   config.before(:each) { I18n.locale = :en }
 
   config.before(:each) do


### PR DESCRIPTION
This branch refactors the link to profile on the main layout dropdown. It now stands in place with all the other menu bar list items, instead of being in its own, and makes it easier - hopefully - to hide it if needed, for example if lack of permissions for the user would redirect them to a 403.

I have tweaked the tests a little as well, and added a couple more.