### PR TITLE
Feature kids tips

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,5 @@ group :development do
   gem 'web-console', '~> 3.7.0'
   gem 'codeclimate-test-reporter', require: nil
 end
+
+gem 'mumuki-domain', github:  'mumuki/mumuki-domain', ref: 'a4ce311bb49a9227bbf7f06ef6e0fddd908f4393'

--- a/README.md
+++ b/README.md
@@ -206,22 +206,29 @@ which are granted to be safe and stable.
 
 ### Bridge Response Format
 
-```json
+```javascript
 {
-  "status": "failed",
-  "guide_finished_by_solution": false,
-  "class_for_progress_list_item":"progress-list-item text-center danger active",
-  "html":"...",
-  "title_html":"...",
-  "button_html":"...",
-  "expectations_html":"...",
-  "remaining_attempts_html":null,
-  "test_results":[
-      {
-        "title":null,
-        "status":"failed",
-        "result":"..."
-      }
+  "status": "passed|passed_with_warnings|failed",
+  "guide_finished_by_solution": "boolean",
+  "class_for_progress_list_item": "string",
+  "html": "string",
+  "remaining_attempts_html": "string" ,
+  "title_html": "string",                         // kids-only
+  "button_html": "string",                        // kids-only
+  "expectations": [                               // kids-only
+    {
+      "status": "passed|failed",
+      "explanation": "string"
+    }
+  ],
+  "tips": [ "string" ],                           // kids-only
+  "test_results": [                               // kids-only
+    {
+      "title": "string",
+      "status": "passed|failed",
+      "result": "string",
+      "summary": "string"
+    }
   ]
 }
 ```
@@ -469,7 +476,7 @@ POST /organization/:id/courses/
 
 ```json
 {
-   "name":"....",
+   "name": "....",
 }
 ```
 
@@ -545,7 +552,7 @@ Sample response body:
 ```json
 {
   "organizations": [
-    { "name": "academy", "contact_email": "a@a.com", "locale": "es-AR", "login_methods": ["facebook"], "books": ["libro"], "public": true, "logo_url":"http://..." },
+    { "name": "academy", "contact_email": "a@a.com", "locale": "es-AR", "login_methods": ["facebook"], "books": ["libro"], "public": true, "logo_url": "http://..." },
     { "name": "alcal", "contact_email": "b@b.com", "locale": "en-US", "login_methods": ["facebook", "github"], "books": ["book"], "public": false }
   ]
 }
@@ -561,7 +568,7 @@ get /organizations/:name
 Sample response body:
 
 ```json
-{ "name": "academy", "contact_email": "a@a.com", "locale": "es-AR", "login_methods": ["facebook"], "books": ["libro"], "public": true, "logo_url":"http://..." }
+{ "name": "academy", "contact_email": "a@a.com", "locale": "es-AR", "login_methods": ["facebook"], "books": ["libro"], "public": true, "logo_url": "http://..." }
 ```
 **Minimal permission**: `janitor` of the organization.
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ which are granted to be safe and stable.
   * `scaleBlocksArea`
   * `scaleState`
   * `showResult`
+* `mumuki.renderers`
+  * `SpeechBubbleRenderer`
+  * `renderSpeechBubbleResultItem`
 * `mumuki.locale`
 * `mumuki.MultipleScenarios`
   * `scenarios`

--- a/app/assets/javascripts/mumuki_laboratory/application/kids.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/kids.js
@@ -180,11 +180,17 @@ mumuki.load(function () {
       $bubble.find('.mu-kids-character-speech-bubble-normal').hide();
       $failedSpeechBubble.show().html(data.title_html);
       $bubble.addClass(data.status);
-      if (data.status === 'passed_with_warnings') {
-        this._appendFirstExpectationHtml($failedSpeechBubble, data);
+
+
+      if (data.status !== 'passed' && data.tips) {
+        console.log(data.tips);
+        this._appendFirstTip($bubble, $failedSpeechBubble, data)
       } else if (data.status === 'failed') {
         this._appendFirstSummaryMessage($bubble, $failedSpeechBubble, data);
+      } else if (data.status === 'passed_with_warnings') {
+        this._appendFirstExpectation($failedSpeechBubble, data);
       }
+
       if (this._shouldDisplayDiscussionsLink(data.status)) {
         $bubble.append(discussionsLinkHtml);
       }
@@ -193,10 +199,6 @@ mumuki.load(function () {
 
     _shouldDisplayDiscussionsLink: function (status) {
       return ['failed', 'passed_with_warnings'].some(it => it === status);
-    },
-
-    _appendFirstExpectationHtml($failedSpeechBubble, data) {
-      $failedSpeechBubble.append(data.expectations_html);
     },
 
     _appendFirstSummaryMessage($bubble, $failedSpeechBubble, data) {
@@ -211,6 +213,21 @@ mumuki.load(function () {
         </div>
       `);
       }
+    },
+
+    _appendFirstExpectation($failedSpeechBubble, data) {
+      $failedSpeechBubble.append(data.expectations_html);
+    },
+
+    _appendFirstTip($bubble, $failedSpeechBubble, data) {
+      $bubble.addClass('with-summary');
+      $failedSpeechBubble.append(`
+      <div class="results-item">
+        <ul class="results-list">
+          <li>${data.tips[0]}</li>
+        </ul>
+      </div>
+    `);
     },
 
     _showOnSuccessPopup: function (data) {

--- a/app/assets/javascripts/mumuki_laboratory/application/kids.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/kids.js
@@ -169,11 +169,11 @@ mumuki.load(function () {
       $bubble.find('.mu-kids-character-speech-bubble-failed').hide();
       $bubble.find('.mu-kids-discussion-link').remove();
       Object.keys(mumuki.kids.resultAction).forEach($bubble.removeClass.bind($bubble));
-      mumuki.kids._getOverlay().hide();
+      mumuki.kids._getOverlay().hide()
     },
 
     _showMessageOnCharacterBubble: function (data) {
-      const renderer = new mumuki.kids.SpeechBubbleRenderer(mumuki.kids._getCharacterBubble());
+      const renderer = new mumuki.renderers.SpeechBubbleRenderer(mumuki.kids._getCharacterBubble());
       renderer.setDiscussionsLinkHtml(discussionsLinkHtml);
       renderer.setResponseData(data);
       renderer.render();

--- a/app/assets/javascripts/mumuki_laboratory/application/kids.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/kids.js
@@ -173,61 +173,11 @@ mumuki.load(function () {
     },
 
     _showMessageOnCharacterBubble: function (data) {
-      let $bubble = mumuki.kids._getCharacterBubble();
-      let $failedSpeechBubble = $bubble.find('.mu-kids-character-speech-bubble-failed');
-
-      $bubble.find('.mu-kids-character-speech-bubble-tabs').hide();
-      $bubble.find('.mu-kids-character-speech-bubble-normal').hide();
-      $failedSpeechBubble.show().html(data.title_html);
-      $bubble.addClass(data.status);
-
-
-      if (data.status !== 'passed' && data.tips) {
-        console.log(data.tips);
-        this._appendFirstTip($bubble, $failedSpeechBubble, data)
-      } else if (data.status === 'failed') {
-        this._appendFirstSummaryMessage($bubble, $failedSpeechBubble, data);
-      } else if (data.status === 'passed_with_warnings') {
-        this._appendFirstExpectation($failedSpeechBubble, data);
-      }
-
-      if (this._shouldDisplayDiscussionsLink(data.status)) {
-        $bubble.append(discussionsLinkHtml);
-      }
+      let renderer = new mumuki.kids.SpeechBubbleRenderer(mumuki.kids._getCharacterBubble());
+      renderer.setDiscussionsLinkHtml(discussionsLinkHtml);
+      renderer.setResponseData(data);
+      renderer.render();
       mumuki.kids._getOverlay().show();
-    },
-
-    _shouldDisplayDiscussionsLink: function (status) {
-      return ['failed', 'passed_with_warnings'].some(it => it === status);
-    },
-
-    _appendFirstSummaryMessage($bubble, $failedSpeechBubble, data) {
-      let summary = data.test_results[0].summary;
-      if (summary) {
-        $bubble.addClass('with-summary');
-        $failedSpeechBubble.append(`
-        <div class="results-item">
-          <ul class="results-list">
-            <li>${summary.message}</li>
-          </ul>
-        </div>
-      `);
-      }
-    },
-
-    _appendFirstExpectation($failedSpeechBubble, data) {
-      $failedSpeechBubble.append(data.expectations_html);
-    },
-
-    _appendFirstTip($bubble, $failedSpeechBubble, data) {
-      $bubble.addClass('with-summary');
-      $failedSpeechBubble.append(`
-      <div class="results-item">
-        <ul class="results-list">
-          <li>${data.tips[0]}</li>
-        </ul>
-      </div>
-    `);
     },
 
     _showOnSuccessPopup: function (data) {

--- a/app/assets/javascripts/mumuki_laboratory/application/kids.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/kids.js
@@ -173,7 +173,7 @@ mumuki.load(function () {
     },
 
     _showMessageOnCharacterBubble: function (data) {
-      let renderer = new mumuki.kids.SpeechBubbleRenderer(mumuki.kids._getCharacterBubble());
+      const renderer = new mumuki.kids.SpeechBubbleRenderer(mumuki.kids._getCharacterBubble());
       renderer.setDiscussionsLinkHtml(discussionsLinkHtml);
       renderer.setResponseData(data);
       renderer.render();

--- a/app/assets/javascripts/mumuki_laboratory/application/speech-bubble-renderer.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/speech-bubble-renderer.js
@@ -21,21 +21,21 @@
       if (this.responseStatus() !== 'passed' && this.responseData.tips) {
         this._appendFirstTip()
       } else if (this.responseStatus() === 'failed') {
-        this._appendFirstSummaryMessage();
+        this._appendFirstFailedTestResultSummary();
       } else if (this.responseStatus() === 'passed_with_warnings') {
-        this._appendFirstExpectation();
+        this._appendFirstExpectationResult();
       }
     }
 
-    _appendFirstSummaryMessage() {
-      let summary = this.responseData.test_results[0].summary;
-      if (summary) {
-        this._appendResultItem(mumuki.kids.renderSpeechBubbleResultItem(summary.message));
+    _appendFirstFailedTestResultSummary() {
+      let failedTestResult = this.responseData.test_results.filter((it) => it.status !== 'failed')[0]
+      if (failedTestResult && failedTestResult.summary) {
+        this._appendResultItem(mumuki.kids.renderSpeechBubbleResultItem(failedTestResult.summary));
       }
     }
 
-    _appendFirstExpectation() {
-      this._appendResultItem(this.responseData.expectations_html);
+    _appendFirstExpectationResult() {
+      this._appendResultItem(mumuki.kids.renderSpeechBubbleResultItem(this.responseData.expectations[0]));
     }
 
     _appendFirstTip() {

--- a/app/assets/javascripts/mumuki_laboratory/application/speech-bubble-renderer.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/speech-bubble-renderer.js
@@ -35,7 +35,7 @@
     }
 
     _appendFirstExpectationResult() {
-      this._appendResultItem(mumuki.kids.renderSpeechBubbleResultItem(this.responseData.expectations[0]));
+      this._appendResultItem(mumuki.kids.renderSpeechBubbleResultItem(this.responseData.expectations[0].explanation));
     }
 
     _appendFirstTip() {

--- a/app/assets/javascripts/mumuki_laboratory/application/speech-bubble-renderer.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/speech-bubble-renderer.js
@@ -9,7 +9,7 @@
         </div>`;
   }
 
-  // A mumuki.kids.SpeechBubbleRenderer allows to configure an speech bubble
+  // A mumuki.renderers.SpeechBubbleRenderer allows to configure a kids speech bubble
   // with the data of a test response from bridge
   class SpeechBubbleRenderer {
     constructor($bubble) {
@@ -18,28 +18,28 @@
     }
 
     _chooseResultItem() {
-      if (this.responseStatus() !== 'passed' && this.responseData.tips) {
+      if (this._responseStatus() !== 'passed' && this._hasTips()) {
         this._appendFirstTip()
-      } else if (this.responseStatus() === 'failed') {
+      } else if (this._responseStatus() === 'failed') {
         this._appendFirstFailedTestResultSummary();
-      } else if (this.responseStatus() === 'passed_with_warnings') {
+      } else if (this._responseStatus() === 'passed_with_warnings') {
         this._appendFirstExpectationResult();
       }
     }
 
     _appendFirstFailedTestResultSummary() {
-      const failedTestResult = this.responseData.test_results.filter((it) => it.status !== 'failed')[0]
+      const failedTestResult = this._failedTestResults()[0]
       if (failedTestResult && failedTestResult.summary) {
-        this._appendResultItem(mumuki.kids.renderSpeechBubbleResultItem(failedTestResult.summary));
+        this._appendResultItem(mumuki.renderers.renderSpeechBubbleResultItem(failedTestResult.summary));
       }
     }
 
     _appendFirstExpectationResult() {
-      this._appendResultItem(mumuki.kids.renderSpeechBubbleResultItem(this.responseData.expectations[0].explanation));
+      this._appendResultItem(mumuki.renderers.renderSpeechBubbleResultItem(this.responseData.expectations[0].explanation));
     }
 
     _appendFirstTip() {
-      this._appendResultItem(mumuki.kids.renderSpeechBubbleResultItem(this.responseData.tips[0]));
+      this._appendResultItem(mumuki.renderers.renderSpeechBubbleResultItem(this.responseData.tips[0]));
     }
 
     _appendResultItem(item) {
@@ -65,6 +65,14 @@
       return this.responseData.status;
     }
 
+    _hasTips() {
+      return this.responseData.tips && this.responseData.tips.length
+    }
+
+    _failedTestResults() {
+      return this.responseData.test_results.filter((it) => it.status === 'failed');
+    }
+
     setDiscussionsLinkHtml(discussionsLinkHtml) {
       this.discussionsLinkHtml = discussionsLinkHtml;
     }
@@ -79,13 +87,13 @@
       this.$bubble.find('.mu-kids-character-speech-bubble-tabs').hide();
       this.$bubble.find('.mu-kids-character-speech-bubble-normal').hide();
       this.$failedArea.show().html(this.responseData.title_html);
-      this._addClass(this.responseStatus());
+      this._addClass(this._responseStatus());
       this._chooseResultItem();
       this._appendDiscussionsLinkHtml();
     }
   }
 
-  mumuki.kids = mumuki.kids || {};
-  mumuki.kids.SpeechBubbleRenderer = SpeechBubbleRenderer;
-  mumuki.kids.renderSpeechBubbleResultItem = renderSpeechBubbleResultItem;
+  mumuki.renderers = mumuki.renderers || {};
+  mumuki.renderers.SpeechBubbleRenderer = SpeechBubbleRenderer;
+  mumuki.renderers.renderSpeechBubbleResultItem = renderSpeechBubbleResultItem;
 })(mumuki)

--- a/app/assets/javascripts/mumuki_laboratory/application/speech-bubble-renderer.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/speech-bubble-renderer.js
@@ -1,0 +1,91 @@
+((mumuki)=> {
+
+  function renderSpeechBubbleResultItem(item) {
+    return `
+        <div class="results-item">
+          <ul class="results-list">
+            <li>${item}</li>
+          </ul>
+        </div>`;
+  }
+
+  // A mumuki.kids.SpeechBubbleRenderer allows to configure an speech bubble
+  // with the data of a test response from bridge
+  class SpeechBubbleRenderer {
+    constructor($bubble) {
+      this.$bubble = $bubble;
+      this.$failedArea = $bubble.find('.mu-kids-character-speech-bubble-failed');
+    }
+
+    _chooseResultItem() {
+      if (this.responseStatus() !== 'passed' && this.responseData.tips) {
+        this._appendFirstTip()
+      } else if (this.responseStatus() === 'failed') {
+        this._appendFirstSummaryMessage();
+      } else if (this.responseStatus() === 'passed_with_warnings') {
+        this._appendFirstExpectation();
+      }
+    }
+
+    _appendFirstSummaryMessage() {
+      let summary = this.responseData.test_results[0].summary;
+      if (summary) {
+        this._appendResultItem(mumuki.kids.renderSpeechBubbleResultItem(summary.message));
+      }
+    }
+
+    _appendFirstExpectation() {
+      this._appendResultItem(this.responseData.expectations_html);
+    }
+
+    _appendFirstTip() {
+      this._appendResultItem(mumuki.kids.renderSpeechBubbleResultItem(this.responseData.tips[0]));
+    }
+
+    _appendResultItem(item) {
+      this._addClass('with-result-item');
+      this.$failedArea.append(item);
+    }
+
+    _addClass(klass) {
+      this.$bubble.addClass(klass);
+    }
+
+    _appendDiscussionsLinkHtml() {
+      if (this._shouldDisplayDiscussionsLink()) {
+        this.$bubble.append(this.discussionsLinkHtml);
+      }
+    }
+
+    _shouldDisplayDiscussionsLink() {
+      return ['failed', 'passed_with_warnings'].some(it => it === this._responseStatus());
+    }
+
+    _responseStatus() {
+      return this.responseData.status;
+    }
+
+    setDiscussionsLinkHtml(discussionsLinkHtml) {
+      this.discussionsLinkHtml = discussionsLinkHtml;
+    }
+
+    setResponseData(responseData) {
+      this.responseData = responseData;
+    }
+
+    // Entry point of the renderer. It just updates the UI, not returning anything
+    // Configure the renderer with `setDiscussionsLinkHtml` and `setResponseData` first.
+    render() {
+      this.$bubble.find('.mu-kids-character-speech-bubble-tabs').hide();
+      this.$bubble.find('.mu-kids-character-speech-bubble-normal').hide();
+      this.$failedArea.show().html(this.responseData.title_html);
+      this._addClass(this.responseStatus());
+      this._chooseResultItem();
+      this._appendDiscussionsLinkHtml();
+    }
+  }
+
+  mumuki.kids = mumuki.kids || {};
+  mumuki.kids.SpeechBubbleRenderer = SpeechBubbleRenderer;
+  mumuki.kids.renderSpeechBubbleResultItem = renderSpeechBubbleResultItem;
+})(mumuki)

--- a/app/assets/javascripts/mumuki_laboratory/application/speech-bubble-renderer.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/speech-bubble-renderer.js
@@ -28,7 +28,7 @@
     }
 
     _appendFirstFailedTestResultSummary() {
-      let failedTestResult = this.responseData.test_results.filter((it) => it.status !== 'failed')[0]
+      const failedTestResult = this.responseData.test_results.filter((it) => it.status !== 'failed')[0]
       if (failedTestResult && failedTestResult.summary) {
         this._appendResultItem(mumuki.kids.renderSpeechBubbleResultItem(failedTestResult.summary));
       }

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_exercise_results.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_exercise_results.scss
@@ -10,6 +10,9 @@
 ul.results-list {
   list-style-type: none;
   padding-left: 10px;
+  li {
+    text-transform: capitalize
+  }
 }
 
 .results-list pre {

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_exercise_results.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_exercise_results.scss
@@ -10,7 +10,7 @@
 ul.results-list {
   list-style-type: none;
   padding-left: 10px;
-  li {
+  li:first-letter {
     text-transform: capitalize
   }
 }

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_exercise_results.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_exercise_results.scss
@@ -30,3 +30,11 @@ ul.results-list {
     color: white;
   }
 }
+
+.mu-single-test-result {
+  .error-text, /* backward compatibility with gobstones runner */
+  .mu-test-result-header {
+    display: block;
+    line-height: 25px;
+  }
+}

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_kids.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_kids.scss
@@ -154,7 +154,7 @@ $kids-speech-tabs-width: 40px;
         }
       }
 
-      &.passed_with_warnings, &.failed.with-summary {
+      &.with-result-item {
         padding-top: 5px;
         padding-bottom: 5px;
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,7 +39,3 @@ module ApplicationHelper
     }.html_safe
   end
 end
-
-def sanitized(html)
-  Mumukit::ContentType::Sanitizer.sanitize html
-end

--- a/app/helpers/contextualization_result_helper.rb
+++ b/app/helpers/contextualization_result_helper.rb
@@ -1,19 +1,6 @@
 module ContextualizationResultHelper
-  def humanized_expectation_result(expectation_result)
-    %Q{#{status_icon(expectation_result[:result])} #{humanized_message expectation_result[:explanation]}}.html_safe
-  end
-
-  def humanized_test_result(test_result)
-    {
-      title: humanized_message(test_result[:title]),
-      result: test_result[:result],
-      status: test_result[:status],
-      summary: humanized_message(test_result.dig(:summary, :message))
-    }
-  end
-
-  def humanized_tip(tip)
-    humanized_message tip
+  def render_affable_expectation_result(affable_expectation_result)
+    %Q{#{status_icon(affable_expectation_result[:result])} #{affable_expectation_result[:explanation]}}.html_safe
   end
 
   def render_feedback?(contextualization)
@@ -34,19 +21,14 @@ module ContextualizationResultHelper
     end
   end
 
-  def humanized_message(message)
-    sanitized Mumukit::ContentType::Markdown.to_html(message, one_liner: true)
-  end
-
   def render_test_result_header(test_result)
-    # TODO markdown on summary message?
     title = test_result[:title]
-    summary_message = test_result.dig(:summary, :message)
+    summary = test_result[:summary]
 
     if title.present?
-      %Q{<strong class="example-title">#{title}</strong>#{summary_message&.prepend(': ')}}.html_safe
-    elsif summary_message
-      %Q{<strong class="example-title">#{summary_message}</strong>}.html_safe
+      %Q{<strong class="example-title">#{title}</strong>#{summary&.prepend(': ')}}.html_safe
+    elsif summary
+      %Q{<strong class="example-title">#{summary}</strong>}.html_safe
     end
   end
 

--- a/app/helpers/contextualization_result_helper.rb
+++ b/app/helpers/contextualization_result_helper.rb
@@ -22,14 +22,7 @@ module ContextualizationResultHelper
   end
 
   def render_test_result_header(test_result)
-    title = test_result[:title]
-    summary = test_result[:summary]
-
-    if title.present?
-      %Q{<strong class="example-title">#{title}</strong>#{summary&.prepend(': ')}}.html_safe
-    elsif summary
-      %Q{<strong class="example-title">#{summary}</strong>}.html_safe
-    end
+    [test_result[:title].presence, test_result[:summary]].compact.join(': ').html_safe
   end
 
   def render_test_results(contextualization)

--- a/app/helpers/contextualization_result_helper.rb
+++ b/app/helpers/contextualization_result_helper.rb
@@ -1,10 +1,19 @@
 module ContextualizationResultHelper
-  def humanized_expectation_result_item(expectation_result)
-    %Q{<li>#{status_icon(expectation_result[:result])} #{humanized_expectation_explanation expectation_result}</li>}.html_safe
+  def humanized_expectation_result(expectation_result)
+    %Q{#{status_icon(expectation_result[:result])} #{humanized_message expectation_result[:explanation]}}.html_safe
   end
 
-  def humanized_expectation_explanation(expectation_result)
-    sanitized Mumukit::ContentType::Markdown.to_html(expectation_result[:explanation], one_liner: true)
+  def humanized_test_result(test_result)
+    {
+      title: humanized_message(test_result[:title]),
+      result: test_result[:result],
+      status: test_result[:status],
+      summary: humanized_message(test_result.dig(:summary, :message))
+    }
+  end
+
+  def humanized_tip(tip)
+    humanized_message tip
   end
 
   def render_feedback?(contextualization)
@@ -23,6 +32,10 @@ module ContextualizationResultHelper
     else
       contextualization.submission_status
     end
+  end
+
+  def humanized_message(message)
+    sanitized Mumukit::ContentType::Markdown.to_html(message, one_liner: true)
   end
 
   def render_test_result_header(test_result)

--- a/app/views/exercise_solutions/_expectations.html.erb
+++ b/app/views/exercise_solutions/_expectations.html.erb
@@ -5,8 +5,8 @@
     <% end %>
 
     <ul class="results-list">
-      <% assignment.humanized_expectation_results.each do |it| %>
-        <li><%= humanized_expectation_result it %></li>
+      <% assignment.affable_expectation_results.each do |it| %>
+        <li><%= render_affable_expectation_result it %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/exercise_solutions/_expectations.html.erb
+++ b/app/views/exercise_solutions/_expectations.html.erb
@@ -6,7 +6,7 @@
 
     <ul class="results-list">
       <% assignment.humanized_expectation_results.each do |it| %>
-        <%= humanized_expectation_result_item it %>
+        <li><%= humanized_expectation_result it %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/layouts/_test_results.html.erb
+++ b/app/views/layouts/_test_results.html.erb
@@ -1,13 +1,15 @@
 <% if contextualization.single_visible_test_result? %>
-  <span class="text-danger"><%= render_test_result_header contextualization.first_test_result %></span>
-  <%= contextualization.first_test_result_html %>
+  <div class="mu-single-test-result">
+    <h5 class="text-danger mu-test-result-header"><%= render_test_result_header contextualization.affable_test_results.first %></h5>
+    <%= contextualization.first_test_result_html %>
+  </div>
 <% else %>
   <strong><%= t :test_results %>:</strong>
-  <ul class="results-list">
+  <ul class="results-list mu-multiple-test-results">
     <% contextualization.affable_test_results.each_with_index do |test_result, index| %>
       <li>
         <% if test_result[:status].failed? %>
-          <span class="text-danger">
+          <span class="text-danger mu-test-result-header">
             <%= status_icon(test_result[:status]) %>
             <%= render_test_result_header test_result %>
             <% unless contextualization.visible_success_output? %>
@@ -15,7 +17,7 @@
             <% end %>
           </span>
         <% else %>
-          <span class="text-success example-title">
+          <span class="text-success mu-test-result-header">
             <%= status_icon(test_result[:status]) %>
             <%= test_result[:title] %>
           </span>

--- a/app/views/layouts/_test_results.html.erb
+++ b/app/views/layouts/_test_results.html.erb
@@ -4,7 +4,7 @@
 <% else %>
   <strong><%= t :test_results %>:</strong>
   <ul class="results-list">
-    <% contextualization.test_results.each_with_index do |test_result, index| %>
+    <% contextualization.affable_test_results.each_with_index do |test_result, index| %>
       <li>
         <% if test_result[:status].failed? %>
           <span class="text-danger">

--- a/lib/mumuki/laboratory/controllers/results_rendering.rb
+++ b/lib/mumuki/laboratory/controllers/results_rendering.rb
@@ -2,7 +2,7 @@ module Mumuki::Laboratory::Controllers::ResultsRendering
   extend ActiveSupport::Concern
 
   included do
-    include ProgressBarHelper, ExerciseInputHelper, ContextualizationResultHelper
+    include ProgressBarHelper, ExerciseInputHelper
 
     before_action :set_guide_previously_done!
   end
@@ -10,23 +10,25 @@ module Mumuki::Laboratory::Controllers::ResultsRendering
   def render_results_json(assignment, results = {})
     if assignment.input_kids?
       merge_kids_specific_renders(assignment, results)
-      render_results = 'exercise_solutions/kids_results'
+      layout = 'exercise_solutions/kids_results'
     else
-      render_results = 'exercise_solutions/results'
+      layout = 'exercise_solutions/results'
     end
 
-    render json: results.merge(progress_json).merge(
-        html: render_results_html(render_results, assignment),
-        remaining_attempts_html: remaining_attempts_text(assignment))
+    render json: results
+                  .merge(progress_json)
+                  .merge(
+                    html: render_results(layout, assignment),
+                    remaining_attempts_html: remaining_attempts_text(assignment))
   end
 
   def merge_kids_specific_renders(assignment, results)
     results.merge!(
-        button_html: render_results_button_html(assignment),
-        title_html: render_results_title_html(assignment),
-        expectations: humanized_expectations_results(assignment),
-        tips: humanized_tips(assignment),
-        test_results: humanized_test_results(assignment))
+        button_html: render_results_button(assignment),
+        title_html: render_results_title(assignment),
+        expectations: assignment.affable_expectation_results,
+        tips: assignment.affable_tips,
+        test_results: assignment.affable_test_results)
   end
 
   def progress_json
@@ -36,17 +38,17 @@ module Mumuki::Laboratory::Controllers::ResultsRendering
     }
   end
 
-  def render_results_html(results_partial, assignment)
+  def render_results(results_partial, assignment)
     render_to_string partial: results_partial,
                      locals: {assignment: assignment}
   end
 
-  def render_results_title_html(assignment)
+  def render_results_title(assignment)
     render_to_string partial: 'exercise_solutions/results_title',
                      locals: {contextualization: assignment}
   end
 
-  def render_results_button_html(assignment)
+  def render_results_button(assignment)
     render_to_string partial: 'exercise_solutions/kids_results_button',
                      locals: {assignment: assignment}
   end
@@ -57,17 +59,5 @@ module Mumuki::Laboratory::Controllers::ResultsRendering
 
   def set_guide_previously_done!
     @guide_previously_done = @exercise.guide_done_for?(current_user)
-  end
-
-  def humanized_expectations_results(assignment)
-    assignment.humanized_expectation_results.map { |it| humanized_expectation_result it }
-  end
-
-  def humanized_tips(assignment)
-    assignment.tips.map { |it| humanized_tip it }
-  end
-
-  def humanized_test_results(assignment)
-    assignment.test_results.map { |it| humanized_test_result it }
   end
 end

--- a/lib/mumuki/laboratory/controllers/results_rendering.rb
+++ b/lib/mumuki/laboratory/controllers/results_rendering.rb
@@ -2,7 +2,7 @@ module Mumuki::Laboratory::Controllers::ResultsRendering
   extend ActiveSupport::Concern
 
   included do
-    include ProgressBarHelper, ExerciseInputHelper
+    include ProgressBarHelper, ExerciseInputHelper, ContextualizationResultHelper
 
     before_action :set_guide_previously_done!
   end
@@ -24,9 +24,9 @@ module Mumuki::Laboratory::Controllers::ResultsRendering
     results.merge!(
         button_html: render_results_button_html(assignment),
         title_html: render_results_title_html(assignment),
-        expectations_html: render_results_expectations_html(assignment),
-        tips: assignment.tips, # TODO markdown on summary message?
-        test_results: assignment.test_results) # TODO markdown on summary message?
+        expectations: humanized_expectations_results(assignment),
+        tips: humanized_tips(assignment),
+        test_results: humanized_test_results(assignment))
   end
 
   def progress_json
@@ -51,16 +51,23 @@ module Mumuki::Laboratory::Controllers::ResultsRendering
                      locals: {assignment: assignment}
   end
 
-  def render_results_expectations_html(assignment)
-    render_to_string partial: 'exercise_solutions/expectations',
-                     locals: {assignment: assignment}
-  end
-
   def guide_finished_by_solution?
     !@guide_previously_done && @exercise.guide_done_for?(current_user)
   end
 
   def set_guide_previously_done!
     @guide_previously_done = @exercise.guide_done_for?(current_user)
+  end
+
+  def humanized_expectations_results(assignment)
+    assignment.humanized_expectation_results.map { |it| humanized_expectation_result it }
+  end
+
+  def humanized_tips(assignment)
+    assignment.tips.map { |it| humanized_tip it }
+  end
+
+  def humanized_test_results(assignment)
+    assignment.test_results.map { |it| humanized_test_result it }
   end
 end

--- a/lib/mumuki/laboratory/controllers/results_rendering.rb
+++ b/lib/mumuki/laboratory/controllers/results_rendering.rb
@@ -25,6 +25,7 @@ module Mumuki::Laboratory::Controllers::ResultsRendering
         button_html: render_results_button_html(assignment),
         title_html: render_results_title_html(assignment),
         expectations_html: render_results_expectations_html(assignment),
+        tips: assignment.tips, # TODO markdown on summary message?
         test_results: assignment.test_results) # TODO markdown on summary message?
   end
 

--- a/spec/controllers/exercise_solutions_controller_spec.rb
+++ b/spec/controllers/exercise_solutions_controller_spec.rb
@@ -55,15 +55,16 @@ describe ExerciseSolutionsController, organization_workspace: :test do
 
       it { expect(response.body).to json_eq({ status: :failed, guide_finished_by_solution: false },
                                             except: [:class_for_progress_list_item, :html, :remaining_attempts_html,
-                                                     :title_html, :button_html, :expectations_html, :test_results]) }
+                                                     :title_html, :button_html, :expectations, :test_results, :tips]) }
 
       it 'includes kids specific renders' do
         body = JSON.parse(response.body)
 
         expect(body.key?('button_html')).to be true
         expect(body.key?('title_html')).to be true
-        expect(body.key?('expectations_html')).to be true
+        expect(body.key?('expectations')).to be true
         expect(body.key?('test_results')).to be true
+        expect(body.key?('tips')).to be true
       end
     end
   end

--- a/spec/helpers/test_results_rendering_spec.rb
+++ b/spec/helpers/test_results_rendering_spec.rb
@@ -7,26 +7,19 @@ describe ContextualizationResultHelper do
   helper ContextualizationResultHelper
 
 
-  describe 'humanized_expectation_result' do
-    let(:html) { humanized_expectation_result expectation_result }
+  describe 'render_affable_expectation_result' do
+    let(:html) { render_affable_expectation_result expectation_result }
 
     context 'plain explanation' do
       let(:expectation_result) { {result: :failed, explanation: 'you must delegate'} }
 
-      it { expect(html).to eq '<li><i class="fa fa-times-circle text-danger status-icon"></i> you must delegate</li>' }
-
+      it { expect(html).to eq '<i class="fa fa-times-circle text-danger status-icon"></i> you must delegate' }
     end
 
     context 'html explanation' do
       let(:expectation_result) { {result: :failed, explanation: 'you must use <strong>if</strong>'} }
 
-      it { expect(html).to eq '<li><i class="fa fa-times-circle text-danger status-icon"></i> you must use <strong>if</strong></li>' }
-    end
-
-    context 'markdown explanation' do
-      let(:expectation_result) { {result: :failed, explanation: 'you must call `fooBar`'} }
-
-      it { expect(html).to eq '<li><i class="fa fa-times-circle text-danger status-icon"></i> you must call <code>fooBar</code></li>' }
+      it { expect(html).to eq '<i class="fa fa-times-circle text-danger status-icon"></i> you must use <strong>if</strong>' }
     end
   end
 
@@ -76,9 +69,9 @@ describe ContextualizationResultHelper do
           let(:problem) { build(:problem, language: language) }
           let(:contextualization) { Assignment.new(
             exercise: problem,
-            test_results: [{title: 'foo is 2', status: :failed, result: 'foo is undefined', summary: {type: 'undefined_variable', message: 'you are using things that are **not defined**'}}]) }
+            test_results: [{title: 'foo is 2', status: :failed, result: 'foo is undefined', summary: {type: 'undefined_variable', message: 'you are using things that are _not defined_'}}]) }
 
-          it { expect(html).to include '<strong class="example-title">foo is 2</strong>: you are using things that are **not defined**' }
+          it { expect(html).to include '<strong class="example-title">foo is 2</strong>: you are using things that are <em>not defined</em>' }
           it { expect(html).to include "<i class=\"fa fa-times-circle text-danger status-icon\"></i>" }
           it { expect(html).to include '<p>foo is undefined</p>' }
         end
@@ -88,9 +81,9 @@ describe ContextualizationResultHelper do
           let(:problem) { build(:problem, language: language) }
           let(:contextualization) { Assignment.new(
             exercise: problem,
-            test_results: [{title: '', status: :failed, result: 'foo is undefined', summary: {type: 'undefined_variable', message: 'you are using things that are **not defined**'}}]) }
+            test_results: [{title: '', status: :failed, result: 'foo is undefined', summary: {type: 'undefined_variable', message: 'you are using things that are _not defined_'}}]) }
 
-          it { expect(html).to include '<strong class="example-title">you are using things that are **not defined**</strong>' }
+          it { expect(html).to include '<strong class="example-title">you are using things that are <em>not defined</em></strong>' }
           it { expect(html).to include "<i class=\"fa fa-times-circle text-danger status-icon\"></i>" }
           it { expect(html).to include '<p>foo is undefined</p>' }
         end

--- a/spec/helpers/test_results_rendering_spec.rb
+++ b/spec/helpers/test_results_rendering_spec.rb
@@ -7,8 +7,8 @@ describe ContextualizationResultHelper do
   helper ContextualizationResultHelper
 
 
-  describe 'humanized_expectation_result_item' do
-    let(:html) { humanized_expectation_result_item expectation_result }
+  describe 'humanized_expectation_result' do
+    let(:html) { humanized_expectation_result expectation_result }
 
     context 'plain explanation' do
       let(:expectation_result) { {result: :failed, explanation: 'you must delegate'} }

--- a/spec/helpers/test_results_rendering_spec.rb
+++ b/spec/helpers/test_results_rendering_spec.rb
@@ -48,7 +48,7 @@ describe ContextualizationResultHelper do
             test_results: [{title: '2 is 2', status: :failed, result: 'something _went_ wrong'}]) }
 
           it { expect(html).to include "<i class=\"fa fa-times-circle text-danger status-icon\"></i>" }
-          it { expect(html).to include "<strong class=\"example-title\">2 is 2</strong>" }
+          it { expect(html).to include "2 is 2" }
           it { expect(html).to include "<pre>something _went_ wrong</pre>" }
         end
 
@@ -60,7 +60,7 @@ describe ContextualizationResultHelper do
             test_results: [{title: '2 is 2', status: :failed, result: 'something went _really_ wrong'}]) }
 
           it { expect(html).to include "<i class=\"fa fa-times-circle text-danger status-icon\"></i>" }
-          it { expect(html).to include "<strong class=\"example-title\">2 is 2</strong>" }
+          it { expect(html).to include "2 is 2" }
           it { expect(html).to include "<p>something went <em>really</em> wrong</p>" }
         end
 
@@ -71,7 +71,7 @@ describe ContextualizationResultHelper do
             exercise: problem,
             test_results: [{title: 'foo is 2', status: :failed, result: 'foo is undefined', summary: {type: 'undefined_variable', message: 'you are using things that are _not defined_'}}]) }
 
-          it { expect(html).to include '<strong class="example-title">foo is 2</strong>: you are using things that are <em>not defined</em>' }
+          it { expect(html).to include 'foo is 2: you are using things that are <em>not defined</em>' }
           it { expect(html).to include "<i class=\"fa fa-times-circle text-danger status-icon\"></i>" }
           it { expect(html).to include '<p>foo is undefined</p>' }
         end
@@ -83,7 +83,7 @@ describe ContextualizationResultHelper do
             exercise: problem,
             test_results: [{title: '', status: :failed, result: 'foo is undefined', summary: {type: 'undefined_variable', message: 'you are using things that are _not defined_'}}]) }
 
-          it { expect(html).to include '<strong class="example-title">you are using things that are <em>not defined</em></strong>' }
+          it { expect(html).to include 'you are using things that are <em>not defined</em>' }
           it { expect(html).to include "<i class=\"fa fa-times-circle text-danger status-icon\"></i>" }
           it { expect(html).to include '<p>foo is undefined</p>' }
         end


### PR DESCRIPTION
### :dart: PR Goal

This PR adds support for showing tips - _aka assistance rules_ - in kids layout. It also implements full-client side rendering of results: `test_results`, `tips` and `expectation_results` HTML is now rendered in client. 

### :eyes: Relations

 * Fixes #1364 
 * Related to #1397 
 * Rebase after #1399 

### :memo:   Additional notes

 * This PR heavily relays on the `affable` feature developed in https://github.com/mumuki/mumuki-domain/pull/87. 
 * Also, it fixes some concerns described in #1399 about markdown rendering and `const` keywords.
 * Client-side rendering is inspired the [offline mode fork](https://github.com/flbulgarelli/mumuki-laboratory/)

### :spiral_notepad:  More details

[Single feedback message proposal](https://docs.google.com/document/d/1-wFSTVtjwEM4hieVb7I-AAeXngmx_Sx77AeEQW-P1Bk/edit#)

### :camera: Screenshot

![image](https://user-images.githubusercontent.com/677436/81341979-d6af8300-9088-11ea-864e-628a6653e224.png)

### :ballot_box_with_check:  Pending tasks

- [x] Capitalize tip in client-side
- [x] Actually favor `const` keyword
- [x] Do more integration testing old and new gobstones runners and other runners