### PR TITLE
Chore remove momentjs from rails assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem 'sass-rails'
 gem 'execjs'
 gem 'rails-i18n', '~> 4.0.0'
 gem 'nprogress-rails'
-gem 'sitemap_generator'
 gem 'font-awesome-rails', '~> 4.7'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,7 @@ gem 'puma'
 
 gem 'mumuki-domain', github: 'mumuki/mumuki-domain'
 
-source 'https://rails-assets.org' do
-  gem 'rails-assets-momentjs'
-end
+gem 'momentjs-rails', '~> 2.10'
 gem 'uglifier', '~> 2.7'
 gem 'therubyracer', platforms: :ruby
 gem 'turbolinks', '~> 5.0'

--- a/app/assets/javascripts/mumuki_laboratory/application.js
+++ b/app/assets/javascripts/mumuki_laboratory/application.js
@@ -10,9 +10,9 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require momentjs
-//= require momentjs/locale/es
-//= require momentjs/locale/pt
+//= require moment
+//= require moment/es.js
+//= require moment/pt.js
 //= require webcomponents-lite
 //= require rails-ujs
 //= require turbolinks


### PR DESCRIPTION
Removing `rails-assets-momentjs`

Fixes #1365 