### PR TITLE
Chore move dependencies from gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,15 +7,9 @@ gem 'puma'
 
 gem 'mumuki-domain', github: 'mumuki/mumuki-domain'
 
-gem 'momentjs-rails', '~> 2.10'
-gem 'uglifier', '~> 2.7'
-gem 'therubyracer', platforms: :ruby
-gem 'turbolinks', '~> 5.0'
-gem 'sass-rails'
 gem 'execjs'
-gem 'rails-i18n', '~> 4.0.0'
-gem 'nprogress-rails'
-gem 'font-awesome-rails', '~> 4.7'
+gem 'therubyracer', platforms: :ruby
+gem 'uglifier', '~> 2.7'
 
 group :test do
   gem 'rspec-rails', '~> 3.6'

--- a/lib/mumuki/laboratory/engine.rb
+++ b/lib/mumuki/laboratory/engine.rb
@@ -1,3 +1,10 @@
+require 'turbolinks'
+require 'font-awesome-rails'
+require 'momentjs-rails'
+require 'nprogress-rails'
+require 'rails-i18n'
+require 'sass-rails'
+
 module Mumuki
   module Laboratory
     class Engine < ::Rails::Engine

--- a/lib/mumuki/laboratory/engine.rb
+++ b/lib/mumuki/laboratory/engine.rb
@@ -3,7 +3,7 @@ require 'font-awesome-rails'
 require 'momentjs-rails'
 require 'nprogress-rails'
 require 'rails-i18n'
-require 'sass-rails'
+require 'sassc-rails'
 
 module Mumuki
   module Laboratory

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -32,5 +32,12 @@ Gem::Specification.new do |s|
   s.add_dependency 'kaminari', '~> 0.16'
   s.add_dependency 'bootstrap-kaminari-views'
 
+  s.add_dependency 'font-awesome-rails', '~> 4.7'
+  s.add_dependency 'momentjs-rails', '~> 2.10'
+  s.add_dependency 'nprogress-rails', '~> 0.2'
+  s.add_dependency 'rails-i18n', '~> 4.0.0'
+  s.add_dependency 'sass-rails', '~> 6.0'
+  s.add_dependency 'turbolinks', '~> 5.0'
+
   s.add_development_dependency 'pg', '~> 0.18.0'
 end

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'momentjs-rails', '~> 2.10'
   s.add_dependency 'nprogress-rails', '~> 0.2'
   s.add_dependency 'rails-i18n', '~> 4.0.0'
-  s.add_dependency 'sass-rails', '~> 6.0'
+  s.add_dependency 'sassc-rails', '~> 2.1'
   s.add_dependency 'turbolinks', '~> 5.0'
 
   s.add_development_dependency 'pg', '~> 0.18.0'

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails-i18n', '~> 4.0.0'
   s.add_dependency 'sassc-rails', '~> 2.1'
   s.add_dependency 'turbolinks', '~> 5.0'
+  s.add_dependency 'sprockets', '~> 3.7'
 
   s.add_development_dependency 'pg', '~> 0.18.0'
 end


### PR DESCRIPTION
Moving some dependencies that are declared in the `Gemfile` but should be in `gemspec`, thus causing duplication issues when using this gem. 

Rebase and merge after #1366 