### PR TITLE
Adding new client-side directives to allow sections of extra code to be hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ which are granted to be safe and stable.
   * `formatContent`
   * `reset`
   * `toggleFullscreen`
+* `mumuki.elipsis`
+  * `replaceHtml`
 * `mumuki.kids`
   * `registerBlocksAreaScaler`
   * `registerStateScaler`

--- a/app/assets/javascripts/mumuki_laboratory/application/elipsis.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/elipsis.js
@@ -1,0 +1,31 @@
+// This module defines three client-side-only special sections, and allows them to be replaced
+// by adding the `mu-elipsis` class, or by calling `mumuki.elipsis()`:
+//
+// * <elipsis-for-student# ...code... #elipsis-for-student>                     : replaces code with an elipsis
+// * <hidden-for-student# ...code... #hidden-for-student>                       : completely hides code
+// * <description-for-student[...text...]# ...code... #description-for-student> : replaces code a message sourrounded by elipsis
+//
+//
+// This module assumes the strings are already markdown-like escaped code strings, not plain code
+(function (mumuki) {
+
+  function elipsis(code) {
+    return code
+      .replace(/&lt;elipsis-for-student#[\s\S]*?#elipsis-for-student&gt;/g, ' ... ')
+      .replace(/&lt;hidden-for-student#[\s\S]*?#hidden-for-student&gt;/g, '')
+      .replace(/&lt;description-for-student\[([^\]]*)\]#[\s\S]*?#description-for-student&gt;/g, ' ... $1 ... ');
+  }
+
+  mumuki.elipsis = elipsis;
+  mumuki.elipsis.replaceHtml = () => {
+    let $elipsis = $('.mu-elipsis');
+    $elipsis.each((it, e) =>  {
+      let $e = $(e);
+      $e.html(mumuki.elipsis($e.html()));
+    })
+  };
+
+  mumuki.load(() => {
+    mumuki.elipsis.replaceHtml();
+  });
+})(mumuki);

--- a/app/views/exercises/_read_only.html.erb
+++ b/app/views/exercises/_read_only.html.erb
@@ -94,7 +94,7 @@
         </div>
       </div>
 
-      <div role="tabpanel" class="tab-pane mu-input-panel fade" id="visible-extra">
+      <div role="tabpanel" class="tab-pane mu-input-panel fade mu-elipsis" id="visible-extra">
         <%= @discussion.extra_preview_html %>
       </div>
     </div>

--- a/app/views/layouts/exercise_inputs/forms/_interactive_form.html.erb
+++ b/app/views/layouts/exercise_inputs/forms/_interactive_form.html.erb
@@ -28,7 +28,7 @@
       <a class="console-reset submission-reset"><%= restart_icon %></a>
     </div>
    </div>
-  <div role="tabpanel" class="tab-pane mu-input-panel fade" id="visible-extra">
+  <div role="tabpanel" class="tab-pane mu-input-panel fade mu-elipsis" id="visible-extra">
     <%= @assignment.extra_preview_html %>
   </div>
   <div role="tabpanel" class="tab-pane mu-input-panel fade" id="messages">

--- a/app/views/layouts/exercise_inputs/forms/_playground_form.html.erb
+++ b/app/views/layouts/exercise_inputs/forms/_playground_form.html.erb
@@ -17,7 +17,7 @@
       <a class="console-reset submission-reset"><%= restart_icon %></a>
     </div>
   </div>
-  <div role="tabpanel" class="tab-pane mu-input-panel fade" id="visible-extra">
+  <div role="tabpanel" class="tab-pane mu-input-panel fade mu-elipsis" id="visible-extra">
     <%= @assignment.extra_preview_html %>
   </div>
 </div>

--- a/app/views/layouts/exercise_inputs/forms/_problem_form.html.erb
+++ b/app/views/layouts/exercise_inputs/forms/_problem_form.html.erb
@@ -51,7 +51,7 @@
       <label for="include_solution"><p><%= t(:load_solution_into_console) %></p></label>
     </div>
   </div>
-  <div role="tabpanel" class="tab-pane mu-input-panel fade" id="visible-extra">
+  <div role="tabpanel" class="tab-pane mu-input-panel fade mu-elipsis" id="visible-extra">
     <%= @assignment.extra_preview_html %>
   </div>
   <div role="tabpanel" class="tab-pane mu-input-panel fade" id="messages">


### PR DESCRIPTION
Fixes #1328

This is a long-standing issue, that is bad because we can not always show extra-code and this leads to confussion, because students can not easily understand if there is code in the library or not. 

I am defining new - server-side agnostic -  sections:

 * `<elipsis-for-student# ...code... #elipsis-for-student>`: replaces content by `...`
 * `<hidden-for-student# ...code... #hidden-for-student>`: removes content sourrounded by section
* `<description-for-student[...text...]# ...code... #description-for-student>`: allows content editors to specify the text to be displayed. 


This is how it looks: 

![image](https://user-images.githubusercontent.com/677436/78595300-31528680-7820-11ea-9605-ddf1eda7271a.png)

Sample  - guide - extra code: 

```javascript
function longitud(secuencia) {
  return secuencia.length; 
}

function rango(s, e) {
  /*<elipsis-for-student#*/
  let r = [];
  for (let i = s; i <= e; i++) {
     r.push(i)
  }
  return r;
  /*#elipsis-for-student>*/
}

function imprimir(s) {
  /*<hidden-for-student#*/
  console.log(s)
  /*#hidden-for-student>*/
}

function poner(a, e) {
  /*<description-for-student[agrega el elemento e al array a]#*/
   array.push(e);
  /*#description-for-student>*/
}

function absoluto(x) {
  return Math.abs(x)
}

function convertirEnMayuscula(x) {
  return x.toUpperCase()
}

function comienzaCon(x, y) {
  return x.startsWith(x, y);
}
```

This code is inspired in actual content from `flbulgarelli/fundamentos-javascript-funciones-tipos-de-datos`