### PR TITLE
Fixing bug that prevents blocks in non-kids layout

### DIFF
--- a/app/views/layouts/exercise_inputs/editors/_custom.html.erb
+++ b/app/views/layouts/exercise_inputs/editors/_custom.html.erb
@@ -4,4 +4,4 @@
 
 <%= form.hidden_field :content, id: "mu-custom-editor-value", value: @current_content %>
 <%= form.hidden_field :content_extra, id: "mu-custom-editor-extra", value: @exercise.extra %>
-<%= form.hidden_field :content, id: "mu-custom-editor-test", value: @exercise.test %>
+<%= form.hidden_field :content_test, id: "mu-custom-editor-test", value: @exercise.test %>


### PR DESCRIPTION
# :dart: Goal 

Allow blocks to be used with non-kids - input_bottom and input_right - layouts

# :memo: Details 

Since long time ago, we wanted blocks to work with other layouts than primary. That wasn't a new feature, but a design goal - primaria.mumuki.io was based in he combination of both kids layout and custom editor. 

However, for some reason that was not working, although a lot of time and effort had been inverted in decoupling the layout, the language and the editor customization. 

In turned out that to my surprise blocks were actually near to work, but it was just a silly bug introduced in early stages of the project in mid 2018  that prevented that to work. This PR fixes that issue. 

# :camera: Screenshots

## :older_adult:  Before change

As you will see, blocks are properly rendered and even work, but a weird error is raised when evaluating the code server-side:

![image](https://user-images.githubusercontent.com/677436/87209305-c1a0db80-c2e7-11ea-87bd-db1712696a5a.png)

After the initial submission, assignment is broken: 

![image](https://user-images.githubusercontent.com/677436/87209381-0298f000-c2e8-11ea-9ee1-541236e6edea.png)

## :baby: After change

Now it works!

![image](https://user-images.githubusercontent.com/677436/87209032-ea74a100-c2e6-11ea-9bbe-fa2b0c24d00c.png)

![image](https://user-images.githubusercontent.com/677436/87209525-98347f80-c2e8-11ea-94b4-c4680b023dea.png)

# :back: Backward compatibility

This change is full-backward compatible 

# :eyes: See also

* I came across with this issue and its solution while working in #1424 , which was also preventing puzzles to work on some situations
* All the screenshots are based on https://mumuki.io/primaria/exercises/4931-un-jardin-de-procedimientos-sembrando-futuro-una-definicion-infinitos-usos. Only the layout was changed