### PR TITLE
Feature serverless evaluation

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/bridge.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/bridge.js
@@ -27,16 +27,16 @@ var mumuki = mumuki || {};
     return lastSubmission.result && lastSubmission.result.status !== 'aborted';
   }
 
-  function sendNewSolution(solution){
+  function sendNewSolution(submission){
     var token = new mumuki.CsrfToken();
     var request = token.newRequest({
       type: 'POST',
       url: window.location.origin + window.location.pathname + '/solutions' + window.location.search,
-      data: solution
+      data: submission
     });
 
     return $.ajax(request).then(preRenderResult).done(function (result) {
-      lastSubmission = { content: solution, result: result };
+      lastSubmission = { content: {solution: submission.solution}, result: result };
     });
   }
 
@@ -78,11 +78,11 @@ var mumuki = mumuki || {};
      *
      * @param {Submission} submission the submission object
      */
-    _submitSolution: function (solution) {
-      if(lastSubmissionFinishedSuccessfully() && sameAsLastSolution(solution)){
+    _submitSolution: function (submission) {
+      if(lastSubmissionFinishedSuccessfully() && sameAsLastSolution(submission)){
         return $.Deferred().resolve(lastSubmission.result);
       } else {
-        return sendNewSolution(solution);
+        return sendNewSolution(submission);
       }
     }
   };

--- a/app/assets/javascripts/mumuki_laboratory/application/bridge.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/bridge.js
@@ -1,9 +1,9 @@
 /**
- * @typedef {{status: string, test_results: [{status: string, title: string}]}} SubmissionResult
+ * @typedef {{status: string, test_results: [{status: string, title: string}]}} ClientResult
  */
 
 /**
- * @typedef {{solution: object, result?: SubmissionResult}} Submission
+ * @typedef {{solution: object, client_result?: ClientResult}} Submission
  */
 
 var mumuki = mumuki || {};

--- a/app/assets/javascripts/mumuki_laboratory/application/bridge.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/bridge.js
@@ -1,3 +1,11 @@
+/**
+ * @typedef {{status: string, test_results: [{status: string, title: string}]}} SubmissionResult
+ */
+
+/**
+ * @typedef {{solution: object, result?: SubmissionResult}} Submission
+ */
+
 var mumuki = mumuki || {};
 
 (function (mumuki) {
@@ -68,7 +76,7 @@ var mumuki = mumuki || {};
     /**
      * Sends a solution object
      *
-     * @param {{solution: object}} solution the solution object
+     * @param {Submission} submission the submission object
      */
     _submitSolution: function (solution) {
       if(lastSubmissionFinishedSuccessfully() && sameAsLastSolution(solution)){

--- a/app/assets/javascripts/mumuki_laboratory/application/custom-editor.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/custom-editor.js
@@ -1,12 +1,16 @@
+/**
+ * @typedef {{name: string, value: string}} EditorProperty
+ */
+
+/**
+ * @typedef {{getContent: () => EditorProperty}} CustomEditorSource
+ */
+
 var mumuki = mumuki || {};
 
 (function (mumuki) {
 
   var CustomEditor = {
-    /**
-     * @typedef {{getContent: () => {name: string, value: string}}} CustomEditorSource
-     */
-
     /**
      * @type {CustomEditorSource[]}
      */
@@ -27,7 +31,7 @@ var mumuki = mumuki || {};
     },
 
     /**
-     * @returns {{name: string, value: string}[]}
+     * @returns {EditorProperty[]}
      */
     getContents() {
       return CustomEditor.sources.map( e => e.getContent() );

--- a/app/assets/javascripts/mumuki_laboratory/application/submission.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/submission.js
@@ -69,7 +69,7 @@ var mumuki = mumuki || {};
    * This content object may include keys like {@code content},
    * {@code content_extra} and {@code content_test}
    *
-   * @returns {{name: string, value: string}[]}
+   * @returns {EditorProperty[]}
    */
   function getStandardEditorContents() {
     mumuki.submission._syncContent();
@@ -145,8 +145,8 @@ var mumuki = mumuki || {};
    * {@link _kidsSolutionProcessor} and {@link _classicSolutionProcessor} - which are automatically choosen depending
    * on the exercise DOM.
    *
-   * @param {{solution: object}} solution
-   */
+   * @param {Submission} solution
+  */
   function processSolution(solution) {
     mumuki.submission._solutionProcessor(solution);
   }

--- a/app/controllers/exercise_solutions_controller.rb
+++ b/app/controllers/exercise_solutions_controller.rb
@@ -24,7 +24,7 @@ class ExerciseSolutionsController < AjaxController
   def solution_params
     {
       content: params.require(:solution).permit!.to_h[:content],
-      client_result: params[:client_result].try { |it| it.permit(:status, test_results: [:title, :status, :resut, :summary]).to_h }
+      client_result: params[:client_result].try { |it| it.permit(:status, test_results: [:title, :status, :result, :summary]).to_h }
     }
   end
 end

--- a/app/controllers/exercise_solutions_controller.rb
+++ b/app/controllers/exercise_solutions_controller.rb
@@ -24,7 +24,7 @@ class ExerciseSolutionsController < AjaxController
   def solution_params
     {
       content: params.require(:solution).permit!.to_h[:content],
-      client_result: params[:client_result].try { |it| it.permit(:status, test_results: []).to_h }
+      client_result: params[:client_result].try { |it| it.permit(:status, test_results: [:title, :status, :resut, :summary]).to_h }
     }
   end
 end

--- a/app/controllers/exercise_solutions_controller.rb
+++ b/app/controllers/exercise_solutions_controller.rb
@@ -22,7 +22,9 @@ class ExerciseSolutionsController < AjaxController
   end
 
   def solution_params
-    params_h = params.require(:solution).permit!.to_h
-    {content: params_h[:content]}
+    {
+      content: params.require(:solution).permit!.to_h[:content],
+      client_result: params[:client_result].try { |it| it.permit(:status, test_results: []).to_h }
+    }
   end
 end

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "checkJs": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["app/assets/javascripts/mumuki_laboratory"]
+}

--- a/spec/controllers/exercise_solutions_controller_spec.rb
+++ b/spec/controllers/exercise_solutions_controller_spec.rb
@@ -13,18 +13,51 @@ describe ExerciseSolutionsController, organization_workspace: :test do
   before { set_current_user! user }
 
   def post_problem(problem)
-    post :create, params: { exercise_id: problem.id, solution: { content: 'asd' } }
+    post :create, params: { exercise_id: problem.id, solution: { content: 'the content' } }
   end
 
 
-  describe 'when simple content is sent' do
+  context 'when submission contains client_result' do
+    let(:problem) { create(:problem) }
+    let(:assignment) { Assignment.last }
+
+    before { expect_any_instance_of(Language).to receive(:run_tests!).with(bridge_request) }
+    before do
+      post :create, params: {
+        exercise_id: problem.id,
+        solution: { content: 'the content' },
+        client_result: {
+          status: :passed_with_warnings
+        }
+      }
+    end
+
+    let(:bridge_request) do
+      {
+        content: 'the content',
+        custom_expectations: "\n",
+        expectations: [],
+        extra: "",
+        locale: "en",
+        settings: {},
+        test: "dont care",
+        client_result: {
+          status: 'passed_with_warnings'
+        }
+      }
+    end
+
+    it { expect(assignment.solution).to eq 'the content' }
+  end
+
+  context 'when simple content is sent' do
     context 'for a non-kids exercise' do
       before { post_problem(problem) }
       let(:assignment) { Assignment.last }
 
       context 'without client-side interpolations' do
         it { expect(response.status).to eq 200 }
-        it { expect(assignment.solution).to eq('asd')}
+        it { expect(assignment.solution).to eq('the content')}
 
         it { expect(response.body).to json_eq({ status: :failed, guide_finished_by_solution: false },
                                               except: [:html, :remaining_attempts_html]) }

--- a/spec/controllers/exercise_solutions_controller_spec.rb
+++ b/spec/controllers/exercise_solutions_controller_spec.rb
@@ -27,7 +27,8 @@ describe ExerciseSolutionsController, organization_workspace: :test do
         exercise_id: problem.id,
         solution: { content: 'the content' },
         client_result: {
-          status: :passed_with_warnings
+          status: :passed_with_warnings,
+          test_results: [{title: 'everything works', status: 'passed'}]
         }
       }
     end
@@ -42,7 +43,8 @@ describe ExerciseSolutionsController, organization_workspace: :test do
         settings: {},
         test: "dont care",
         client_result: {
-          status: 'passed_with_warnings'
+          status: 'passed_with_warnings',
+          test_results: [{title: 'everything works', status: 'passed'}]
         }
       }
     end


### PR DESCRIPTION
# :dart: Goal

The goal of this PR is to make server send `client_result` information to runners. 

# :memo: Notes 

Laboratory does not persist not process `client_result`, yet. It also documents type information about submission object, and makes an explicit distinction between solution and submission concepts - although some methods are still `*Solution` for backward compatibilty. 

# ~:ballot_box_with_check: Pending tasks~

~Add some tests~

# :back: Backward compatibility

This PR is full backward compatible



# :eyes: See also

Depends on https://github.com/mumuki/mumuki-domain/pull/108

