### PR TITLE
Moving multiple-files class to parent

### DIFF
--- a/app/views/layouts/exercise_inputs/editors/_multiple_files.html.erb
+++ b/app/views/layouts/exercise_inputs/editors/_multiple_files.html.erb
@@ -26,8 +26,8 @@
       <% end %>
     </div>
 
-    <div class="mu-overlapped">
-      <a class="editor-resize multiple-files" title="<%= t(:fullscreen) %> (F11)">
+    <div class="mu-overlapped multiple-files">
+      <a class="editor-resize" title="<%= t(:fullscreen) %> (F11)">
         <span class="fa-stack fa-lg">
           <i class="fa fa-square-o fa-stack-2x"></i>
           <i class="fa fa-expand fa-stack-1x"></i>


### PR DESCRIPTION
Fixes #1415 

This is a silly bug because multiple-editor have being taken into account, but class was inserted in the wrong place. 

