### PR TITLE
Feature client side prerender

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,6 @@ which are granted to be safe and stable.
 {
   "status": "passed|passed_with_warnings|failed",
   "guide_finished_by_solution": "boolean",
-  "class_for_progress_list_item": "string",
   "html": "string",
   "remaining_attempts_html": "string" ,
   "title_html": "string",                         // kids-only

--- a/app/assets/javascripts/mumuki_laboratory/application/bridge.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/bridge.js
@@ -27,9 +27,18 @@ var mumuki = mumuki || {};
       data: solution
     });
 
-    return $.ajax(request).done(function (result) {
+    return $.ajax(request).then(preRenderResult).done(function (result) {
       lastSubmission = { content: solution, result: result };
     });
+  }
+
+
+  /**
+   * Pre-renders some html parts of submission UI
+   * */
+  function preRenderResult(result) {
+    result.class_for_progress_list_item = mumuki.renderers.progressListItemClassForStatus(result.status, true)
+    return result;
   }
 
   mumuki.load(function () {
@@ -67,7 +76,7 @@ var mumuki = mumuki || {};
       } else {
         return sendNewSolution(solution);
       }
-    },
+    }
   };
 
   mumuki.bridge = {

--- a/app/assets/javascripts/mumuki_laboratory/application/progress.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/progress.js
@@ -2,6 +2,9 @@ var mumuki = mumuki || {};
 
 (function (mumuki) {
 
+  /**
+   * Updates the current exercise progress indicator
+   * */
   mumuki.updateProgressBarAndShowModal = function (data) {
     $('.progress-list-item.active').attr('class', data.class_for_progress_list_item);
     if(data.guide_finished_by_solution) $('#guide-done').modal();

--- a/app/assets/javascripts/mumuki_laboratory/application/results-renderer.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/results-renderer.js
@@ -15,6 +15,7 @@
       case "failed":               return "fa-times-circle";
       case "passed_with_warnings": return "fa-exclamation-circle";
       case "passed":               return "fa-check-circle";
+      case "pending":              return "fa-circle";
     }
   }
 

--- a/app/assets/javascripts/mumuki_laboratory/application/results-renderer.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/results-renderer.js
@@ -45,6 +45,6 @@
 
   mumuki.renderers = mumuki.renderers || {};
   mumuki.renderers.classForStatus = classForStatus;
-  mumuki.renderers.classForStatus = iconForStatus;
+  mumuki.renderers.iconForStatus = iconForStatus;
   mumuki.renderers.progressListItemClassForStatus = progressListItemClassForStatus;
 })();

--- a/app/assets/javascripts/mumuki_laboratory/application/results-renderer.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/results-renderer.js
@@ -26,10 +26,10 @@
    */
   function classForStatus(status) {
     switch (status) {
-      case "passed":               return "success";
+      case "errored":              return "broken";
       case "failed":               return "danger";
       case "passed_with_warnings": return "warning";
-      case "errored":              return "broken";
+      case "passed":               return "success";
       case "pending":              return "muted";
     }
   };

--- a/app/assets/javascripts/mumuki_laboratory/application/results-renderer.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/results-renderer.js
@@ -1,0 +1,50 @@
+(() => {
+
+  // ==========================
+  // View function for building
+  // the results UI
+  // ==========================
+
+  /**
+   * @param {string} status
+   * @returns {string}
+   */
+  function iconForStatus(status) {
+    switch (status) {
+      case "errored":              return "fa-minus-circle";
+      case "failed":               return "fa-times-circle";
+      case "passed_with_warnings": return "fa-exclamation-circle";
+      case "passed":               return "fa-check-circle";
+    }
+  }
+
+  /**
+   *
+   * @param {string} status
+   * @returns {string}
+   */
+  function classForStatus(status) {
+    switch (status) {
+      case "passed": return "success";
+      case "failed": return "danger";
+      case "passed_with_warnings": return "warning";
+      case "errored": return "broken";
+      case "pending": return "muted";
+    }
+  };
+
+
+  /**
+   * @param {string} status
+   * @param {boolean} [active]
+   * @returns {string}
+   */
+  function progressListItemClassForStatus(status, active = false) {
+    return `progress-list-item text-center ${classForStatus(status)} ${active ? 'active' : ''}`;
+  };
+
+  mumuki.renderers = mumuki.renderers || {};
+  mumuki.renderers.classForStatus = classForStatus;
+  mumuki.renderers.classForStatus = iconForStatus;
+  mumuki.renderers.progressListItemClassForStatus = progressListItemClassForStatus;
+})();

--- a/app/assets/javascripts/mumuki_laboratory/application/results-renderer.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/results-renderer.js
@@ -25,11 +25,11 @@
    */
   function classForStatus(status) {
     switch (status) {
-      case "passed": return "success";
-      case "failed": return "danger";
+      case "passed":               return "success";
+      case "failed":               return "danger";
       case "passed_with_warnings": return "warning";
-      case "errored": return "broken";
-      case "pending": return "muted";
+      case "errored":              return "broken";
+      case "pending":              return "muted";
     }
   };
 

--- a/lib/mumuki/laboratory/controllers/results_rendering.rb
+++ b/lib/mumuki/laboratory/controllers/results_rendering.rb
@@ -33,8 +33,7 @@ module Mumuki::Laboratory::Controllers::ResultsRendering
 
   def progress_json
     {
-      guide_finished_by_solution: guide_finished_by_solution?,
-      class_for_progress_list_item: class_for_progress_list_item(@exercise, true)
+      guide_finished_by_solution: guide_finished_by_solution?
     }
   end
 

--- a/spec/controllers/confirmations_controller_spec.rb
+++ b/spec/controllers/confirmations_controller_spec.rb
@@ -15,6 +15,6 @@ describe ExerciseConfirmationsController, organization_workspace: :test do
     before { post :create, params: { exercise_id: reading.id } }
 
     it { expect(response.status).to eq 200 }
-    it { expect(response.body).to json_like(guide_finished_by_solution: true, class_for_progress_list_item: 'progress-list-item text-center success active') }
+    it { expect(response.body).to json_like(guide_finished_by_solution: true) }
   end
 end

--- a/spec/controllers/exercise_solutions_controller_spec.rb
+++ b/spec/controllers/exercise_solutions_controller_spec.rb
@@ -27,7 +27,7 @@ describe ExerciseSolutionsController, organization_workspace: :test do
         it { expect(assignment.solution).to eq('asd')}
 
         it { expect(response.body).to json_eq({ status: :failed, guide_finished_by_solution: false },
-                                              except: [:class_for_progress_list_item, :html, :remaining_attempts_html]) }
+                                              except: [:html, :remaining_attempts_html]) }
 
 
         it 'does not include kids specific renders' do
@@ -54,7 +54,7 @@ describe ExerciseSolutionsController, organization_workspace: :test do
       before { post_problem(kids_problem) }
 
       it { expect(response.body).to json_eq({ status: :failed, guide_finished_by_solution: false },
-                                            except: [:class_for_progress_list_item, :html, :remaining_attempts_html,
+                                            except: [:html, :remaining_attempts_html,
                                                      :title_html, :button_html, :expectations, :test_results, :tips]) }
 
       it 'includes kids specific renders' do


### PR DESCRIPTION
# :dart: Goal

The goal of this PR is twofold: on one hand it stops generating the `class_for_progress_list_item` class at the server, but in client instead. On the other hand, it introduces the concept of pre-rendering, which was extracted from this PR https://github.com/mumuki/mumuki-laboratory/pull/1434/files, in order to make user-less and runner-less features easier to implement. 

# :back: Backward compatibility 

This PR is 100% backward compatible



