### PR TITLE
Displaying summary

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,3 +29,5 @@ group :development do
   gem 'codeclimate-test-reporter', require: nil
 end
 
+
+gem 'mumukit-bridge', github: 'mumuki/mumukit-bridge', branch: 'feature-test-summary'

--- a/Gemfile
+++ b/Gemfile
@@ -31,3 +31,4 @@ end
 
 
 gem 'mumukit-bridge', github: 'mumuki/mumukit-bridge', branch: 'feature-test-summary'
+gem 'mumuki-domain', github:  'mumuki/mumuki-domain', branch: 'chore-test-results-html-improvements'

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,4 @@ group :development do
   gem 'codeclimate-test-reporter', require: nil
 end
 
-
-gem 'mumukit-bridge', github: 'mumuki/mumukit-bridge', branch: 'feature-test-summary'
-gem 'mumuki-domain', github:  'mumuki/mumuki-domain', branch: 'chore-test-results-html-improvements'
+gem 'mumuki-domain', github:  'mumuki/mumuki-domain', branch: 'master'

--- a/app/assets/javascripts/mumuki_laboratory/application/kids.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/kids.js
@@ -173,13 +173,17 @@ mumuki.load(function () {
     },
 
     _showMessageOnCharacterBubble: function (data) {
-      var $bubble = mumuki.kids._getCharacterBubble();
+      let $bubble = mumuki.kids._getCharacterBubble();
+      let $failedSppechBubble = $bubble.find('.mu-kids-character-speech-bubble-failed');
+
       $bubble.find('.mu-kids-character-speech-bubble-tabs').hide();
       $bubble.find('.mu-kids-character-speech-bubble-normal').hide();
-      $bubble.find('.mu-kids-character-speech-bubble-failed').show().html(data.title_html);
+      $failedSppechBubble.show().html(data.title_html);
       $bubble.addClass(data.status);
       if (data.status === 'passed_with_warnings') {
-        $bubble.find('.mu-kids-character-speech-bubble-failed').append(data.expectations_html);
+        this._appendFirstExpectationHtml($failedSppechBubble, data);
+      } else if (data.status === 'failed') {
+        this._appendFirstSummaryMessage($failedSppechBubble, data);
       }
       if (this._shouldDisplayDiscussionsLink(data.status)) {
         $bubble.append(discussionsLinkHtml);
@@ -189,6 +193,17 @@ mumuki.load(function () {
 
     _shouldDisplayDiscussionsLink: function (status) {
       return ['failed', 'passed_with_warnings'].some(it => it === status);
+    },
+
+    _appendFirstExpectationHtml($failedSppechBubble, data) {
+      $failedSppechBubble.append(data.expectations_html);
+    },
+
+    _appendFirstSummaryMessage($failedSppechBubble, data) {
+      let summary = data.test_results[0].summary;
+      if (summary) {
+        $failedSppechBubble.append(summary.message);
+      }
     },
 
     _showOnSuccessPopup: function (data) {

--- a/app/assets/javascripts/mumuki_laboratory/application/kids.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/kids.js
@@ -174,16 +174,16 @@ mumuki.load(function () {
 
     _showMessageOnCharacterBubble: function (data) {
       let $bubble = mumuki.kids._getCharacterBubble();
-      let $failedSppechBubble = $bubble.find('.mu-kids-character-speech-bubble-failed');
+      let $failedSpeechBubble = $bubble.find('.mu-kids-character-speech-bubble-failed');
 
       $bubble.find('.mu-kids-character-speech-bubble-tabs').hide();
       $bubble.find('.mu-kids-character-speech-bubble-normal').hide();
-      $failedSppechBubble.show().html(data.title_html);
+      $failedSpeechBubble.show().html(data.title_html);
       $bubble.addClass(data.status);
       if (data.status === 'passed_with_warnings') {
-        this._appendFirstExpectationHtml($failedSppechBubble, data);
+        this._appendFirstExpectationHtml($failedSpeechBubble, data);
       } else if (data.status === 'failed') {
-        this._appendFirstSummaryMessage($bubble, $failedSppechBubble, data);
+        this._appendFirstSummaryMessage($bubble, $failedSpeechBubble, data);
       }
       if (this._shouldDisplayDiscussionsLink(data.status)) {
         $bubble.append(discussionsLinkHtml);
@@ -195,15 +195,15 @@ mumuki.load(function () {
       return ['failed', 'passed_with_warnings'].some(it => it === status);
     },
 
-    _appendFirstExpectationHtml($failedSppechBubble, data) {
-      $failedSppechBubble.append(data.expectations_html);
+    _appendFirstExpectationHtml($failedSpeechBubble, data) {
+      $failedSpeechBubble.append(data.expectations_html);
     },
 
-    _appendFirstSummaryMessage($bubble, $failedSppechBubble, data) {
+    _appendFirstSummaryMessage($bubble, $failedSpeechBubble, data) {
       let summary = data.test_results[0].summary;
       if (summary) {
         $bubble.addClass('with-summary');
-        $failedSppechBubble.append(`
+        $failedSpeechBubble.append(`
         <div class="results-item">
           <ul class="results-list">
             <li>${summary.message}</li>

--- a/app/assets/javascripts/mumuki_laboratory/application/kids.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/kids.js
@@ -183,7 +183,7 @@ mumuki.load(function () {
       if (data.status === 'passed_with_warnings') {
         this._appendFirstExpectationHtml($failedSppechBubble, data);
       } else if (data.status === 'failed') {
-        this._appendFirstSummaryMessage($failedSppechBubble, data);
+        this._appendFirstSummaryMessage($bubble, $failedSppechBubble, data);
       }
       if (this._shouldDisplayDiscussionsLink(data.status)) {
         $bubble.append(discussionsLinkHtml);
@@ -199,10 +199,17 @@ mumuki.load(function () {
       $failedSppechBubble.append(data.expectations_html);
     },
 
-    _appendFirstSummaryMessage($failedSppechBubble, data) {
+    _appendFirstSummaryMessage($bubble, $failedSppechBubble, data) {
       let summary = data.test_results[0].summary;
       if (summary) {
-        $failedSppechBubble.append(summary.message);
+        $bubble.addClass('with-summary');
+        $failedSppechBubble.append(`
+        <div class="results-item">
+          <ul class="results-list">
+            <li>${summary.message}</li>
+          </ul>
+        </div>
+      `);
       }
     },
 

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_kids.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_kids.scss
@@ -154,7 +154,7 @@ $kids-speech-tabs-width: 40px;
         }
       }
 
-      &.passed_with_warnings {
+      &.passed_with_warnings, &.failed.with-summary {
         padding-top: 5px;
         padding-bottom: 5px;
 

--- a/app/helpers/contextualization_result_helper.rb
+++ b/app/helpers/contextualization_result_helper.rb
@@ -25,7 +25,7 @@ module ContextualizationResultHelper
     end
   end
 
-  def render_test_result_head(test_result)
+  def render_test_result_header(test_result)
     # TODO markdown on summary message?
     title = test_result[:title]
     summary_message = test_result.dig(:summary, :message)

--- a/app/helpers/contextualization_result_helper.rb
+++ b/app/helpers/contextualization_result_helper.rb
@@ -25,9 +25,16 @@ module ContextualizationResultHelper
     end
   end
 
-  def render_test_result_summary_message(test_result)
+  def render_test_result_head(test_result)
     # TODO markdown on summary message?
-    test_result.dig(:summary, :message)&.prepend(': ')
+    title = test_result[:title]
+    summary_message = test_result.dig(:summary, :message)
+
+    if title.present?
+      %Q{<strong class="example-title">#{title}</strong>#{summary_message&.prepend(': ')}}.html_safe
+    elsif summary_message
+      %Q{<strong class="example-title">#{summary_message}</strong>}.html_safe
+    end
   end
 
   def render_test_results(contextualization)

--- a/app/helpers/contextualization_result_helper.rb
+++ b/app/helpers/contextualization_result_helper.rb
@@ -25,6 +25,11 @@ module ContextualizationResultHelper
     end
   end
 
+  def render_test_result_summary_message(test_result)
+    # TODO markdown on summary message?
+    test_result.dig(:summary, :message)&.prepend(': ')
+  end
+
   def render_test_results(contextualization)
     if contextualization.test_results.present?
       template = contextualization.result.present? ? 'layouts/mixed_results' : 'layouts/test_results'

--- a/app/views/layouts/_test_results.html.erb
+++ b/app/views/layouts/_test_results.html.erb
@@ -1,6 +1,6 @@
-<% if contextualization.single_visual_result? %>
-  <span class="text-danger"><%= render_test_result_header contextualization.test_results.first %></span>
-  <%= contextualization.single_visual_result_html %>
+<% if contextualization.single_visible_test_result? %>
+  <span class="text-danger"><%= render_test_result_header contextualization.first_test_result %></span>
+  <%= contextualization.first_test_result_html %>
 <% else %>
   <strong><%= t :test_results %>:</strong>
   <ul class="results-list">
@@ -22,7 +22,7 @@
         <% end %>
 
         <div class="example-result collapse <%= 'in' if contextualization.visible_success_output? %>" id="example-result-<%= index %>">
-          <%= contextualization.output_content_type.to_html test_result[:result] %>
+          <%= contextualization.test_result_html test_result %>
         </div>
       </li>
     <% end %>

--- a/app/views/layouts/_test_results.html.erb
+++ b/app/views/layouts/_test_results.html.erb
@@ -8,7 +8,7 @@
         <% if test_result[:status].failed? %>
           <span class="text-danger">
             <%= status_icon(test_result[:status]) %>
-            <strong class="example-title"><%= test_result[:title] %></strong><%= render_test_result_summary_message test_result %>
+            <%= render_test_result_head test_result %>
             <% unless contextualization.visible_success_output? %>
               <a data-toggle="collapse" href="#example-result-<%= index %>"  class="example-see-more"><%= t :view_details %></a>
             <% end %>

--- a/app/views/layouts/_test_results.html.erb
+++ b/app/views/layouts/_test_results.html.erb
@@ -1,4 +1,5 @@
 <% if contextualization.single_visual_result? %>
+  <span class="text-danger"><%= render_test_result_head contextualization.test_results.first %></span>
   <%= contextualization.single_visual_result_html %>
 <% else %>
   <strong><%= t :test_results %>:</strong>

--- a/app/views/layouts/_test_results.html.erb
+++ b/app/views/layouts/_test_results.html.erb
@@ -8,7 +8,7 @@
         <% if test_result[:status].failed? %>
           <span class="text-danger">
             <%= status_icon(test_result[:status]) %>
-            <strong class="example-title"><%= test_result[:title] %></strong><%= test_result.dig(:summary, :message)&.prepend(': ')  %>
+            <strong class="example-title"><%= test_result[:title] %></strong><%= render_test_result_summary_message test_result %>
             <% unless contextualization.visible_success_output? %>
               <a data-toggle="collapse" href="#example-result-<%= index %>"  class="example-see-more"><%= t :view_details %></a>
             <% end %>

--- a/app/views/layouts/_test_results.html.erb
+++ b/app/views/layouts/_test_results.html.erb
@@ -8,7 +8,7 @@
         <% if test_result[:status].failed? %>
           <span class="text-danger">
             <%= status_icon(test_result[:status]) %>
-            <strong class="example-title"><%= test_result[:title] %></strong>
+            <strong class="example-title"><%= test_result[:title] %></strong><%= test_result.dig(:summary, :message)&.prepend(': ')  %>
             <% unless contextualization.visible_success_output? %>
               <a data-toggle="collapse" href="#example-result-<%= index %>"  class="example-see-more"><%= t :view_details %></a>
             <% end %>

--- a/app/views/layouts/_test_results.html.erb
+++ b/app/views/layouts/_test_results.html.erb
@@ -1,5 +1,5 @@
 <% if contextualization.single_visual_result? %>
-  <span class="text-danger"><%= render_test_result_head contextualization.test_results.first %></span>
+  <span class="text-danger"><%= render_test_result_header contextualization.test_results.first %></span>
   <%= contextualization.single_visual_result_html %>
 <% else %>
   <strong><%= t :test_results %>:</strong>
@@ -9,7 +9,7 @@
         <% if test_result[:status].failed? %>
           <span class="text-danger">
             <%= status_icon(test_result[:status]) %>
-            <%= render_test_result_head test_result %>
+            <%= render_test_result_header test_result %>
             <% unless contextualization.visible_success_output? %>
               <a data-toggle="collapse" href="#example-result-<%= index %>"  class="example-see-more"><%= t :view_details %></a>
             <% end %>

--- a/lib/mumuki/laboratory/controllers/results_rendering.rb
+++ b/lib/mumuki/laboratory/controllers/results_rendering.rb
@@ -25,7 +25,7 @@ module Mumuki::Laboratory::Controllers::ResultsRendering
         button_html: render_results_button_html(assignment),
         title_html: render_results_title_html(assignment),
         expectations_html: render_results_expectations_html(assignment),
-        test_results: assignment.test_results)
+        test_results: assignment.test_results) # TODO markdown on summary message?
   end
 
   def progress_json

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", "~> 5.1.6"
 
   s.add_dependency 'mumuki-domain', '~> 7.4.0'
+  s.add_dependency 'mumukit-bridge', '~> 4.1'
   s.add_dependency 'mumukit-login', '~> 7.2'
   s.add_dependency 'mumukit-nuntius', '~> 6.1'
   s.add_dependency 'mumukit-auth', '~> 7.7'

--- a/spec/dummy/db/seeds.rb
+++ b/spec/dummy/db/seeds.rb
@@ -16,6 +16,12 @@ Organization.find_or_create_by!(name: 'private') do |org|
   org.public = false
 end
 
+  Organization.find_or_create_by!(name: 'primaria') do |org|
+    org.book = Book.find_by!(slug: 'mumukiproject/mumuki-libro-primaria')
+    org.login_methods = Mumukit::Login::Settings.login_methods
+    org.public = true
+  end
+
 Organization.find_or_create_by!(name: 'central')
 
 User.find_or_create_by!(uid: 'dev.student@mumuki.org') { |org| org.permissions = {student: 'central/*'} }

--- a/spec/helpers/test_results_rendering_spec.rb
+++ b/spec/helpers/test_results_rendering_spec.rb
@@ -35,10 +35,11 @@ describe ContextualizationResultHelper do
 
     context 'structured results' do
       context 'when single passed submission' do
-        let(:contextualization) { struct(
-          exercise: struct(hidden?: false),
-          test_results: [{title: '2 is 2', status: :passed, result: ''}],
-          output_content_type: Mumukit::ContentType::Plain) }
+        let(:language) { build(:language, output_content_type: :plain) }
+        let(:problem) { build(:problem, language: language) }
+        let(:contextualization) { Assignment.new(
+          exercise: problem,
+          test_results: [{title: '2 is 2', status: :passed, result: ''}]) }
 
         it { expect(html).to be_html_safe }
         it { expect(html).to include "<i class=\"fa fa-check-circle text-success status-icon\"></i>" }
@@ -47,10 +48,11 @@ describe ContextualizationResultHelper do
 
       context 'when single failed submission' do
         context 'when plain results' do
-          let(:contextualization) { struct(
-            exercise: struct(hidden?: false),
-            test_results: [{title: '2 is 2', status: :failed, result: 'something _went_ wrong'}],
-            output_content_type: Mumukit::ContentType::Plain) }
+          let(:language) { build(:language, output_content_type: :plain) }
+          let(:problem) { build(:problem, language: language) }
+          let(:contextualization) { Assignment.new(
+            exercise: problem,
+            test_results: [{title: '2 is 2', status: :failed, result: 'something _went_ wrong'}]) }
 
           it { expect(html).to include "<i class=\"fa fa-times-circle text-danger status-icon\"></i>" }
           it { expect(html).to include "<strong class=\"example-title\">2 is 2</strong>" }
@@ -58,31 +60,49 @@ describe ContextualizationResultHelper do
         end
 
         context 'when markdown results' do
-          let(:contextualization) { struct(
-            exercise: struct(hidden?: false),
-            test_results: [{title: '2 is 2', status: :failed, result: 'something went _really_ wrong'}],
-            output_content_type: Mumukit::ContentType::Markdown) }
+          let(:language) { build(:language, output_content_type: :markdown) }
+          let(:problem) { build(:problem, language: language) }
+          let(:contextualization) { Assignment.new(
+            exercise: problem,
+            test_results: [{title: '2 is 2', status: :failed, result: 'something went _really_ wrong'}]) }
 
           it { expect(html).to include "<i class=\"fa fa-times-circle text-danger status-icon\"></i>" }
           it { expect(html).to include "<strong class=\"example-title\">2 is 2</strong>" }
           it { expect(html).to include "<p>something went <em>really</em> wrong</p>" }
         end
 
-        context 'when markdown results with summary' do
-          let(:contextualization) { struct(
-            exercise: struct(hidden?: false),
-            test_results: [{title: 'foo is 2', status: :failed, result: 'foo is undefined', summary: {type: 'undefined_variable', summary: 'you are using things that are **not defined**'}}],
-            output_content_type: Mumukit::ContentType::Markdown) }
+        context 'when markdown results with summary and title' do
+          let(:language) { build(:language, output_content_type: :markdown) }
+          let(:problem) { build(:problem, language: language) }
+          let(:contextualization) { Assignment.new(
+            exercise: problem,
+            test_results: [{title: 'foo is 2', status: :failed, result: 'foo is undefined', summary: {type: 'undefined_variable', message: 'you are using things that are **not defined**'}}]) }
 
-          it { expect(html).to eq "" }
+          it { expect(html).to include '<strong class="example-title">foo is 2</strong>: you are using things that are **not defined**' }
+          it { expect(html).to include "<i class=\"fa fa-times-circle text-danger status-icon\"></i>" }
+          it { expect(html).to include '<p>foo is undefined</p>' }
+        end
+
+        context 'when markdown results with summary and no title' do
+          let(:language) { build(:language, output_content_type: :markdown) }
+          let(:problem) { build(:problem, language: language) }
+          let(:contextualization) { Assignment.new(
+            exercise: problem,
+            test_results: [{title: '', status: :failed, result: 'foo is undefined', summary: {type: 'undefined_variable', message: 'you are using things that are **not defined**'}}]) }
+
+          it { expect(html).to include '<strong class="example-title">you are using things that are **not defined**</strong>' }
+          it { expect(html).to include "<i class=\"fa fa-times-circle text-danger status-icon\"></i>" }
+          it { expect(html).to include '<p>foo is undefined</p>' }
         end
       end
     end
 
     context 'unstructured results' do
-      let(:contextualization) { struct(
-        exercise: struct(hidden?: false),
-        result_html: '<pre>ooops, something went wrong</pre>'.html_safe) }
+      let(:language) { build(:language, )}
+      let(:problem) { build(:problem, language: language) }
+      let(:contextualization) { Assignment.new(
+        exercise: problem,
+        result: 'ooops, something went wrong'.html_safe) }
 
       it { expect(html).to be_html_safe }
       it { expect(html).to include '<pre>ooops, something went wrong</pre>' }

--- a/spec/helpers/test_results_rendering_spec.rb
+++ b/spec/helpers/test_results_rendering_spec.rb
@@ -67,6 +67,15 @@ describe ContextualizationResultHelper do
           it { expect(html).to include "<strong class=\"example-title\">2 is 2</strong>" }
           it { expect(html).to include "<p>something went <em>really</em> wrong</p>" }
         end
+
+        context 'when markdown results with summary' do
+          let(:contextualization) { struct(
+            exercise: struct(hidden?: false),
+            test_results: [{title: 'foo is 2', status: :failed, result: 'foo is undefined', summary: {type: 'undefined_variable', summary: 'you are using things that are **not defined**'}}],
+            output_content_type: Mumukit::ContentType::Markdown) }
+
+          it { expect(html).to eq "" }
+        end
       end
     end
 


### PR DESCRIPTION
### :dart: PR Goal

This PR add supports for summaries: short text messages generated by the runner that try to capture the essence of the test-failure, hiding lower-level details - which continue con live in the results.

Such summaries are important for the following reasons: 

 - They may be generated in the user's language instead of just plain english
 - They become first citizens in the platform instead of being tangled within some runners code
 - They come also with a symbolic key, which allows to perform better analysis on data
 - They are displayable in kids layout :confetti_ball: 

### :eyes: Relations

 * Related to #1364 
 * Related to #1397 

### :ballot_box_with_check: Pending tasks

- [x] Fix tests
- ~Change bubble text when there switching in multiple scenarios~
- [x] Do more integration testing
- ~Support markdown~ I will support in the next #1400 PR, since it is a little more complex to do this in a appropriate manner

### :spiral_notepad:  More details

[Single feedback message proposal](https://docs.google.com/document/d/1-wFSTVtjwEM4hieVb7I-AAeXngmx_Sx77AeEQW-P1Bk/edit#)

### :camera: Screenshots

##### Standard layout

![summary_1](https://user-images.githubusercontent.com/677436/81222920-7ef71600-8fbb-11ea-94c4-ce6ecf01ed24.png)

##### Standard layout with gobstones multi-scenario exercise with title tests and summary

![image](https://user-images.githubusercontent.com/677436/82097747-e3138b80-96d9-11ea-8e6d-e2e26c9b257e.png)


##### Standard layout with gobstones multi-scenario exercise with untitled tests

![image](https://user-images.githubusercontent.com/677436/81301821-f2e2fe00-904f-11ea-8f3c-575c3abec07e.png)
#### Standard layout with gobstones single-scenario exercise with untitled test

![image](https://user-images.githubusercontent.com/677436/81303937-c1b7fd00-9052-11ea-8b1f-4e379d0e5bd0.png)
 

#### Kids layout, different head 

![image](https://user-images.githubusercontent.com/677436/82096874-2967eb00-96d8-11ea-8c56-931f82bfae36.png)

##### Kids layout, different board

![image](https://user-images.githubusercontent.com/677436/81251603-095e6a80-8ffa-11ea-8fb0-16b188d6c1c7.png)

##### Kids layout, when no summary present 

:warning:  _This is what will happen if gobstones runner does not yet support summary_

![image](https://user-images.githubusercontent.com/677436/82097449-4cdf6580-96d9-11ea-91ef-3a58b6ed04ae.png)

###### Standard layout, when summary not present in gobstones exercise

:warning:  _This is what will happen if gobstones runner does not yet support summary_


![image](https://user-images.githubusercontent.com/677436/82097973-5f0dd380-96da-11ea-9679-6c1abd828d82.png)
