### PR TITLE
Use specific content name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ ruby '~> 2.3'
 
 gem 'puma'
 
-gem 'mumuki-domain', github: 'mumuki/mumuki-domain'
-
 gem 'execjs'
 gem 'therubyracer', platforms: :ruby
 gem 'uglifier', '~> 2.7'

--- a/app/views/book/show.html.erb
+++ b/app/views/book/show.html.erb
@@ -30,11 +30,11 @@
     </div>
   <% end %>
 
-  <h2><%= t(:content) %></h2>
+  <h2><%= t(:chapters) %></h2>
 
   <% @book.chapters.each do |it| %>
     <div class="chapter">
-      <h3><%= t(:chapter_number, number: it.number) %> <%= link_to_path_element it, mode: :plain %></h3>
+      <h3><%= it.number %>. <%= link_to_path_element it, mode: :plain %></h3>
 
       <div class="text-box">
         <%= it.description_teaser_html %>

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -14,10 +14,10 @@
 
 <% if @chapter.lessons.present? %>
 <div>
-  <h3><%= t(:content) %></h3>
+  <h3><%= t(:lessons) %></h3>
 
   <% @chapter.lessons.each do |lesson| %>
-    <h4><%= t(:lesson_number, number: lesson.number) %>: <%= link_to_path_element lesson, mode: :plain %></h4>
+    <h4><%= lesson.number %>. <%= link_to_path_element lesson, mode: :plain %></h4>
     <%= render partial: 'layouts/progress_listing', locals: {exercises: lesson.exercises} %>
   <% end %>
 </div>

--- a/app/views/layouts/_guide.html.erb
+++ b/app/views/layouts/_guide.html.erb
@@ -37,7 +37,7 @@
 </div>
 
 <h3>
-  <%= t :content %>
+  <%= t :exercises %>
   <%= restart_guide_link(@guide) if current_user && @guide.started?(current_user) && @guide.resettable? %>
 </h3>
 

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -28,6 +28,7 @@ en:
   blocked_forum_explanation: You are not allowed to see this content. <br> Are you in the middle of an exam right now?
   cancel_subscription: Cancel your subscription.
   chapter: Chapter
+  chapters: Chapters
   chapter_finished_html: You have finished %{chapter}!
   chapter_number: Chapter %{number}
   classroom_ui: Classroom
@@ -70,6 +71,7 @@ en:
   exam_number: 'Exam %{number}:'
   exams: Exams
   exercise: Exercise
+  exercises: Exercises
   exercise_count: exercises
   exercise_done: All our tests passed!
   exercise_number: Exercise %{number}
@@ -110,6 +112,7 @@ en:
   latest_exercises: Latest exercises
   learning: Learning
   lesson: Lesson
+  lessons: Lessons
   lesson_number: Lesson %{number}
   let_us_know: please let us know!
   loading: Loading

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -30,6 +30,7 @@ es:
   blocked_forum_explanation: Es decir que no tenés autorización para ver este contenido. <br> ¿Puede que estés en medio de un examen?
   cancel_subscription: Cancelá tu subscripción.
   chapter: Capítulo
+  chapters: Capítulos
   chapter_finished_html: ¡Terminaste %{chapter}! ¡Felicitaciones!
   chapter_number: 'Capítulo %{number}'
   classroom_ui: Aula
@@ -122,6 +123,7 @@ es:
   latest_exercises: Últimos ejercicios
   learning: Aprendizaje
   lesson: Lección
+  lessons: Lecciones
   lesson_number: Lección %{number}
   let_us_know: ¡Por favor avisanos!
   loading: Cargando

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -28,6 +28,7 @@ pt:
   birthdate: Fecha de nacimiento
   blocked_forum_explanation: Você não tem permissão para ver este conteúdo. <br> Você está no meio de um exame agora?
   chapter: Capítulo
+  chapters: Capítulos
   chapter_finished_html: Você terminou %{chapter}! Parabéns!
   chapter_number: Capítulo %{number}
   classroom_ui: Sala de aula
@@ -117,6 +118,7 @@ pt:
   latest_exercises: Últimos exercícios
   learning: Aprendendo
   lesson: Lição
+  lessons: Lições
   lesson_number: Lição %{number}
   let_us_know: Por favor, avise-nos!
   loading: Carregando

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190929180601) do
+ActiveRecord::Schema.define(version: 20191022180238) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -162,7 +162,6 @@ ActiveRecord::Schema.define(version: 20190929180601) do
     t.boolean "extra_visible", default: false
     t.boolean "manual_evaluation", default: false
     t.integer "editor", default: 0, null: false
-    t.string "choice_values", default: [], null: false, array: true
     t.text "goal"
     t.string "initial_state"
     t.string "final_state"

--- a/spec/features/guides_flow_spec.rb
+++ b/spec/features/guides_flow_spec.rb
@@ -55,14 +55,14 @@ feature 'Guides Flow', organization_workspace: :test do
         visit "/guides/#{complement.guide.id}"
 
         expect(page).to have_text('a complement')
-        expect(page).to have_text('Content')
+        expect(page).to have_text('Exercises')
       end
 
       scenario 'visit lesson by id' do
         visit "/guides/#{lesson.guide.id}"
 
         expect(page).to have_text('awesomeGuide')
-        expect(page).to have_text('Content')
+        expect(page).to have_text('Exercises')
         expect(page).to_not have_text('Creative Commons')
       end
 
@@ -72,7 +72,7 @@ feature 'Guides Flow', organization_workspace: :test do
 
         expect(page).to have_text('awesomeGuide')
         expect(page).to have_text('An awesome guide')
-        expect(page).to have_text('Content')
+        expect(page).to have_text('Exercises')
       end
     end
 
@@ -83,7 +83,7 @@ feature 'Guides Flow', organization_workspace: :test do
         visit "/guides/#{lesson.guide.id}"
 
         expect(page).to have_text('awesomeGuide')
-        expect(page).to have_text('Content')
+        expect(page).to have_text('Exercises')
         expect(page).to have_text('Jon Doe')
         expect(page).to have_text('Creative Commons')
       end

--- a/spec/features/login_flow_spec.rb
+++ b/spec/features/login_flow_spec.rb
@@ -19,8 +19,7 @@ feature 'Login Flow', organization_workspace: :test do
     click_on 'Sign in'
 
     expect(page).to have_text('Start Practicing!')
-    expect(page).to have_text('Content')
-    expect(page).to have_text('Chapter')
+    expect(page).to have_text('Chapters')
     expect(page).to_not have_text('Sign in')
     expect(page).to have_text('Sign Out')
   end
@@ -54,8 +53,7 @@ feature 'Login Flow', organization_workspace: :test do
     expect(page).to have_text('Sign Out')
     click_on 'Sign Out'
 
-    expect(page).to have_text('Content')
-    expect(page).to have_text('Chapter')
+    expect(page).to have_text('Chapters')
 
     expect(page).to have_text('Sign in')
     expect(page).to_not have_text('Sign out')

--- a/spec/features/standard_flow_spec.rb
+++ b/spec/features/standard_flow_spec.rb
@@ -23,7 +23,7 @@ feature 'Standard Flow', organization_workspace: :test do
 
     expect(page).to have_text('Values and Functions')
     expect(page).to have_text('Values are everywhere...')
-    expect(page).to have_text('Content')
+    expect(page).to have_text('Exercises')
     expect(page).to have_text('The Basic Values')
     expect(page).to have_text('Start this lesson!')
     expect(page).to_not have_text("Let's say we")

--- a/spec/features/topic_flow_spec.rb
+++ b/spec/features/topic_flow_spec.rb
@@ -15,7 +15,7 @@ feature 'Topic Flow', organization_workspace: :test do
     visit "/topics/#{topic_in_path.transparent_id}"
 
     expect(page).to have_text('Functional Programming')
-    expect(page).to have_text('Content')
+    expect(page).to have_text('Lessons')
   end
 
   scenario 'visit topic in path not transparently' do


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/11720274/73306148-590ee800-41fa-11ea-844b-87416dca4e65.png)

After:
![image](https://user-images.githubusercontent.com/11720274/73306183-73e15c80-41fa-11ea-81f8-63defdd57b4f.png)

This was requested by @lauramangifesta