### PR TITLE
Feature support markdown on expectation messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,5 @@ group :development do
   gem 'web-console'
   gem 'codeclimate-test-reporter', require: nil
 end
+
+gem 'mumukit-content-type', github: 'mumuki/mumukit-content-type', branch: 'feature-allow-one-liner-markdown-rendering'

--- a/Gemfile
+++ b/Gemfile
@@ -29,4 +29,3 @@ group :development do
   gem 'codeclimate-test-reporter', require: nil
 end
 
-gem 'mumukit-content-type', github: 'mumuki/mumukit-content-type', branch: 'feature-allow-one-liner-markdown-rendering'

--- a/app/helpers/contextualization_result_helper.rb
+++ b/app/helpers/contextualization_result_helper.rb
@@ -1,6 +1,10 @@
 module ContextualizationResultHelper
   def humanized_expectation_result_item(expectation_result)
-    %Q{<li>#{status_icon(expectation_result[:result])} #{sanitized expectation_result[:explanation]}</li>}.html_safe
+    %Q{<li>#{status_icon(expectation_result[:result])} #{humanized_expectation_explanation expectation_result}</li>}.html_safe
+  end
+
+  def humanized_expectation_explanation(expectation_result)
+    sanitized Mumukit::ContentType::Markdown.to_html(expectation_result[:explanation], one_liner: true)
   end
 
   def render_feedback?(contextualization)

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'mumukit-login', '~> 7.1'
   s.add_dependency 'mumukit-nuntius', '~> 6.1'
   s.add_dependency 'mumukit-auth', '~> 7.7'
+  s.add_dependency 'mumukit-content-type', '~> 1.9'
 
   s.add_dependency 'mumuki-styles', '~> 1.21.3'
   s.add_dependency 'muvment', '~> 1.2'

--- a/spec/helpers/test_results_rendering_spec.rb
+++ b/spec/helpers/test_results_rendering_spec.rb
@@ -3,54 +3,81 @@ require 'ostruct'
 
 describe ContextualizationResultHelper do
   helper IconsHelper
+  helper FontAwesome::Rails::IconHelper
   helper ContextualizationResultHelper
 
-  let(:html) { render_test_results contextualization }
 
-  context 'structured results' do
-    context 'when single passed submission' do
-      let(:contextualization) { struct(
-        exercise: struct(hidden?: false),
-        test_results: [{title: '2 is 2', status: :passed, result: ''}],
-        output_content_type: Mumukit::ContentType::Plain) }
+  describe 'humanized_expectation_result_item' do
+    let(:html) { humanized_expectation_result_item expectation_result }
 
-      it { expect(html).to be_html_safe }
-      it { expect(html).to include "<i class=\"fa fa-check-circle text-success status-icon\"></i>" }
-      it { expect(html).to include "2 is 2" }
+    context 'plain explanation' do
+      let(:expectation_result) { {result: :failed, explanation: 'you must delegate'} }
+
+      it { expect(html).to eq '<li><i class="fa fa-times-circle text-danger status-icon"></i> you must delegate</li>' }
+
     end
 
-    context 'when single failed submission' do
-      context 'when plain results' do
-        let(:contextualization) { struct(
-          exercise: struct(hidden?: false),
-          test_results: [{title: '2 is 2', status: :failed, result: 'something _went_ wrong'}],
-          output_content_type: Mumukit::ContentType::Plain) }
+    context 'html explanation' do
+      let(:expectation_result) { {result: :failed, explanation: 'you must use <strong>if</strong>'} }
 
-        it { expect(html).to include "<i class=\"fa fa-times-circle text-danger status-icon\"></i>" }
-        it { expect(html).to include "<strong class=\"example-title\">2 is 2</strong>" }
-        it { expect(html).to include "<pre>something _went_ wrong</pre>" }
-      end
+      it { expect(html).to eq '<li><i class="fa fa-times-circle text-danger status-icon"></i> you must use <strong>if</strong></li>' }
+    end
 
-      context 'when markdown results' do
-        let(:contextualization) { struct(
-          exercise: struct(hidden?: false),
-          test_results: [{title: '2 is 2', status: :failed, result: 'something went _really_ wrong'}],
-          output_content_type: Mumukit::ContentType::Markdown) }
+    context 'markdown explanation' do
+      let(:expectation_result) { {result: :failed, explanation: 'you must call `fooBar`'} }
 
-        it { expect(html).to include "<i class=\"fa fa-times-circle text-danger status-icon\"></i>" }
-        it { expect(html).to include "<strong class=\"example-title\">2 is 2</strong>" }
-        it { expect(html).to include "<p>something went <em>really</em> wrong</p>" }
-      end
+      it { expect(html).to eq '<li><i class="fa fa-times-circle text-danger status-icon"></i> you must call <code>fooBar</code></li>' }
     end
   end
 
-  context 'unstructured results' do
-    let(:contextualization) { struct(
-      exercise: struct(hidden?: false),
-      result_html: '<pre>ooops, something went wrong</pre>'.html_safe) }
+  describe 'render_test_results' do
+    let(:html) { render_test_results contextualization }
 
-    it { expect(html).to be_html_safe }
-    it { expect(html).to include '<pre>ooops, something went wrong</pre>' }
-    it { expect(html).to include '<strong>Results:</strong>' }
+    context 'structured results' do
+      context 'when single passed submission' do
+        let(:contextualization) { struct(
+          exercise: struct(hidden?: false),
+          test_results: [{title: '2 is 2', status: :passed, result: ''}],
+          output_content_type: Mumukit::ContentType::Plain) }
+
+        it { expect(html).to be_html_safe }
+        it { expect(html).to include "<i class=\"fa fa-check-circle text-success status-icon\"></i>" }
+        it { expect(html).to include "2 is 2" }
+      end
+
+      context 'when single failed submission' do
+        context 'when plain results' do
+          let(:contextualization) { struct(
+            exercise: struct(hidden?: false),
+            test_results: [{title: '2 is 2', status: :failed, result: 'something _went_ wrong'}],
+            output_content_type: Mumukit::ContentType::Plain) }
+
+          it { expect(html).to include "<i class=\"fa fa-times-circle text-danger status-icon\"></i>" }
+          it { expect(html).to include "<strong class=\"example-title\">2 is 2</strong>" }
+          it { expect(html).to include "<pre>something _went_ wrong</pre>" }
+        end
+
+        context 'when markdown results' do
+          let(:contextualization) { struct(
+            exercise: struct(hidden?: false),
+            test_results: [{title: '2 is 2', status: :failed, result: 'something went _really_ wrong'}],
+            output_content_type: Mumukit::ContentType::Markdown) }
+
+          it { expect(html).to include "<i class=\"fa fa-times-circle text-danger status-icon\"></i>" }
+          it { expect(html).to include "<strong class=\"example-title\">2 is 2</strong>" }
+          it { expect(html).to include "<p>something went <em>really</em> wrong</p>" }
+        end
+      end
+    end
+
+    context 'unstructured results' do
+      let(:contextualization) { struct(
+        exercise: struct(hidden?: false),
+        result_html: '<pre>ooops, something went wrong</pre>'.html_safe) }
+
+      it { expect(html).to be_html_safe }
+      it { expect(html).to include '<pre>ooops, something went wrong</pre>' }
+      it { expect(html).to include '<strong>Results:</strong>' }
+    end
   end
 end


### PR DESCRIPTION
Depends on https://github.com/mumuki/mumukit-content-type/pull/14

This allows custom expectation rules to be properly rendered, which is currently not happening:

![screencapture-mumuki-io-informatorio-exercises-8687-fundamentos-procedimientos-cuadradomulticolor-2020-03-27-13_31_53](https://user-images.githubusercontent.com/677436/77778432-bcb56600-702f-11ea-99ca-05e79a9293ed.png)
