### PR TITLE
Using helper method to render passing test_results as well

### DIFF
--- a/app/helpers/contextualization_result_helper.rb
+++ b/app/helpers/contextualization_result_helper.rb
@@ -21,8 +21,17 @@ module ContextualizationResultHelper
     end
   end
 
+  def render_test_result_title(test_result)
+    [test_result[:title].presence, test_result[:summary]].compact.join(': ')
+  end
+
   def render_test_result_header(test_result)
-    [test_result[:title].presence, test_result[:summary]].compact.join(': ').html_safe
+    %Q{
+      <span class="text-#{status_class_for(test_result[:status])} mu-test-result-header">
+        #{status_icon(test_result[:status])}
+        #{render_test_result_title test_result}
+      </span>
+    }.html_safe
   end
 
   def render_test_results(contextualization)

--- a/app/helpers/icons_helper.rb
+++ b/app/helpers/icons_helper.rb
@@ -39,6 +39,10 @@ module IconsHelper
     icon_class_for(exercise.assignment_for(current_user))
   end
 
+  def status_class_for(status_like)
+    icon_class_for(status_like.to_submission_status)
+  end
+
   def icon_class_for(iconizable)
     iconizable.iconize[:class].to_s
   end

--- a/app/views/layouts/_test_results.html.erb
+++ b/app/views/layouts/_test_results.html.erb
@@ -8,24 +8,15 @@
   <ul class="results-list mu-multiple-test-results">
     <% contextualization.affable_test_results.each_with_index do |test_result, index| %>
       <li>
+        <%= render_test_result_header test_result %>
         <% if test_result[:status].failed? %>
-          <span class="text-danger mu-test-result-header">
-            <%= status_icon(test_result[:status]) %>
-            <%= render_test_result_header test_result %>
-            <% unless contextualization.visible_success_output? %>
-              <a data-toggle="collapse" href="#example-result-<%= index %>"  class="example-see-more"><%= t :view_details %></a>
-            <% end %>
-          </span>
-        <% else %>
-          <span class="text-success mu-test-result-header">
-            <%= status_icon(test_result[:status]) %>
-            <%= render_test_result_header test_result %>
-          </span>
+          <% unless contextualization.visible_success_output? %>
+            <a data-toggle="collapse" href="#example-result-<%= index %>"  class="example-see-more"><%= t :view_details %></a>
+            <div class="example-result collapse <%= 'in' if contextualization.visible_success_output? %>" id="example-result-<%= index %>">
+              <%= contextualization.test_result_html test_result %>
+            </div>
+          <% end %>
         <% end %>
-
-        <div class="example-result collapse <%= 'in' if contextualization.visible_success_output? %>" id="example-result-<%= index %>">
-          <%= contextualization.test_result_html test_result %>
-        </div>
       </li>
     <% end %>
   </ul>

--- a/app/views/layouts/_test_results.html.erb
+++ b/app/views/layouts/_test_results.html.erb
@@ -19,7 +19,7 @@
         <% else %>
           <span class="text-success mu-test-result-header">
             <%= status_icon(test_result[:status]) %>
-            <%= test_result[:title] %>
+            <%= render_test_result_header test_result %>
           </span>
         <% end %>
 


### PR DESCRIPTION
Resolves #1422 

@flbulgarelli is it safe to assume that a passing test_result won't have a summary? If it's not, is it safe to assume that we would like to display them anyway? :smile: 

Reviewer tip: The issue is solved in the first commit. The second commit just does a visual refactor to avoid duplicated logic and rendering of unseeable (? test_results details.