### PR TITLE
Using another separator for client-side sections

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/elipsis.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/elipsis.js
@@ -1,9 +1,9 @@
 // This module defines three client-side-only special sections, and allows them to be replaced
 // by adding the `mu-elipsis` class, or by calling `mumuki.elipsis()`:
 //
-// * <elipsis-for-student# ...code... #elipsis-for-student>                     : replaces code with an elipsis
-// * <hidden-for-student# ...code... #hidden-for-student>                       : completely hides code
-// * <description-for-student[...text...]# ...code... #description-for-student> : replaces code a message sourrounded by elipsis
+// * <elipsis-for-student@ ...code... @elipsis-for-student>                     : replaces code with an elipsis
+// * <hidden-for-student@ ...code... @hidden-for-student>                       : completely hides code
+// * <description-for-student[...text...]@ ...code... @description-for-student> : replaces code a message sourrounded by elipsis
 //
 //
 // This module assumes the strings are already markdown-like escaped code strings, not plain code
@@ -11,9 +11,9 @@
 
   function elipsis(code) {
     return code
-      .replace(/&lt;elipsis-for-student#[\s\S]*?#elipsis-for-student&gt;/g, ' ... ')
-      .replace(/&lt;hidden-for-student#[\s\S]*?#hidden-for-student&gt;/g, '')
-      .replace(/&lt;description-for-student\[([^\]]*)\]#[\s\S]*?#description-for-student&gt;/g, ' ... $1 ... ');
+      .replace(/&lt;elipsis-for-student@[\s\S]*?@elipsis-for-student&gt;/g, ' ... ')
+      .replace(/&lt;hidden-for-student@[\s\S]*?@hidden-for-student&gt;/g, '')
+      .replace(/&lt;description-for-student\[([^\]]*)\]@[\s\S]*?@description-for-student&gt;/g, ' ... $1 ... ');
   }
 
   mumuki.elipsis = elipsis;


### PR DESCRIPTION
There is a problem I didn't notice with #1391 : the new inspections collide with mumukit server side inspections, making the code evaluation framework crash. 

Because of this, I am slightly changing the client-side section's format:

Integration test screenshots:

http://localhost:3000/central/exercises/3102-programacion-imperativa-funciones-y-tipos-de-datos-funciones-declaracion#visible-extra
![image](https://user-images.githubusercontent.com/677436/79897990-dd7b9c00-83e0-11ea-80dc-6a7cd891b4ca.png)


![image](https://user-images.githubusercontent.com/677436/79897600-56c6bf00-83e0-11ea-8403-77ab7ff2879f.png)


I am using the new JS library that is here: https://github.com/MumukiProject/mumuki-apendice-imperativa-javascript/commit/a661d36aeb9f6982e3d09c75524437bd167ba2f2

I am using exercises from this guide: http://localhost:3000/central/exercises/3102-programacion-imperativa-funciones-y-tipos-de-datos-funciones-declaracion