### PR TITLE
Organization in breadcrumb 

### DIFF
--- a/app/helpers/breadcrumbs_helper.rb
+++ b/app/helpers/breadcrumbs_helper.rb
@@ -4,13 +4,9 @@ module BreadcrumbsHelper
     breadcrumbs0(e.navigable_name, e, extra, 'last')
   end
 
-  def name_me(link, brand='')
-    "<li class='mu-breadcrumb-list-item #{brand}'>#{link}</li>".html_safe
-  end
-
   def home_breadcrumb
-    link = link_to "<i class='da da-mumuki' aria-label=#{t(:home)}></i>".html_safe, mu_home_path
-    name_me link, 'brand'
+    home = "<i class='da da-mumuki' aria-label=#{t(:home)}></i>".html_safe
+    breadcrumb_list_item_with_link home, mu_home_path, 'brand'
   end
 
   def mu_home_path
@@ -18,32 +14,32 @@ module BreadcrumbsHelper
   end
 
   def organization_breadcrumb
-    if Organization.current.breadcrumb_image_url.present?
-      organization_image_breadcrumb
-    else
-      organization_text_breadcrumb
-    end
+    Organization.current.breadcrumb_image_url.present? ? organization_image_breadcrumb : organization_text_breadcrumb
   end
 
   def organization_image_breadcrumb
-    link = link_to image_tag(Organization.current.breadcrumb_image_url, class: "da mu-breadcrumb-img"), root_path
-    name_me link
+    image = image_tag(Organization.current.breadcrumb_image_url, class: "da mu-breadcrumb-img")
+    breadcrumb_list_item_with_link image, root_path
   end
 
   def organization_text_breadcrumb
-    name_me(link_to organization_name, root_path)
+    breadcrumb_list_item_with_link organization_name, root_path
   end
 
   def organization_name
     Organization.current.name
   end
 
-  def breadcrumb_item_class(last)
-    "class='mu-breadcrumb-list-item #{last}'"
+  def breadcrumb_item_class(clazz)
+    "class='mu-breadcrumb-list-item #{clazz}'"
   end
 
-  def breadcrumb_list_item(last, item)
-    "<li #{breadcrumb_item_class(last)}>#{h item}</li>".html_safe
+  def breadcrumb_list_item(clazz, item)
+    "<li #{breadcrumb_item_class(clazz)}>#{h item}</li>".html_safe
+  end
+
+  def breadcrumb_list_item_with_link(item, where_to, brand='')
+    breadcrumb_list_item brand, (link_to item, where_to)
   end
 
   private

--- a/app/helpers/breadcrumbs_helper.rb
+++ b/app/helpers/breadcrumbs_helper.rb
@@ -20,12 +20,12 @@ module BreadcrumbsHelper
     "class='mu-breadcrumb-list-item #{clazz}'"
   end
 
-  def breadcrumb_list_item(clazz, item)
+  def breadcrumb_list_item(item, clazz='')
     "<li #{breadcrumb_item_class(clazz)}>#{h item}</li>".html_safe
   end
 
   def breadcrumb_list_item_with_link(item, where_to, brand='')
-    breadcrumb_list_item brand, (link_to item, where_to)
+    breadcrumb_list_item (link_to item, where_to), brand
   end
 
   private
@@ -35,12 +35,12 @@ module BreadcrumbsHelper
   end
 
   def breadcrumbs0(base, e, extra, last)
-    return "#{breadcrumbs_for_linkable(e)} #{breadcrumb_list_item(last, extra)}".html_safe if extra
+    return "#{breadcrumbs_for_linkable(e)} #{breadcrumb_list_item(extra, last)}".html_safe if extra
 
     if e.navigation_end?
-      "#{home_and_organization_breadcrumbs(link_for_organization: true)} #{breadcrumb_list_item(last, base)}".html_safe
+      "#{home_and_organization_breadcrumbs(link_for_organization: true)} #{breadcrumb_list_item(base, last)}".html_safe
     else
-      "#{breadcrumbs_for_linkable(e.navigable_parent)} #{breadcrumb_list_item(last, base)}".html_safe
+      "#{breadcrumbs_for_linkable(e.navigable_parent)} #{breadcrumb_list_item(base, last)}".html_safe
     end
   end
 end

--- a/app/helpers/breadcrumbs_helper.rb
+++ b/app/helpers/breadcrumbs_helper.rb
@@ -3,8 +3,8 @@ module BreadcrumbsHelper
     breadcrumbs0(e.navigable_name, e, extra, 'last')
   end
 
-  def home_and_organization_breadcrumbs
-    "#{home_breadcrumb} #{organization_breadcrumb}".html_safe
+  def home_and_organization_breadcrumbs(link_for_organization: false)
+    "#{home_breadcrumb} #{organization_breadcrumb link_for_organization}".html_safe
   end
 
   def home_breadcrumb
@@ -16,17 +16,21 @@ module BreadcrumbsHelper
     root_path
   end
 
-  def organization_breadcrumb
-    Organization.current.breadcrumb_image_url.present? ? organization_image_breadcrumb : organization_text_breadcrumb
+  def organization_breadcrumb(has_link)
+    Organization.current.breadcrumb_image_url.present? ? organization_image_breadcrumb(has_link) : organization_text_breadcrumb(has_link)
   end
 
-  def organization_image_breadcrumb
+  def organization_image_breadcrumb(has_link)
     image = image_tag(Organization.current.breadcrumb_image_url, class: "da mu-breadcrumb-img")
-    breadcrumb_list_item_with_link image, root_path
+    link_breadcrumb_if has_link, image
   end
 
-  def organization_text_breadcrumb
-    breadcrumb_list_item_with_link organization_name, root_path
+  def organization_text_breadcrumb(has_link)
+    link_breadcrumb_if has_link, organization_name
+  end
+
+  def link_breadcrumb_if(has_link, item)
+    has_link ? breadcrumb_list_item_with_link(item, root_path) : breadcrumb_list_item('', item)
   end
 
   def organization_name
@@ -55,7 +59,7 @@ module BreadcrumbsHelper
     return "#{breadcrumbs_for_linkable(e)} #{breadcrumb_list_item(last, extra)}".html_safe if extra
 
     if e.navigation_end?
-      "#{home_and_organization_breadcrumbs} #{breadcrumb_list_item(last, base)}".html_safe
+      "#{home_and_organization_breadcrumbs(link_for_organization: true)} #{breadcrumb_list_item(last, base)}".html_safe
     else
       "#{breadcrumbs_for_linkable(e.navigable_parent)} #{breadcrumb_list_item(last, base)}".html_safe
     end

--- a/app/helpers/breadcrumbs_helper.rb
+++ b/app/helpers/breadcrumbs_helper.rb
@@ -1,7 +1,10 @@
 module BreadcrumbsHelper
-
   def breadcrumbs(e, extra=nil)
     breadcrumbs0(e.navigable_name, e, extra, 'last')
+  end
+
+  def home_and_organization_breadcrumbs
+    "#{home_breadcrumb} #{organization_breadcrumb}".html_safe
   end
 
   def home_breadcrumb
@@ -52,7 +55,7 @@ module BreadcrumbsHelper
     return "#{breadcrumbs_for_linkable(e)} #{breadcrumb_list_item(last, extra)}".html_safe if extra
 
     if e.navigation_end?
-      "#{home_breadcrumb} #{organization_breadcrumb} #{breadcrumb_list_item(last, base)}".html_safe
+      "#{home_and_organization_breadcrumbs} #{breadcrumb_list_item(last, base)}".html_safe
     else
       "#{breadcrumbs_for_linkable(e.navigable_parent)} #{breadcrumb_list_item(last, base)}".html_safe
     end

--- a/app/helpers/breadcrumbs_helper.rb
+++ b/app/helpers/breadcrumbs_helper.rb
@@ -16,12 +16,18 @@ module BreadcrumbsHelper
   def organization_breadcrumb
     if Organization.current.breadcrumb_image_url.present?
       organization_image_breadcrumb
+    else
+      organization_text_breadcrumb
     end
   end
 
   def organization_image_breadcrumb
     link = link_to image_tag(Organization.current.breadcrumb_image_url, class: "da mu-breadcrumb-img"), root_path
     name_me link
+  end
+
+  def organization_text_breadcrumb
+    home_breadcrumb(link_to Organization.current.name, root_path)
   end
 
   def breadcrumb_item_class(last)

--- a/app/helpers/breadcrumbs_helper.rb
+++ b/app/helpers/breadcrumbs_helper.rb
@@ -9,8 +9,12 @@ module BreadcrumbsHelper
   end
 
   def home_breadcrumb
-    link = link_to "<i class='da da-mumuki' aria-label=#{t(:home)}></i>".html_safe, root_path
+    link = link_to "<i class='da da-mumuki' aria-label=#{t(:home)}></i>".html_safe, mu_home_path
     name_me link, 'brand'
+  end
+
+  def mu_home_path
+    root_path
   end
 
   def organization_breadcrumb

--- a/app/helpers/breadcrumbs_helper.rb
+++ b/app/helpers/breadcrumbs_helper.rb
@@ -16,27 +16,6 @@ module BreadcrumbsHelper
     root_path
   end
 
-  def organization_breadcrumb(has_link)
-    Organization.current.breadcrumb_image_url.present? ? organization_image_breadcrumb(has_link) : organization_text_breadcrumb(has_link)
-  end
-
-  def organization_image_breadcrumb(has_link)
-    image = image_tag(Organization.current.breadcrumb_image_url, class: "da mu-breadcrumb-img")
-    link_breadcrumb_if has_link, image
-  end
-
-  def organization_text_breadcrumb(has_link)
-    link_breadcrumb_if has_link, organization_name
-  end
-
-  def link_breadcrumb_if(has_link, item)
-    has_link ? breadcrumb_list_item_with_link(item, root_path) : breadcrumb_list_item('', item)
-  end
-
-  def organization_name
-    Organization.current.name
-  end
-
   def breadcrumb_item_class(clazz)
     "class='mu-breadcrumb-list-item #{clazz}'"
   end

--- a/app/helpers/breadcrumbs_helper.rb
+++ b/app/helpers/breadcrumbs_helper.rb
@@ -4,7 +4,7 @@ module BreadcrumbsHelper
   end
 
   def home_and_organization_breadcrumbs(link_for_organization: false)
-    "#{home_breadcrumb} #{organization_breadcrumb link_for_organization}".html_safe
+    "#{home_breadcrumb} #{organization_breadcrumb has_link: link_for_organization}".html_safe
   end
 
   def home_breadcrumb

--- a/app/helpers/breadcrumbs_helper.rb
+++ b/app/helpers/breadcrumbs_helper.rb
@@ -4,16 +4,24 @@ module BreadcrumbsHelper
     breadcrumbs0(e.navigable_name, e, extra, 'last')
   end
 
-  def home_breadcrumb
-    "<li class='mu-breadcrumb-list-item brand '>#{breadcrumb_home_link}</li>".html_safe
+  def name_me(link, brand='')
+    "<li class='mu-breadcrumb-list-item #{brand}'>#{link}</li>".html_safe
   end
 
-  def breadcrumb_home_link
+  def home_breadcrumb
+    link = link_to "<i class='da da-mumuki' aria-label=#{t(:home)}></i>".html_safe, root_path
+    name_me link, 'brand'
+  end
+
+  def organization_breadcrumb
     if Organization.current.breadcrumb_image_url.present?
-      link_to image_tag(Organization.current.breadcrumb_image_url, class: "da mu-breadcrumb-img"), root_path
-    else
-      link_to "<i class='da da-mumuki' aria-label=#{t(:home)}></i>".html_safe, root_path
+      organization_image_breadcrumb
     end
+  end
+
+  def organization_image_breadcrumb
+    link = link_to image_tag(Organization.current.breadcrumb_image_url, class: "da mu-breadcrumb-img"), root_path
+    name_me link
   end
 
   def breadcrumb_item_class(last)
@@ -34,7 +42,7 @@ module BreadcrumbsHelper
     return "#{breadcrumbs_for_linkable(e)} #{breadcrumb_list_item(last, extra)}".html_safe if extra
 
     if e.navigation_end?
-      "#{home_breadcrumb} #{breadcrumb_list_item(last, base)}".html_safe
+      "#{home_breadcrumb} #{organization_breadcrumb} #{breadcrumb_list_item(last, base)}".html_safe
     else
       "#{breadcrumbs_for_linkable(e.navigable_parent)} #{breadcrumb_list_item(last, base)}".html_safe
     end

--- a/app/helpers/breadcrumbs_helper.rb
+++ b/app/helpers/breadcrumbs_helper.rb
@@ -3,13 +3,13 @@ module BreadcrumbsHelper
     breadcrumbs0(e.navigable_name, e, extra, 'last')
   end
 
-  def home_and_organization_breadcrumbs(link_for_organization: false)
-    "#{home_breadcrumb} #{organization_breadcrumb has_link: link_for_organization}".html_safe
+  def header_breadcrumbs(link_for_organization: true)
+    "#{home_breadcrumb} #{organization_breadcrumb(has_link: link_for_organization)}".html_safe
   end
 
   def home_breadcrumb
     home = "<i class='da da-mumuki' aria-label=#{t(:home)}></i>".html_safe
-    breadcrumb_list_item_with_link home, mu_home_path, 'brand'
+    breadcrumb_item_for_linkable home, mu_home_path, 'brand'
   end
 
   def mu_home_path
@@ -24,8 +24,8 @@ module BreadcrumbsHelper
     "<li #{breadcrumb_item_class(clazz)}>#{h item}</li>".html_safe
   end
 
-  def breadcrumb_list_item_with_link(item, where_to, brand='')
-    breadcrumb_list_item (link_to item, where_to), brand
+  def breadcrumb_item_for_linkable(e, link_path, clazz='')
+    breadcrumb_list_item link_to(e, link_path), clazz
   end
 
   private
@@ -38,7 +38,7 @@ module BreadcrumbsHelper
     return "#{breadcrumbs_for_linkable(e)} #{breadcrumb_list_item(extra, last)}".html_safe if extra
 
     if e.navigation_end?
-      "#{home_and_organization_breadcrumbs(link_for_organization: true)} #{breadcrumb_list_item(base, last)}".html_safe
+      "#{header_breadcrumbs} #{breadcrumb_list_item(base, last)}".html_safe
     else
       "#{breadcrumbs_for_linkable(e.navigable_parent)} #{breadcrumb_list_item(base, last)}".html_safe
     end

--- a/app/helpers/breadcrumbs_helper.rb
+++ b/app/helpers/breadcrumbs_helper.rb
@@ -31,7 +31,11 @@ module BreadcrumbsHelper
   end
 
   def organization_text_breadcrumb
-    home_breadcrumb(link_to Organization.current.name, root_path)
+    name_me(link_to organization_name, root_path)
+  end
+
+  def organization_name
+    Organization.current.name
   end
 
   def breadcrumb_item_class(last)

--- a/app/helpers/breadcrumbs_organization_helper.rb
+++ b/app/helpers/breadcrumbs_organization_helper.rb
@@ -15,7 +15,7 @@ module BreadcrumbsOrganizationHelper
   end
 
   def link_breadcrumb_if(has_link, item)
-    has_link ? breadcrumb_list_item_with_link(item, root_path) : breadcrumb_list_item('', item)
+    has_link ? breadcrumb_list_item_with_link(item, root_path) : breadcrumb_list_item(item)
   end
 
   def organization_name

--- a/app/helpers/breadcrumbs_organization_helper.rb
+++ b/app/helpers/breadcrumbs_organization_helper.rb
@@ -1,24 +1,23 @@
 module BreadcrumbsOrganizationHelper
-  def organization_breadcrumb(has_link)
-    Organization.current.breadcrumb_image_url.present? ? image_breadcrumb(has_link) : text_breadcrumb(has_link)
+  def organization_breadcrumb(has_link: false)
+    link_breadcrumb_if(has_link, image_or_text_breadcrumb)
   end
 
   private
 
-  def image_breadcrumb(has_link)
-    image = image_tag Organization.current.breadcrumb_image_url, class: "da mu-breadcrumb-img"
-    link_breadcrumb_if has_link, image
+  def image_or_text_breadcrumb
+    Organization.current.breadcrumb_image_url.present? ? image_breadcrumb : text_breadcrumb
   end
 
-  def text_breadcrumb(has_link)
-    link_breadcrumb_if has_link, organization_name
+  def image_breadcrumb
+    image_tag Organization.current.breadcrumb_image_url, class: "da mu-breadcrumb-img"
+  end
+
+  def text_breadcrumb
+    Organization.current.name
   end
 
   def link_breadcrumb_if(has_link, item)
     has_link ? breadcrumb_list_item_with_link(item, root_path) : breadcrumb_list_item(item)
-  end
-
-  def organization_name
-    Organization.current.name
   end
 end

--- a/app/helpers/breadcrumbs_organization_helper.rb
+++ b/app/helpers/breadcrumbs_organization_helper.rb
@@ -1,0 +1,24 @@
+module BreadcrumbsOrganizationHelper
+  def organization_breadcrumb(has_link)
+    Organization.current.breadcrumb_image_url.present? ? image_breadcrumb(has_link) : text_breadcrumb(has_link)
+  end
+
+  private
+
+  def image_breadcrumb(has_link)
+    image = image_tag Organization.current.breadcrumb_image_url, class: "da mu-breadcrumb-img"
+    link_breadcrumb_if has_link, image
+  end
+
+  def text_breadcrumb(has_link)
+    link_breadcrumb_if has_link, organization_name
+  end
+
+  def link_breadcrumb_if(has_link, item)
+    has_link ? breadcrumb_list_item_with_link(item, root_path) : breadcrumb_list_item('', item)
+  end
+
+  def organization_name
+    Organization.current.name
+  end
+end

--- a/app/helpers/organization_breadcrumbs_helper.rb
+++ b/app/helpers/organization_breadcrumbs_helper.rb
@@ -1,4 +1,4 @@
-module BreadcrumbsOrganizationHelper
+module OrganizationBreadcrumbsHelper
   def organization_breadcrumb(has_link: false)
     link_breadcrumb_if(has_link, image_or_text_breadcrumb)
   end

--- a/app/helpers/organization_breadcrumbs_helper.rb
+++ b/app/helpers/organization_breadcrumbs_helper.rb
@@ -1,23 +1,24 @@
 module OrganizationBreadcrumbsHelper
-  def organization_breadcrumb(has_link: false)
-    link_breadcrumb_if(has_link, image_or_text_breadcrumb)
+  def organization_breadcrumb(has_link: true)
+    clazz = 'last' unless has_link
+    breadcrumb_item_for_linkable(organization_breadcrumb_item_content, root_path, clazz)
   end
 
   private
 
-  def image_or_text_breadcrumb
-    Organization.current.breadcrumb_image_url.present? ? image_breadcrumb : text_breadcrumb
+  def organization_breadcrumb_item_content(organization=Organization.current)
+    if organization.breadcrumb_image_url.present?
+      breadcrumb_image_for organization
+    else
+      breadcrumb_text_for organization
+    end
   end
 
-  def image_breadcrumb
-    image_tag Organization.current.breadcrumb_image_url, class: "da mu-breadcrumb-img"
+  def breadcrumb_image_for(organization)
+    image_tag organization.breadcrumb_image_url, class: "da mu-breadcrumb-img"
   end
 
-  def text_breadcrumb
-    Organization.current.name
-  end
-
-  def link_breadcrumb_if(has_link, item)
-    has_link ? breadcrumb_list_item_with_link(item, root_path) : breadcrumb_list_item(item)
+  def breadcrumb_text_for(organization)
+    organization.name
   end
 end

--- a/app/views/book/show.html.erb
+++ b/app/views/book/show.html.erb
@@ -1,3 +1,7 @@
+<%= content_for :breadcrumbs do %>
+  <%= home_and_organization_breadcrumbs %>
+<% end %>
+
 <div class="col-md-offset-2 col-md-8">
   <div class="book-header <%= current_user? ? '' : 'logged' %>">
     <h1>ム mumuki<%= Organization.current.title_suffix %></h1>

--- a/app/views/book/show.html.erb
+++ b/app/views/book/show.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :breadcrumbs do %>
-  <%= home_and_organization_breadcrumbs %>
+  <%= header_breadcrumbs(link_for_organization: false) %>
 <% end %>
 
 <div class="col-md-offset-2 col-md-8">

--- a/spec/helpers/breadcrumbs_helper_spec.rb
+++ b/spec/helpers/breadcrumbs_helper_spec.rb
@@ -20,7 +20,7 @@ describe BreadcrumbsHelper, organization_workspace: :test do
   context 'exercise' do
     let(:breadcrumb) { breadcrumbs(exercise) }
 
-    context 'exercise in complement' do
+    context 'in complement' do
       let!(:complement) { create(:complement, name: 'my guide', exercises: [
           create(:exercise, name: 'my exercise')
       ]) }
@@ -28,65 +28,76 @@ describe BreadcrumbsHelper, organization_workspace: :test do
 
       before { reindex_current_organization! }
 
-      it { expect(breadcrumb).to include('da da-mumuki') }
-      it { expect(breadcrumb).to include('test') }
-      it { expect(breadcrumb).to include('my exercise') }
-      it { expect(breadcrumb).to include('my guide') }
-      it { expect(breadcrumb).to be_html_safe }
+      it 'breadcrumb goes mumuki / test organization / guide / exercise' do
+        expect(breadcrumb).to include('da da-mumuki')
+        expect(breadcrumb).to include('test')
+        expect(breadcrumb).to include('my guide')
+        expect(breadcrumb).to include('my exercise')
+        expect(breadcrumb).to be_html_safe
+      end
 
-      it { expect(breadcrumb).to include home_breadcrumb_with_link }
-      it { expect(breadcrumb).to include organization_breadcrumb_with_link }
-      it { expect(breadcrumb).to include "<a href=\"/complements/#{complement.id}-my-guide\">my guide</a>" }
-      it { expect(breadcrumb).to include "<li class='mu-breadcrumb-list-item last'>1. my exercise</li>" }
+      it 'mumuki, organization and guide have links but exercise does not' do
+        expect(breadcrumb).to include home_breadcrumb_with_link
+        expect(breadcrumb).to include organization_breadcrumb_with_link
+        expect(breadcrumb).to include "<a href=\"/complements/#{complement.id}-my-guide\">my guide</a>"
+        expect(breadcrumb).to include "<li class='mu-breadcrumb-list-item last'>1. my exercise</li>"
+      end
     end
 
-    context 'exercise in chapter' do
+    context 'in chapter' do
       let!(:chapter) { create(:chapter, name: 'my chapter', lessons: [lesson]) }
       let(:lesson) { create(:lesson, name: 'my lesson', exercises: [exercise]) }
       let(:exercise) { create(:exercise, name: 'my exercise') }
 
       before { reindex_current_organization! }
 
-      it { expect(breadcrumb).to include('da da-mumuki') }
-      it { expect(breadcrumb).to include('test') }
-      it { expect(breadcrumb).to include('my exercise') }
-      it { expect(breadcrumb).to include('my lesson') }
-      it { expect(breadcrumb).to include('my chapter') }
-      it { expect(breadcrumb).to be_html_safe }
+      it 'breadcrumb goes mumuki / test organization / chapter / lesson / exercise' do
+        expect(breadcrumb).to include('da da-mumuki')
+        expect(breadcrumb).to include('test')
+        expect(breadcrumb).to include('my chapter')
+        expect(breadcrumb).to include('my lesson')
+        expect(breadcrumb).to include('my exercise')
+        expect(breadcrumb).to be_html_safe
+      end
 
-      it { expect(breadcrumb).to include home_breadcrumb_with_link }
-      it { expect(breadcrumb).to include organization_breadcrumb_with_link }
-      it { expect(breadcrumb).to include "<a href=\"/chapters/#{chapter.id}-my-chapter\">my chapter</a>" }
-      it { expect(breadcrumb).to include "<a href=\"/lessons/#{lesson.id}-my-chapter-my-lesson\">1. my lesson</a>" }
-      it { expect(breadcrumb).to include "<li class='mu-breadcrumb-list-item last'>1. my exercise</li>" }
+      it 'mumuki, organization, chapter and lesson have links but exercise does not' do
+        expect(breadcrumb).to include home_breadcrumb_with_link
+        expect(breadcrumb).to include organization_breadcrumb_with_link
+        expect(breadcrumb).to include "<a href=\"/chapters/#{chapter.id}-my-chapter\">my chapter</a>"
+        expect(breadcrumb).to include "<a href=\"/lessons/#{lesson.id}-my-chapter-my-lesson\">1. my lesson</a>"
+        expect(breadcrumb).to include "<li class='mu-breadcrumb-list-item last'>1. my exercise</li>"
+      end
     end
   end
 
   context 'book' do
+    let(:breadcrumb) { home_and_organization_breadcrumbs }
+
     describe 'in organization with text breadcrumb' do
-      let(:breadcrumb) { home_and_organization_breadcrumbs }
+      it 'breadcrumb goes mumuki / test organization' do
+        expect(breadcrumb).to include('da da-mumuki')
+        expect(breadcrumb).to include('test')
+      end
 
-      it { expect(breadcrumb).to include('da da-mumuki') }
-      it { expect(breadcrumb).to include('test') }
-
-      it { expect(breadcrumb).to include home_breadcrumb_with_link }
-      it { expect(breadcrumb).to_not include organization_breadcrumb_with_link }
+      it 'mumuki has link but organization does not' do
+        expect(breadcrumb).to include home_breadcrumb_with_link
+        expect(breadcrumb).to_not include organization_breadcrumb_with_link
+      end
     end
 
     describe 'in organization with image breadcrumb' do
-      let(:breadcrumb) { home_and_organization_breadcrumbs }
+      before { Organization.current.profile = Mumuki::Domain::Organization::Profile.new({breadcrumb_image_url: "organization.jpg"}) }
 
-      let(:organization) { create(:another_test_organization) }
-      before { organization.switch! }
+      it 'breadcrumb goes mumuki / organization logo' do
+        expect(breadcrumb).to include('da da-mumuki')
+        expect(breadcrumb).to_not include('test')
+      end
 
-      before { organization.profile = Mumuki::Domain::Organization::Profile.new({breadcrumb_image_url: "organization.jpg"}) }
-
-      it { expect(breadcrumb).to include('da da-mumuki') }
-      it { expect(breadcrumb).to_not include('test') }
-
-      it { expect(breadcrumb).to include home_breadcrumb_with_link }
-      it { expect(breadcrumb).to_not include organization_breadcrumb_with_link }
-      it { expect(breadcrumb).to include "<li class='mu-breadcrumb-list-item '><img class=\"da mu-breadcrumb-img\" src=\"/images/organization.jpg\"" }
+      it 'mumuki has link but organization logo does not' do
+        expect(breadcrumb).to include home_breadcrumb_with_link
+        expect(breadcrumb).to_not include organization_breadcrumb_with_link
+        expect(breadcrumb).to include "<li class='mu-breadcrumb-list-item '><img class=\"da mu-breadcrumb-img\" src=\"/images/organization.jpg\""
+      end
     end
   end
 end

--- a/spec/helpers/breadcrumbs_helper_spec.rb
+++ b/spec/helpers/breadcrumbs_helper_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe BreadcrumbsHelper, organization_workspace: :test do
 
   helper BreadcrumbsHelper
-  helper BreadcrumbsOrganizationHelper
+  helper OrganizationBreadcrumbsHelper
   helper LinksHelper
   helper ERB::Util
 

--- a/spec/helpers/breadcrumbs_helper_spec.rb
+++ b/spec/helpers/breadcrumbs_helper_spec.rb
@@ -9,6 +9,7 @@ describe BreadcrumbsHelper, organization_workspace: :test do
 
   let(:home_breadcrumb_with_link) { "<li class='mu-breadcrumb-list-item brand'><a href=\"#{root_path}\">" }
   let(:organization_breadcrumb_with_link) { "<li class='mu-breadcrumb-list-item '><a href=\"#{root_path}\">" }
+  let(:organization_breadcrumb_without_link) { "<li class='mu-breadcrumb-list-item last'><a href=\"#{root_path}\">" }
 
   context 'user' do
     let(:user) { create(:user, first_name: "Alfonsina", last_name: "Storni") }
@@ -71,7 +72,7 @@ describe BreadcrumbsHelper, organization_workspace: :test do
   end
 
   context 'book' do
-    let(:breadcrumb) { home_and_organization_breadcrumbs }
+    let(:breadcrumb) { header_breadcrumbs(link_for_organization: false) }
 
     describe 'in organization with text breadcrumb' do
       it 'breadcrumb goes mumuki / test organization' do
@@ -81,7 +82,7 @@ describe BreadcrumbsHelper, organization_workspace: :test do
 
       it 'mumuki has link but organization does not' do
         expect(breadcrumb).to include home_breadcrumb_with_link
-        expect(breadcrumb).to_not include organization_breadcrumb_with_link
+        expect(breadcrumb).to include organization_breadcrumb_without_link
       end
     end
 
@@ -95,8 +96,7 @@ describe BreadcrumbsHelper, organization_workspace: :test do
 
       it 'mumuki has link but organization logo does not' do
         expect(breadcrumb).to include home_breadcrumb_with_link
-        expect(breadcrumb).to_not include organization_breadcrumb_with_link
-        expect(breadcrumb).to include "<li class='mu-breadcrumb-list-item '><img class=\"da mu-breadcrumb-img\" src=\"/images/organization.jpg\""
+        expect(breadcrumb).to include organization_breadcrumb_without_link
       end
     end
   end

--- a/spec/helpers/breadcrumbs_helper_spec.rb
+++ b/spec/helpers/breadcrumbs_helper_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe BreadcrumbsHelper, organization_workspace: :test do
 
   helper BreadcrumbsHelper
+  helper BreadcrumbsOrganizationHelper
   helper LinksHelper
   helper ERB::Util
 

--- a/spec/helpers/breadcrumbs_helper_spec.rb
+++ b/spec/helpers/breadcrumbs_helper_spec.rb
@@ -7,6 +7,9 @@ describe BreadcrumbsHelper, organization_workspace: :test do
   helper LinksHelper
   helper ERB::Util
 
+  let(:home_breadcrumb_with_link) { "<li class='mu-breadcrumb-list-item brand'><a href=\"#{root_path}\">" }
+  let(:organization_breadcrumb_with_link) { "<li class='mu-breadcrumb-list-item '><a href=\"#{root_path}\">" }
+
   context 'user' do
     let(:user) { create(:user, first_name: "Alfonsina", last_name: "Storni") }
     let(:breadcrumb) { breadcrumbs(user) }
@@ -25,10 +28,14 @@ describe BreadcrumbsHelper, organization_workspace: :test do
 
       before { reindex_current_organization! }
 
+      it { expect(breadcrumb).to include('da da-mumuki') }
+      it { expect(breadcrumb).to include('test') }
       it { expect(breadcrumb).to include('my exercise') }
       it { expect(breadcrumb).to include('my guide') }
       it { expect(breadcrumb).to be_html_safe }
 
+      it { expect(breadcrumb).to include home_breadcrumb_with_link }
+      it { expect(breadcrumb).to include organization_breadcrumb_with_link }
       it { expect(breadcrumb).to include "<a href=\"/complements/#{complement.id}-my-guide\">my guide</a>" }
       it { expect(breadcrumb).to include "<li class='mu-breadcrumb-list-item last'>1. my exercise</li>" }
     end
@@ -40,14 +47,46 @@ describe BreadcrumbsHelper, organization_workspace: :test do
 
       before { reindex_current_organization! }
 
+      it { expect(breadcrumb).to include('da da-mumuki') }
+      it { expect(breadcrumb).to include('test') }
       it { expect(breadcrumb).to include('my exercise') }
       it { expect(breadcrumb).to include('my lesson') }
       it { expect(breadcrumb).to include('my chapter') }
       it { expect(breadcrumb).to be_html_safe }
 
+      it { expect(breadcrumb).to include home_breadcrumb_with_link }
+      it { expect(breadcrumb).to include organization_breadcrumb_with_link }
       it { expect(breadcrumb).to include "<a href=\"/chapters/#{chapter.id}-my-chapter\">my chapter</a>" }
       it { expect(breadcrumb).to include "<a href=\"/lessons/#{lesson.id}-my-chapter-my-lesson\">1. my lesson</a>" }
       it { expect(breadcrumb).to include "<li class='mu-breadcrumb-list-item last'>1. my exercise</li>" }
+    end
+  end
+
+  context 'book' do
+    describe 'in organization with text breadcrumb' do
+      let(:breadcrumb) { home_and_organization_breadcrumbs }
+
+      it { expect(breadcrumb).to include('da da-mumuki') }
+      it { expect(breadcrumb).to include('test') }
+
+      it { expect(breadcrumb).to include home_breadcrumb_with_link }
+      it { expect(breadcrumb).to_not include organization_breadcrumb_with_link }
+    end
+
+    describe 'in organization with image breadcrumb' do
+      let(:breadcrumb) { home_and_organization_breadcrumbs }
+
+      let(:organization) { create(:another_test_organization) }
+      before { organization.switch! }
+
+      before { organization.profile = Mumuki::Domain::Organization::Profile.new({breadcrumb_image_url: "organization.jpg"}) }
+
+      it { expect(breadcrumb).to include('da da-mumuki') }
+      it { expect(breadcrumb).to_not include('test') }
+
+      it { expect(breadcrumb).to include home_breadcrumb_with_link }
+      it { expect(breadcrumb).to_not include organization_breadcrumb_with_link }
+      it { expect(breadcrumb).to include "<li class='mu-breadcrumb-list-item '><img class=\"da mu-breadcrumb-img\" src=\"/images/organization.jpg\"" }
     end
   end
 end


### PR DESCRIPTION
This PR changes a few things regarding breadcrumbs navigation.

mumuki logo is now omnipresent, even on organizations that have a breadcrumb image set.

![image](https://user-images.githubusercontent.com/11304439/63469944-c6e00800-c441-11e9-90f7-80fc346f8dbf.png)

________________________________

Organizations without an image will appear as text on the breadcrumb.

![image](https://user-images.githubusercontent.com/11304439/63469918-b465ce80-c441-11e9-95c0-b996d526c19b.png)

________________________________

Breadcrumbs now also appear on book views (organization root), for consistency.

![image](https://user-images.githubusercontent.com/11304439/63469756-5933dc00-c441-11e9-80c3-a671ac960bbe.png)
