### PR TITLE
Render kids results button only if it's a kids exercise

### DIFF
--- a/lib/mumuki/laboratory/controllers/results_rendering.rb
+++ b/lib/mumuki/laboratory/controllers/results_rendering.rb
@@ -40,8 +40,10 @@ module Mumuki::Laboratory::Controllers::ResultsRendering
   end
 
   def render_results_button_html(assignment)
-    render_to_string partial: 'exercise_solutions/kids_results_button',
-                     locals: {assignment: assignment}
+    if assignment.input_kids?
+      render_to_string partial: 'exercise_solutions/kids_results_button',
+                       locals: {assignment: assignment}
+    end
   end
 
   def render_results_expectations_html(assignment)


### PR DESCRIPTION
While debugging on the eternal integration of [flow](https://github.com/mumuki/mumukit-flow/) I found that the results button was being rendered twice - also querying the database twice while at it.

There's a json that renders `exercise_solutions/kids_results_button` in `results_rendering.rb`, except that it never checks if it's actually a kids exercise, making non-kids exercises render a results button twice: the first one is the correct one and corresponds to this stack

```
#6 [method]  exercise_button <WithStudentPathNavigation::Navigation#exercise_button(user, navigable)>
#7 [method]  next_exercise_button <WithStudentPathNavigation#next_exercise_button(user, exercise)>
#8 [method]  __home_mumudev_dev_mumuki_laboratory_app_views_exercise_solutions__results_button_html_erb___1323202815507080639_69989944866720 <ActionView::CompiledTemplates#__home_mumudev_dev_mumuki_laboratory_app_views_exercise_solutions__results_button_html_erb___1323202815507080639_69989944866720(local_assigns, output_buffer)>
...
#24 [method]  __home_mumudev_dev_mumuki_laboratory_app_views_exercise_solutions__results_html_erb__1783646152166654749_69989944569620 <ActionView::CompiledTemplates#__home_mumudev_dev_mumuki_laboratory_app_views_exercise_solutions__results_html_erb__1783646152166654749_69989944569620(local_assigns, output_buffer)>
...
#46 [method]  render_results_html <Mumuki::Laboratory::Controllers::ResultsRendering#render_results_html(assignment)>
#47 [method]  render_results_json <Mumuki::Laboratory::Controllers::ResultsRendering#render_results_json(assignment, results=?)>
#48 [method]  create <ExerciseSolutionsController#create()>
```
while this is the kids one which doesn't belong in the adult world:
```
...
#6 [method]  exercise_button <WithStudentPathNavigation::Navigation#exercise_button(user, navigable)>
#7 [method]  next_exercise_button <WithStudentPathNavigation#next_exercise_button(user, exercise)>
#8 [method]  __home_mumudev_dev_mumuki_laboratory_app_views_exercise_solutions__kids_results_button_html_erb___3730979988483927938_69989933833560 <ActionView::CompiledTemplates#__home_mumudev_dev_mumuki_laboratory_app_views_exercise_solutions__kids_results_button_html_erb___3730979988483927938_69989933833560(local_assigns, output_buffer)>
...
#30 [method]  render_results_button_html <Mumuki::Laboratory::Controllers::ResultsRendering#render_results_button_html(assignment)>
#31 [method]  render_results_json <Mumuki::Laboratory::Controllers::ResultsRendering#render_results_json(assignment, results=?)>
#32 [method]  create <ExerciseSolutionsController#create()>
```
This is the query that was duplicated, although everything seems to be cached:
```
  CACHE Exercise Load (0.1ms)  SELECT "exercises".* FROM "exercises" left join public.assignments assignments
                on assignments.exercise_id = exercises.id
                and assignments.submitter_id = 4
                and assignments.submission_status = 2 WHERE "exercises"."guide_id" = $1 AND (assignments.id is null) ORDER BY "exercises"."number" ASC  [["guide_id", 140]]
  CACHE Guide Load (0.0ms)  SELECT  "guides".* FROM "guides" WHERE "guides"."id" = $1 LIMIT $2  [["id", 140], ["LIMIT", 1]]
  CACHE Usage Load (0.0ms)  SELECT  "usages".* FROM "usages" WHERE "usages"."item_id" = $1 AND "usages"."item_type" = $2 AND "usages"."organization_id" = 3 ORDER BY "usages"."id" ASC LIMIT $3  [["item_id", 140], ["item_type", "Guide"], ["LIMIT", 1]]
  CACHE Lesson Load (0.0ms)  SELECT  "lessons".* FROM "lessons" WHERE "lessons"."id" = $1 ORDER BY "lessons"."number" ASC LIMIT $2  [["id", 160], ["LIMIT", 1]]
  CACHE Usage Load (0.0ms)  SELECT  "usages".* FROM "usages" WHERE "usages"."item_id" = $1 AND "usages"."item_type" = $2 AND "usages"."organization_id" = 3 ORDER BY "usages"."id" ASC LIMIT $3  [["item_id", 140], ["item_type", "Guide"], ["LIMIT", 1]]
  CACHE Lesson Load (0.0ms)  SELECT  "lessons".* FROM "lessons" WHERE "lessons"."id" = $1 ORDER BY "lessons"."number" ASC LIMIT $2  [["id", 160], ["LIMIT", 1]]
  CACHE Topic Load (0.0ms)  SELECT  "topics".* FROM "topics" WHERE "topics"."id" = $1 LIMIT $2  [["id", 53], ["LIMIT", 1]]
  CACHE Usage Load (0.0ms)  SELECT  "usages".* FROM "usages" WHERE "usages"."item_id" = $1 AND "usages"."item_type" = $2 AND "usages"."organization_id" = 3 ORDER BY "usages"."id" ASC LIMIT $3  [["item_id", 53], ["item_type", "Topic"], ["LIMIT", 1]]
  CACHE Chapter Load (0.0ms)  SELECT  "chapters".* FROM "chapters" WHERE "chapters"."id" = $1 ORDER BY "chapters"."number" ASC LIMIT $2  [["id", 98], ["LIMIT", 1]]
  CACHE Guide Load (0.0ms)  SELECT  "guides".* FROM "guides" WHERE "guides"."id" = $1 LIMIT $2  [["id", 140], ["LIMIT", 1]]
  CACHE Usage Load (0.0ms)  SELECT  "usages".* FROM "usages" WHERE "usages"."item_id" = $1 AND "usages"."item_type" = $2 AND "usages"."organization_id" = 3 ORDER BY "usages"."id" ASC LIMIT $3  [["item_id", 53], ["item_type", "Topic"], ["LIMIT", 1]]
  CACHE Chapter Load (0.0ms)  SELECT  "chapters".* FROM "chapters" WHERE "chapters"."id" = $1 ORDER BY "chapters"."number" ASC LIMIT $2  [["id", 98], ["LIMIT", 1]]
  CACHE Topic Load (0.0ms)  SELECT  "topics".* FROM "topics" WHERE "topics"."id" = $1 LIMIT $2  [["id", 53], ["LIMIT", 1]]
```
I've tested some kids exercises and I don't think I'm breaking anything.