### PR TITLE
Changing gone explanation

### DIFF
--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -86,7 +86,7 @@ en:
   forbidden_explanation: You are not allowed to see this content.
   gender: Gender
   go_to: 'Go to %{organization}'
-  gone_explanation: This exam is no longer available.
+  gone_explanation: This content is no longer available.
   guide: Guide
   guide_created: Guide created successfully
   guide_finished: You completed %{guide}!

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -94,7 +94,7 @@ es:
   forbidden_explanation: Es decir que no tenés autorización para ver este contenido. <br> ¿Puede que hayas ingresado con una cuenta incorrecta?
   gender: Género
   go_to: 'Ir a %{organization}'
-  gone_explanation: ¡Ups! Esto es lo que se conoce como %{error}, es decir que ya no podés ver este examen.
+  gone_explanation: ¡Ups! Esto es lo que se conoce como %{error}, es decir que ya no podés ver este contenido.
   guide: Lección
   guide_created: Guía creada exitosamente
   guide_finished: ¡Terminaste %{guide}!

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -91,7 +91,7 @@ pt:
   gender: Gênero
   get_messages: Ver mensagens
   go_to: Vá para %{organization}
-  gone_explanation: Opa! Isto é o que é conhecido como %{error}, ou seja, você não pode mais ver esse exame.
+  gone_explanation: Opa! Isto é o que é conhecido como %{error}, ou seja, você não pode mais ver esse conteúdo.
   guide: Lição
   guide_created: Guia criado com sucesso
   guide_finished: Você terminou %{guide}!


### PR DESCRIPTION
Currently, you can get 410 errors not only on an exam context, but also in an invitation context - which is fine. This leads to weird situations when you enter an expired link  and get a message about an expired exam. 

