### PR TITLE
Feature submissions store

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/bridge.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/bridge.js
@@ -1,14 +1,25 @@
 /**
- * @typedef {{status: string, test_results: [{status: string, title: string}]}} ClientResult
+ * @typedef {{status: SubmissionStatus, test_results: [{status: SubmissionStatus, title: string}]}} ClientResult
  */
 
 /**
  * @typedef {{solution: object, client_result?: ClientResult}} Submission
  */
 
+/**
+ * @typedef {"errored"|"failed"|"passed_with_warnings"|"passed"|"pending"} SubmissionStatus
+ */
+
+/**
+ * @typedef {{content?: {solution: object}, result?: object}} SubmissionAndResult
+ */
+
 var mumuki = mumuki || {};
 
 (function (mumuki) {
+  /**
+   * @type {SubmissionAndResult}
+   */
   var lastSubmission = {};
 
   function Laboratory(exerciseId){
@@ -27,6 +38,9 @@ var mumuki = mumuki || {};
     return lastSubmission.result && lastSubmission.result.status !== 'aborted';
   }
 
+  /**
+   * @param {Submission} submission the submission object
+   */
   function sendNewSolution(submission){
     var token = new mumuki.CsrfToken();
     var request = token.newRequest({

--- a/app/assets/javascripts/mumuki_laboratory/application/bridge.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/bridge.js
@@ -54,7 +54,7 @@ mumuki.bridge = (() => {
       if(lastSubmission){
         return $.Deferred().resolve(lastSubmission);
       } else {
-        return this._sendNewSolution(submission).done(function (result) {
+        return this._sendNewSolution(submission).done((result) => {
           mumuki.SubmissionsStore.setLastSubmission(mumuki.currentExerciseId, this._buildLastSubmission(submission, result));
         });
       }

--- a/app/assets/javascripts/mumuki_laboratory/application/current-exercise.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/current-exercise.js
@@ -1,3 +1,5 @@
+/** @type {number} */
+mumuki.currentExerciseId = null;
 (() => {
   mumuki.load(() => {
     // Set global currentExerciseId

--- a/app/assets/javascripts/mumuki_laboratory/application/current-exercise.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/current-exercise.js
@@ -1,0 +1,11 @@
+(() => {
+  mumuki.load(() => {
+    // Set global currentExerciseId
+    const $muExerciseId = $('#mu-exercise-id');
+    if ($muExerciseId) {
+      mumuki.currentExerciseId = Number($muExerciseId.val());
+    } else {
+      mumuki.currentExerciseId = null;
+    }
+  })
+})();

--- a/app/assets/javascripts/mumuki_laboratory/application/results-renderer.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/results-renderer.js
@@ -6,7 +6,7 @@
   // ==========================
 
   /**
-   * @param {string} status
+   * @param {SubmissionStatus} status
    * @returns {string}
    */
   function iconForStatus(status) {
@@ -20,8 +20,7 @@
   }
 
   /**
-   *
-   * @param {string} status
+   * @param {SubmissionStatus} status
    * @returns {string}
    */
   function classForStatus(status) {
@@ -36,7 +35,7 @@
 
 
   /**
-   * @param {string} status
+   * @param {SubmissionStatus} status
    * @param {boolean} [active]
    * @returns {string}
    */

--- a/app/assets/javascripts/mumuki_laboratory/application/submission.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/submission.js
@@ -82,6 +82,8 @@ var mumuki = mumuki || {};
    *
    * This method will use CustomEditor's sources if availble, or
    * standard editor's content sources otherwise
+   *
+   * @returns {Submission}
    */
   function getContent() {
     let content = {};
@@ -97,6 +99,7 @@ var mumuki = mumuki || {};
       content[it.name] = it.value;
     });
 
+    // @ts-ignore
     return content;
   }
 

--- a/app/assets/javascripts/mumuki_laboratory/application/submissions-store.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/submissions-store.js
@@ -1,0 +1,55 @@
+(() => {
+  const SubmissionsStore = new class {
+    /**
+     * @param {number} exerciseId
+     * @returns {SubmissionStatus}
+     */
+    getLastSubmissionStatus(exerciseId) {
+      const submission = this.getLastSubmission(exerciseId);
+      return submission ? submission.result.status : 'pending';
+    }
+
+    /**
+     * @param {number} exerciseId
+     * @returns {SubmissionAndResult}
+     */
+    getLastSubmission(exerciseId) {
+      const submission = window.localStorage.getItem(this._keyFor(exerciseId));
+      if (!submission) return null;
+      return JSON.parse(submission);
+    }
+
+    /**
+     * @param {number} exerciseId
+     * @param {SubmissionAndResult} submission
+     */
+    setLastSubmission(exerciseId, submission) {
+      window.localStorage.setItem(this._keyFor(exerciseId), this._asString(submission));
+    }
+
+    getCachedResultFor(exerciseId, newSolution) {
+      const lastSubmission = this.getLastSubmission(exerciseId);
+      if (!lastSubmission
+          || lastSubmission.result.status === 'aborted'
+          || !this._solutionEquals(lastSubmission, newSolution)) {
+        return null;
+      }
+      return lastSubmission.result;
+    }
+
+    // private API
+
+    _asString(object) {
+      return JSON.stringify(object);
+    }
+
+    _keyFor(exerciseId) {
+      return `/exercise/${exerciseId}/submission`;
+    }
+
+    _solutionEquals(submission, solution) {
+      return this._asString(submission.content) === this._asString(solution);
+    }
+  };
+  mumuki.SubmissionsStore = SubmissionsStore;
+})();

--- a/app/assets/javascripts/mumuki_laboratory/application/submissions-store.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/submissions-store.js
@@ -1,4 +1,4 @@
-(() => {
+mumuki.SubmissionsStore = (() => {
   const SubmissionsStore = new class {
     /**
      * @param {number} exerciseId
@@ -14,33 +14,60 @@
      * @returns {SubmissionAndResult}
      */
     getLastSubmission(exerciseId) {
-      const submission = window.localStorage.getItem(this._keyFor(exerciseId));
-      if (!submission) return null;
-      return JSON.parse(submission);
+      const submissionAndResult = window.localStorage.getItem(this._keyFor(exerciseId));
+      if (!submissionAndResult) return null;
+      return JSON.parse(submissionAndResult);
     }
 
     /**
      * @param {number} exerciseId
-     * @param {SubmissionAndResult} submission
+     * @param {SubmissionAndResult} submissionAndResult
      */
-    setLastSubmission(exerciseId, submission) {
-      window.localStorage.setItem(this._keyFor(exerciseId), this._asString(submission));
+    setLastSubmission(exerciseId, submissionAndResult) {
+      window.localStorage.setItem(this._keyFor(exerciseId), this._asString(submissionAndResult));
     }
 
     /**
+     * Retrieves the last cached, non-aborted result for the given submission
      *
      * @param {number} exerciseId
-     * @param {*} newSolution
-     * @returns {SubmissionResult}
+     * @param {Submission} submission
+     * @returns {SubmissionResult} the cached result for this submission
      */
-    getCachedResultFor(exerciseId, newSolution) {
+    getCachedResultFor(exerciseId, submission) {
       const lastSubmission = this.getLastSubmission(exerciseId);
       if (!lastSubmission
           || lastSubmission.result.status === 'aborted'
-          || !this._solutionEquals(lastSubmission, newSolution)) {
+          || !this.submissionSolutionEquals(lastSubmission.submission, submission)) {
         return null;
       }
       return lastSubmission.result;
+    }
+
+     /**
+     * Extract the submission's solution content
+     *
+     * @param {Submission} submission
+     * @returns {string}
+     */
+    submissionSolutionContent(submission) {
+      if (submission.solution) {
+        return submission.solution.content;
+      } else {
+        return submission['solution[content]'];
+      }
+    }
+
+    /**
+     * Compares two solutions to determine if they are equivalent
+     * from the point of view of the code evaluation
+     *
+     * @param {Submission} one
+     * @param {Submission} other
+     * @returns {boolean}
+     */
+    submissionSolutionEquals(one, other) {
+      return this.submissionSolutionContent(one) === this.submissionSolutionContent(other);
     }
 
     // private API
@@ -52,10 +79,7 @@
     _keyFor(exerciseId) {
       return `/exercise/${exerciseId}/submission`;
     }
-
-    _solutionEquals(submission, solution) {
-      return this._asString(submission.content) === this._asString(solution);
-    }
   };
-  mumuki.SubmissionsStore = SubmissionsStore;
+
+  return SubmissionsStore;
 })();

--- a/app/assets/javascripts/mumuki_laboratory/application/submissions-store.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/submissions-store.js
@@ -27,6 +27,12 @@
       window.localStorage.setItem(this._keyFor(exerciseId), this._asString(submission));
     }
 
+    /**
+     *
+     * @param {number} exerciseId
+     * @param {*} newSolution
+     * @returns {SubmissionResult}
+     */
     getCachedResultFor(exerciseId, newSolution) {
       const lastSubmission = this.getLastSubmission(exerciseId);
       if (!lastSubmission

--- a/app/views/exercises/show.html.erb
+++ b/app/views/exercises/show.html.erb
@@ -45,6 +45,7 @@
 <%= render_exercise_input_layout(@exercise) %>
 
 <%= hidden_field_tag default_content_tag_id(@exercise), @default_content %>
+<%= hidden_field_tag "mu-exercise-id", @exercise.id %>
 
 <div style="display: none" id="processing-template">
   <div class="bs-callout bs-callout-info">

--- a/app/views/layouts/_progress_bar.html.erb
+++ b/app/views/layouts/_progress_bar.html.erb
@@ -1,6 +1,12 @@
 <div class="progress-list-flex">
   <% guide.exercises.each do |e| %>
-    <a <%= turbolinks_enable_for e %> href="<%= exercise_path(e)%>" aria-label="<%= e.navigable_name %>" title="<%= e.navigable_name %>" class="<%= class_for_progress_list_item(e, e == actual)%>">
+    <a
+      <%= turbolinks_enable_for e %>
+      href="<%= exercise_path(e)%>"
+      aria-label="<%= e.navigable_name %>"
+      title="<%= e.navigable_name %>"
+      data-mu-exercise-id="<%= e.id %>"
+      class="<%= class_for_progress_list_item(e, e == actual)%>">
     </a>
   <% end %>
 </div>

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "none",
     "target": "es6",
     "checkJs": true,
     "allowSyntheticDefaultImports": true


### PR DESCRIPTION
# :dart: Goal

This PR introduces the `SubmissionsStore`, a JS repository for user progress that replaced the one-variable last-submission cache. 

This has two consequences: 

  1. All progress is going to be stored in the client. This has no actual impact on the behavior of mumuki, but will be leveraged in next PRs 
   2. The last-submission cache is now persistent. 
        1. :-1: This should have no real impact to end-users in normal conditions, but is something that content-editors must take into account - now when performing an additional request after a content change, they will have to clear local storage, which is more cumbersome, I know.  
        2. :+1: But the good news is that now end-users will not accidentally break their progress if they send an already-passed submission from the same device after a content change. 

# :warning: Pitfalls

This API is not yet stable, and I may change in the near future, but is consistent enough to merging into main branch and start using it. 

# :memo: Details

* This PR introduces the global `currentExerciseId` 
* This PR adds more type information
* This PR converts bridge to an ES6 class

# :soon: Future work

More tests and documentation will be added when this API is stabilized. 

# :back: Backward compatibility

This PR is not backward compatible 

# :eyes: See also 

* #1433  and https://github.com/mumuki/mumuki-laboratory/pull/1434 The original PRs from which this code was extracted
* #1450 The experimental incognito mode that uses this code

