### PR TITLE
Add welcome email

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,19 +1,19 @@
 class UserMailer < ApplicationMailer
 
   def we_miss_you_reminder(user, cycles)
-    send_reminder! user, :we_miss_you, "#{cycles.ordinalize}_reminder"
+    build_email user, :we_miss_you, "#{cycles.ordinalize}_reminder"
   end
 
   def no_submissions_reminder(user)
-    send_reminder! user, :start_using_mumuki, "no_submissions_reminder"
+    build_email user, :start_using_mumuki, 'no_submissions_reminder'
   end
 
   private
 
-  def send_reminder!(user, subject, template_name)
+  def build_email(user, subject, template_name, organization = nil)
     @user = user
     @unsubscribe_code = User.unsubscription_verifier.generate(user.id)
-    @organization = user.last_organization
+    @organization = organization || user.last_organization
 
     I18n.with_locale(@organization.locale) do
       mail to: user.email,

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,7 +1,6 @@
 class UserMailer < ApplicationMailer
   def welcome_email(user, organization)
-    template = organization.welcome_email_template.try { |it| { inline: it } } || 'welcome'
-    build_email user, :welcome, template, organization
+    build_email user, :welcome, { inline: organization.welcome_email_template }, organization
   end
 
   def we_miss_you_reminder(user, cycles)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,4 +1,7 @@
 class UserMailer < ApplicationMailer
+  def welcome_email(user, organization)
+    build_email user, :welcome, 'welcome', organization
+  end
 
   def we_miss_you_reminder(user, cycles)
     build_email user, :we_miss_you, "#{cycles.ordinalize}_reminder"

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,7 +1,7 @@
 class UserMailer < ApplicationMailer
   def welcome_email(user, organization)
     with_locale(user, organization) do
-      organization_name = organization[:display_name] || t(:your_new_organization)
+      organization_name = organization.display_name || t(:your_new_organization)
       build_email t(:welcome, name: organization_name), { inline: organization.welcome_email_template }
     end
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,14 +1,15 @@
 class UserMailer < ApplicationMailer
   def welcome_email(user, organization)
-    build_email user, :welcome, { inline: organization.welcome_email_template }, organization
+    organization_name = organization[:display_name] || t(:your_new_organization)
+    build_email user, t(:welcome, name: organization_name), { inline: organization.welcome_email_template }, organization
   end
 
   def we_miss_you_reminder(user, cycles)
-    build_email user, :we_miss_you, "#{cycles.ordinalize}_reminder"
+    build_email user, t(:we_miss_you), "#{cycles.ordinalize}_reminder"
   end
 
   def no_submissions_reminder(user)
-    build_email user, :start_using_mumuki, 'no_submissions_reminder'
+    build_email user, t(:start_using_mumuki), 'no_submissions_reminder'
   end
 
   private
@@ -20,7 +21,7 @@ class UserMailer < ApplicationMailer
 
     I18n.with_locale(@organization.locale) do
       mail to: user.email,
-           subject: t(subject),
+           subject: subject,
            content_type: 'text/html',
            body: render(template)
     end

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -260,6 +260,7 @@ en:
   view_details: View details
   want_permissions: The next user requires permissions
   we_miss_you: We miss you!
+  welcome: Welcome to your new organization!
   working: "Working"
   wrong_answer: The answer is wrong
   you_must_sign_in_before_submitting: You must sign in before submitting your solutions

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -93,7 +93,9 @@ en:
   first_name: First Name
   forbidden_explanation: You are not allowed to see this content.
   format: Format
+  fullscreen: "Fullscreen"
   gender: Gender
+  get_messages: "View messages"
   go_to: 'Go to %{organization}'
   gone_explanation: This content is no longer available.
   guide: Guide
@@ -162,6 +164,7 @@ en:
   not_in_any_organizations: It seems you aren't in any organizations yet!
   notify_problem_with_exercise: Report a bug
   office: Office
+  only_landscape_support: Please, rotate your tablet or cellphone to continue practicing
   opened: Open
   opened_count: '%{count} opened'
   other: Other
@@ -230,6 +233,7 @@ en:
   submissions_for: Submissions for %{exercise}
   subscribe: Subscribe
   tag: Tags
+  task: Task
   teacher_info: Information for teachers
   tell_us_how: Please tell us how this happened!
   tell_us_if_our_error: If you think this is our fault, %{issues}
@@ -260,12 +264,9 @@ en:
   view_details: View details
   want_permissions: The next user requires permissions
   we_miss_you: We miss you!
-  welcome: Welcome to your new organization!
+  welcome: Welcome to %{name}!
   working: "Working"
   wrong_answer: The answer is wrong
   you_must_sign_in_before_submitting: You must sign in before submitting your solutions
   you_never_submitted_solutions: It seems that you've never submitted solutions since you created your account.
-  fullscreen: "Fullscreen"
-  get_messages: "View messages"
-  task: Task
-  only_landscape_support: Please, rotate your tablet or cellphone to continue practicing
+  your_new_organization: your new organization

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -284,6 +284,7 @@ es:
   view_details: Ver detalles
   want_permissions: El siguiente usuario requiere permisos
   we_miss_you: ¡Te extrañamos!
+  welcome: Te damos la bienvenida a tu nueva organización!
   will_paginate:
     previous_label: "&#8592; Anterior"
     next_label: "Siguiente &#8594;"

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -99,7 +99,9 @@ es:
   first_name: Nombre
   forbidden_explanation: Es decir que no tenés autorización para ver este contenido. <br> ¿Puede que hayas ingresado con una cuenta incorrecta?
   format: Dar formato
+  fullscreen: "Pantalla completa"
   gender: Género
+  get_messages: "Ver mensajes"
   go_to: 'Ir a %{organization}'
   gone_explanation: Este contenido ya no está disponible.
   guide: Lección
@@ -176,6 +178,7 @@ es:
   not_in_any_organizations: ¡Parece que no estás en ninguna organización todavía!
   notify_problem_with_exercise: Reportá un bug
   office: Secretaría
+  only_landscape_support: Por favor, rotá tu tablet o celular para realizar ejercicios
   opened: Abierta
   opened_count:
     one: '1 abierta'
@@ -253,6 +256,7 @@ es:
   submissions_count: Soluciones
   submissions_for: Soluciones para %{exercise}
   tag: Etiquetas
+  task: Consigna
   teacher_info: Información para docentes
   tell_us_how: ¡Contanos cómo te pasó esto!
   tell_us_if_our_error: Si pensás que es un error nuestro, %{issues}
@@ -284,7 +288,7 @@ es:
   view_details: Ver detalles
   want_permissions: El siguiente usuario requiere permisos
   we_miss_you: ¡Te extrañamos!
-  welcome: Te damos la bienvenida a tu nueva organización!
+  welcome: Te damos la bienvenida a %{name}!
   will_paginate:
     previous_label: "&#8592; Anterior"
     next_label: "Siguiente &#8594;"
@@ -293,7 +297,4 @@ es:
   wrong_answer: La respuesta no es correcta
   you_must_sign_in_before_submitting: Tenés que iniciar sesión antes de empezar a enviar tus soluciones
   you_never_submitted_solutions: Parece que nunca enviaste soluciones desde que creaste tu cuenta.
-  fullscreen: "Pantalla completa"
-  get_messages: "Ver mensajes"
-  task: Consigna
-  only_landscape_support: Por favor, rotá tu tablet o celular para realizar ejercicios
+  your_new_organization: tu nueva organización

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -265,6 +265,7 @@ pt:
   username: Nome de usuário
   view_details: Ver detalhes
   want_permissions: O próximo usuário requer permissões
+  welcome: Convidamos você a sua nova organização!
   working: Processamento
   wrong_answer: A resposta não é correta
   you_must_sign_in_before_submitting: Você deve fazer o login antes de começar a enviar suas soluções

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -171,6 +171,7 @@ pt:
   not_in_any_organizations: Parece que você ainda não está em nenhuma organização!
   notify_problem_with_exercise: Relatar um erro
   office: Secretariado
+  only_landscape_support: Por favor, gire seu tablet ou celular para realizar exercícios
   opened: Aberto
   opened_count: '%{count} aberto'
   organizations: Organizações
@@ -240,6 +241,7 @@ pt:
   submissions_for: Soluções para %{exercise}
   subscribe: se inscrever
   tag: Etiquetas
+  task: Tarefa
   teacher_info: Informação para professores
   tell_us_how: Conte-nos como isso aconteceu com você!
   tell_us_if_our_error: Se você acha que é nosso erro, %{issues}
@@ -265,9 +267,8 @@ pt:
   username: Nome de usuário
   view_details: Ver detalhes
   want_permissions: O próximo usuário requer permissões
-  welcome: Convidamos você a sua nova organização!
+  welcome: Convidamos você a {name}!
   working: Processamento
   wrong_answer: A resposta não é correta
   you_must_sign_in_before_submitting: Você deve fazer o login antes de começar a enviar suas soluções
-  task: Tarefa
-  only_landscape_support: Por favor, gire seu tablet ou celular para realizar exercícios
+  your_new_organization: sua nova organização

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 5.1.6"
 
-  s.add_dependency 'mumuki-domain', '~> 7.8.0'
+  s.add_dependency 'mumuki-domain', '~> 7.8.1'
   s.add_dependency 'mumukit-bridge', '~> 4.1'
   s.add_dependency 'mumukit-login', '~> 7.3'
   s.add_dependency 'mumukit-nuntius', '~> 6.1'

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -148,21 +148,21 @@ RSpec.describe UserMailer, type: :mailer do
 
       context "registered 1 week ago" do
         it { expect(user.should_remind?).to be true }
-        it { expect(reminder.body.encoded).to include("you've never submitted solutions") }
+        it { expect(reminder.body.encoded).to include('you&#39;ve never submitted solutions') }
       end
 
       context "last submission 2 weeks ago" do
         let(:days_since_user_creation) { 16 }
 
         it { expect(user.should_remind?).to be true }
-        it { expect(reminder.body.encoded).to include("you've never submitted solutions") }
+        it { expect(reminder.body.encoded).to include('you&#39;ve never submitted solutions') }
       end
 
       context "last submission 3 weeks ago" do
         let(:days_since_user_creation) { 26 }
 
         it { expect(user.should_remind?).to be true }
-        it { expect(reminder.body.encoded).to include("you've never submitted solutions") }
+        it { expect(reminder.body.encoded).to include('you&#39;ve never submitted solutions') }
       end
 
       context "last submission 4 weeks ago" do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -178,4 +178,26 @@ RSpec.describe UserMailer, type: :mailer do
       it { expect(user.should_remind?).to be false }
     end
   end
+
+  describe 'welcome email' do
+    let(:email) { UserMailer.welcome_email(user, organization) }
+
+    let(:non_custom_welcome_orga) { create :organization }
+    let(:custom_welcome_orga) { create :organization, welcome_email_template: 'hello <%= @user.first_name %>!' }
+
+    let(:user) { create :user, first_name: 'some name' }
+
+    context 'when organization does not have a custom welcome template' do
+      let(:organization) { non_custom_welcome_orga }
+
+      it { expect(email.body.encoded).to_not include 'welcome some name!' }
+      it { expect(email.body.encoded).to include 'Mumuki' }
+    end
+
+    context 'when organization does have a custom welcome template' do
+      let(:organization) { custom_welcome_orga }
+
+      it { expect(email.body.encoded).to eq 'hello some name!' }
+    end
+  end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -186,14 +186,7 @@ RSpec.describe UserMailer, type: :mailer do
     let(:custom_welcome_orga) { create :organization, welcome_email_template: 'hello <%= @user.first_name %>!' }
 
     let(:user) { create :user, first_name: 'some name' }
-
-    context 'when organization does not have a custom welcome template' do
-      let(:organization) { non_custom_welcome_orga }
-
-      it { expect(email.body.encoded).to_not include 'welcome some name!' }
-      it { expect(email.body.encoded).to include 'Mumuki' }
-    end
-
+    
     context 'when organization does have a custom welcome template' do
       let(:organization) { custom_welcome_orga }
 


### PR DESCRIPTION
~:warning: Do not merge yet! :warning:~

~Need to work on making welcome email customizable by organization.~

~(Also email template is just a copy-paste, need to localize stuff)~

Depends on mumuki/mumuki-domain#105.

^ Yeah, these two PRs are co-dependent, which is not good. I'm thinking the right thing would be to move any email-sending code to laboratory, and possibly monkey-patch domain's classes there... thoughts @luchotc ?

In this specific case this could be solved by merging the `welcome_email_template` migration first, and then the rest of the domain PR after this one, but either way using `UserMailer` in domain which is defined in laboratory doesn't seem like a good idea