### PR TITLE
Chore refactor js modules

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/alias-modes.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/alias-modes.js
@@ -1,4 +1,4 @@
-mumuki.load(function () {
+mumuki.load(() => {
 
   function CodeMirrorAlias(alias, current) {
     CodeMirror.defineMIME(alias, CodeMirror.mimeModes[current]);

--- a/app/assets/javascripts/mumuki_laboratory/application/codemirror-builder.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/codemirror-builder.js
@@ -1,6 +1,4 @@
-var mumuki = mumuki || {};
-
-(function (mumuki) {
+(() => {
   function submit() {
     $('body').removeClass('fullscreen');
     $('.editor-resize .fa-stack-1x').removeClass('fa-compress').addClass('fa-expand');
@@ -102,4 +100,4 @@ var mumuki = mumuki || {};
 
   mumuki.editor = mumuki.editor || {};
   mumuki.editor.CodeMirrorBuilder = CodeMirrorBuilder;
-}(mumuki));
+})();

--- a/app/assets/javascripts/mumuki_laboratory/application/codemirror-builder.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/codemirror-builder.js
@@ -1,12 +1,6 @@
 var mumuki = mumuki || {};
 
 (function (mumuki) {
-
-  function CodeMirrorBuilder(textarea) {
-    this.textarea = textarea;
-    this.$textarea = $(textarea);
-  }
-
   function submit() {
     $('body').removeClass('fullscreen');
     $('.editor-resize .fa-stack-1x').removeClass('fa-compress').addClass('fa-expand');
@@ -29,8 +23,13 @@ var mumuki = mumuki || {};
     autoRefresh: true
   };
 
-  CodeMirrorBuilder.prototype = {
-    setupEditor: function () {
+  class CodeMirrorBuilder {
+    constructor(textarea) {
+      this.textarea = textarea;
+      this.$textarea = $(textarea);
+    }
+
+    setupEditor() {
       this.editor = this.createEditor({
         lineNumbers: true,
         extraKeys: {
@@ -47,8 +46,9 @@ var mumuki = mumuki || {};
       });
 
       return this;
-    },
-    setupSimpleEditor: function () {
+    }
+
+    setupSimpleEditor() {
       this.editor = this.createEditor({
         mode: 'text',
         extraKeys: {
@@ -61,8 +61,9 @@ var mumuki = mumuki || {};
       });
 
       return this;
-    },
-    setupReadOnlyEditor: function () {
+    }
+
+    setupReadOnlyEditor() {
       this.editor = this.createEditor({
         readOnly: true,
         cursorBlinkRate: -1, //Hides the cursor
@@ -70,8 +71,9 @@ var mumuki = mumuki || {};
       });
 
       return this;
-    },
-    setupLanguage: function (language) {
+    }
+
+    setupLanguage(language) {
       var highlightMode = language || this.$textarea.data('editor-language');
       if (highlightMode === 'dynamic') {
         mumuki.page.dynamicEditors.push(this.editor);
@@ -81,16 +83,19 @@ var mumuki = mumuki || {};
       }
 
       return this;
-    },
-    setupMinLines: function (minLines) {
+    }
+
+    setupMinLines(minLines) {
       this.editor.setOption('minLines', minLines);
 
       return this;
-    },
-    build: function () {
+    }
+
+    build() {
       return this.editor;
-    },
-    createEditor: function (customOptions) {
+    }
+
+    createEditor(customOptions) {
       return CodeMirror.fromTextArea(this.textarea, Object.assign({}, codeMirrorDefaults, customOptions));
     }
   };

--- a/app/assets/javascripts/mumuki_laboratory/application/codemirror.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/codemirror.js
@@ -1,6 +1,4 @@
-var mumuki = mumuki || {};
-
-(function (mumuki) {
+(() => {
   function createCodeMirrors() {
     return $(".editor").map(function (index, textarea) {
       var $textarea = $("#solution_content");
@@ -101,4 +99,4 @@ var mumuki = mumuki || {};
     });
   });
 
-}(mumuki));
+})();

--- a/app/assets/javascripts/mumuki_laboratory/application/codemirror.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/codemirror.js
@@ -78,7 +78,7 @@
   mumuki.page.editors = [];
 
 
-  mumuki.load(function () {
+  mumuki.load(() => {
     mumuki.page.editors = createCodeMirrors();
     mumuki.submission.registerContentSyncer(mumuki.editor.syncContent);
     updateCodeMirrorLanguage();

--- a/app/assets/javascripts/mumuki_laboratory/application/confirmation.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/confirmation.js
@@ -1,4 +1,4 @@
-mumuki.load(function () {
+mumuki.load(() => {
   $('.btn-confirmation').on('click change', function (evt) {
     var token = new mumuki.CsrfToken();
 

--- a/app/assets/javascripts/mumuki_laboratory/application/console.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/console.js
@@ -145,7 +145,7 @@
   };
 
 
-  mumuki.load(function () {
+  mumuki.load(() => {
     var prompt = $('#prompt').attr('value');
     var queryConsole = new QueryConsole();
 

--- a/app/assets/javascripts/mumuki_laboratory/application/console.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/console.js
@@ -1,5 +1,4 @@
-var mumuki = mumuki || {};
-(function (mumuki) {
+(() => {
   function historicalQueries() {
     var queries = $('#historical_queries').val();
     if (queries) {
@@ -172,4 +171,4 @@ var mumuki = mumuki || {};
     queryConsole.preloadHistoricalQueries();
   });
 
-}(mumuki));
+})();

--- a/app/assets/javascripts/mumuki_laboratory/application/console.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/console.js
@@ -35,40 +35,40 @@
     $('.jquery-console-prompt-box:not(:last)').remove()
   }
 
-  function QueryConsole() {
-    this.endpoint = $('#console_endpoint').val();
-    this.token = new mumuki.CsrfToken();
-    this.statefulConsole = $('#stateful_console').val() === "true";
-    this.lines = [];
-  }
-
-  QueryConsole.prototype = {
-    newQuery: function (line) {
+  class QueryConsole {
+    constructor() {
+      this.endpoint = $('#console_endpoint').val();
+      this.token = new mumuki.CsrfToken();
+      this.statefulConsole = $('#stateful_console').val() === "true";
+      this.lines = [];
+      this.controller = null;
+    }
+    newQuery(line) {
       var cookies = this.statefulConsole ? this.lines : [];
       return new Query(line, cookies, this);
-    },
-    clearState: function () {
+    }
+    clearState() {
       this.lines = [];
       clearConsole();
-    },
-    sendQuery: function (queryContent) {
+    }
+    sendQuery(queryContent) {
       this.controller.promptText(queryContent);
       this.controller.typer.commandTrigger();
-    },
-    preloadQuery: function (queryWithResults) {
+    }
+    preloadQuery(queryWithResults) {
       this.lines.push(queryWithResults.query);
       this.enqueuePreloadedQuery(queryWithResults);
       this.sendQuery(queryWithResults.query);
-    },
-    enqueuePreloadedQuery: function (queryWithResults) {
+    }
+    enqueuePreloadedQuery(queryWithResults) {
       this.preloadedQuery = queryWithResults;
-    },
-    dequeuePreloadedQuery: function () {
+    }
+    dequeuePreloadedQuery() {
       var result = this.preloadedQuery;
       this.preloadedQuery = undefined;
       return result;
-    },
-    preloadHistoricalQueries: function () {
+    }
+    preloadHistoricalQueries() {
       var self = this;
       historicalQueries().forEach(function (queryWithResults) {
         self.preloadQuery(queryWithResults);
@@ -76,24 +76,23 @@
     }
   };
 
-  function Query(line, cookie, console) {
-    this.console = console;
-    this.line = line;
-    this.cookie = cookie;
-  }
-
-  Query.prototype = {
+  class Query {
+    constructor(line, cookie, console) {
+      this.console = console;
+      this.line = line;
+      this.cookie = cookie;
+    }
     get token() {
       return this.console.token;
-    },
+    }
     get content() {
       var firstEditor = mumuki.page.editors[0];
       if (firstEditor && $("#include_solution").prop("checked"))
         return firstEditor.getValue();
       else
         return '';
-    },
-    submit: function (report, queryConsole, line) {
+    }
+    submit(report, queryConsole, line) {
       var self = this;
       var preloadedQuery = queryConsole.dequeuePreloadedQuery();
       if (preloadedQuery) {
@@ -109,8 +108,8 @@
       }).fail(function (response) {
         reportStatus(response.responseText, 'failed', report);
       });
-    },
-    displayGoalResult: function (response) {
+    }
+    displayGoalResult(response) {
       if (response.status == 'passed') {
         $('.submission-results').show();
         $('.submission-results').html(response.html);
@@ -120,15 +119,15 @@
         $('.submission-results').hide();
         $('.progress-list-item.active').attr('class', "progress-list-item text-center danger active");
       }
-    },
-    displayQueryResult: function (report, queryConsole, line, response) {
+    }
+    displayQueryResult(report, queryConsole, line, response) {
       if (response.status !== 'errored') {
         queryConsole.lines.push(line);
         reportStatus(response.result, response.status, report);
       } else {
         reportStatus(response.result, 'failed', report);
       }
-    },
+    }
     get _request() {
       var self = this;
       return self.token.newRequest({
@@ -136,10 +135,10 @@
         type: 'POST',
         data: self._requestData
       })
-    },
+    }
     get _requestUrl() {
       return this.console.endpoint;
-    },
+    }
     get _requestData() {
       return {content: this.content, query: this.line, cookie: this.cookie};
     }

--- a/app/assets/javascripts/mumuki_laboratory/application/csrf-token.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/csrf-token.js
@@ -1,5 +1,4 @@
-var mumuki = mumuki || {};
-(function (mumuki) {
+mumuki.CsrfToken =  (() => {
   function CsrfToken() {
     this.value = $('meta[name="csrf-token"]').attr('content');
   }
@@ -14,5 +13,5 @@ var mumuki = mumuki || {};
     }
   };
 
-  mumuki.CsrfToken = CsrfToken;
-}(mumuki));
+  return CsrfToken;
+})();

--- a/app/assets/javascripts/mumuki_laboratory/application/csrf-token.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/csrf-token.js
@@ -1,17 +1,15 @@
 mumuki.CsrfToken =  (() => {
-  function CsrfToken() {
-    this.value = $('meta[name="csrf-token"]').attr('content');
-  }
-
-  CsrfToken.prototype = {
-    newRequest: function (data) {
+  class CsrfToken {
+    constructor() {
+      this.value = $('meta[name="csrf-token"]').attr('content');
+    }
+    newRequest(data) {
       var self = this;
       data.beforeSend = function (xhr) {
         xhr.setRequestHeader('X-CSRF-Token', self.value);
       };
       return data;
     }
-  };
-
+  }
   return CsrfToken;
 })();

--- a/app/assets/javascripts/mumuki_laboratory/application/custom-editor.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/custom-editor.js
@@ -6,11 +6,16 @@
  * @typedef {{getContent: () => EditorProperty}} CustomEditorSource
  */
 
-var mumuki = mumuki || {};
+/**
+ * This module allows custom editors to register
+ * content sources that can not me mapped to standard selectors {@code mu-custom-editor-value},
+ * {@code mu-custom-editor-extra} and {@code mu-custom-editor-test}
+ *
+ * CustomEditor sources are cleared after page reload even when using turbolinks
+ */
+mumuki.CustomEditor = (() => {
 
-(function (mumuki) {
-
-  var CustomEditor = {
+  const CustomEditor = {
     /**
      * @type {CustomEditorSource[]}
      */
@@ -50,14 +55,5 @@ var mumuki = mumuki || {};
     mumuki.CustomEditor.clearSources();
   });
 
-  /**
-   * This module allows custom editors to register
-   * content sources that can not me mapped to standard selectors {@code mu-custom-editor-value},
-   * {@code mu-custom-editor-extra} and {@code mu-custom-editor-test}
-   *
-   * CustomEditor sources are cleared after page reload even when using turbolinks
-   *
-   * @module mumuki.CustomEditor
-   */
-  mumuki.CustomEditor = CustomEditor;
-}(mumuki));
+  return CustomEditor;
+})();

--- a/app/assets/javascripts/mumuki_laboratory/application/discussions.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/discussions.js
@@ -1,5 +1,3 @@
-var mumuki = mumuki || {};
-
 mumuki.load(function () {
   var $subscriptionSpans = $('.discussion-subscription > span');
   var $upvoteSpans = $('.discussion-upvote > span');

--- a/app/assets/javascripts/mumuki_laboratory/application/discussions.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/discussions.js
@@ -1,4 +1,4 @@
-mumuki.load(function () {
+mumuki.load(() => {
   var $subscriptionSpans = $('.discussion-subscription > span');
   var $upvoteSpans = $('.discussion-upvote > span');
 

--- a/app/assets/javascripts/mumuki_laboratory/application/elipsis.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/elipsis.js
@@ -7,7 +7,7 @@
 //
 //
 // This module assumes the strings are already markdown-like escaped code strings, not plain code
-(function (mumuki) {
+mumuki.elipsis = (() => {
 
   function elipsis(code) {
     return code
@@ -16,8 +16,7 @@
       .replace(/&lt;description-for-student\[([^\]]*)\]@[\s\S]*?@description-for-student&gt;/g, ' ... $1 ... ');
   }
 
-  mumuki.elipsis = elipsis;
-  mumuki.elipsis.replaceHtml = () => {
+  elipsis.replaceHtml = () => {
     let $elipsis = $('.mu-elipsis');
     $elipsis.each((it, e) =>  {
       let $e = $(e);
@@ -28,4 +27,6 @@
   mumuki.load(() => {
     mumuki.elipsis.replaceHtml();
   });
-})(mumuki);
+
+  return elipsis;
+})();

--- a/app/assets/javascripts/mumuki_laboratory/application/inputs.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/inputs.js
@@ -1,12 +1,14 @@
-(() => {
+mumuki.onInputsReady = (() => {
   // Declares a `document.ready` handler that will be
   // activated only when there is at least one element that match
   // the given selector
-	mumuki.onInputsReady = (inputsSelector, callback) => {
+	function onInputsReady(inputsSelector, callback) {
 		$(document).ready((event) => {
 			if ($(inputsSelector).length === 0) return;
 
 			callback(event);
 		})
 	}
+
+	return onInputsReady;
 })();

--- a/app/assets/javascripts/mumuki_laboratory/application/interval.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/interval.js
@@ -1,6 +1,4 @@
-var mumuki = mumuki || {};
-
-(function (mumuki) {
+(function () {
   // When using Turbolinks, intervals loaded inside <body> aren't destroyed on page changes
   // Use this function instead if you want the behaviour of a regular setInterval
   mumuki.setInterval = function (intervalFunction, milliseconds) {
@@ -14,4 +12,4 @@ var mumuki = mumuki || {};
     return interval;
   }.bind(this);
 
-}(mumuki));
+}());

--- a/app/assets/javascripts/mumuki_laboratory/application/kids.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/kids.js
@@ -1,4 +1,4 @@
-mumuki.load(function () {
+mumuki.load(() => {
   let $bubble = $('.mu-kids-character-speech-bubble').children('.mu-kids-character-speech-bubble-normal');
 
   let availableTabs = ['.description', '.hint'];

--- a/app/assets/javascripts/mumuki_laboratory/application/load-analytics.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/load-analytics.js
@@ -1,4 +1,4 @@
-mumuki.load(function(){
+mumuki.load(() => {
   ga('create', 'UA-58353823-1', 'auto');
   ga('send', 'pageview');
 });

--- a/app/assets/javascripts/mumuki_laboratory/application/load-error-svg.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/load-error-svg.js
@@ -1,4 +1,4 @@
-mumuki.load(function () {
+mumuki.load(() => {
   var error_svgs = ['403', '404', '500', 'timeout_1', 'timeout_2', 'timeout_3'];
 
   mumuki.errors = mumuki.errors || {};

--- a/app/assets/javascripts/mumuki_laboratory/application/messages.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/messages.js
@@ -1,4 +1,4 @@
-mumuki.load(function () {
+mumuki.load(() => {
   var Chat = {
     $body: function () {
       return $('body')

--- a/app/assets/javascripts/mumuki_laboratory/application/multiple-scenarios.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/multiple-scenarios.js
@@ -1,6 +1,4 @@
-var mumuki = mumuki || {};
-
-(function (mumuki) {
+mumuki.MultipleScenarios = (() => {
 
   const setControlVisibility = function ($control, visible) {
     visible ? $control.show() : $control.hide();
@@ -147,6 +145,5 @@ var mumuki = mumuki || {};
     }
   }
 
-  mumuki.MultipleScenarios = MultipleScenarios;
-
-}(mumuki));
+  return MultipleScenarios;
+})();

--- a/app/assets/javascripts/mumuki_laboratory/application/pin.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/pin.js
@@ -1,12 +1,10 @@
-var mumuki = mumuki || {};
-
-(function (mumuki) {
+mumuki.pin = (() => {
   function smoothScrollToElement(domElement) {
     var SPEED = 1000;
     $('html, body').animate({scrollTop: domElement.offset().top}, SPEED);
   }
 
-  mumuki.pin = {
+  return {
     scroll: function () {
       var scrollPin = $('.scroll-pin');
       if (scrollPin.length) {
@@ -14,4 +12,4 @@ var mumuki = mumuki || {};
       }
     }
   }
-})(mumuki);
+})();

--- a/app/assets/javascripts/mumuki_laboratory/application/progress.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/progress.js
@@ -1,13 +1,14 @@
-var mumuki = mumuki || {};
-
-(function (mumuki) {
+mumuki.updateProgressBarAndShowModal = (() => {
 
   /**
    * Updates the current exercise progress indicator
+   *
+   * @param {SubmissionResult} data
    * */
-  mumuki.updateProgressBarAndShowModal = function (data) {
+  function updateProgressBarAndShowModal(data) {
     $('.progress-list-item.active').attr('class', data.class_for_progress_list_item);
     if(data.guide_finished_by_solution) $('#guide-done').modal();
   };
 
-})(mumuki);
+  return updateProgressBarAndShowModal;
+})();

--- a/app/assets/javascripts/mumuki_laboratory/application/submission.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/submission.js
@@ -1,6 +1,4 @@
-var mumuki = mumuki || {};
-
-(function (mumuki) {
+mumuki.submission = (() => {
 
   // =============
   // UI Components
@@ -247,7 +245,7 @@ var mumuki = mumuki || {};
    *
    * @module mumuki.submission
    */
-  mumuki.submission = {
+  return {
     processSolution,
     _registerSolutionProcessor,
     _selectSolutionProcessor,
@@ -260,5 +258,4 @@ var mumuki = mumuki || {};
     animateTimeoutError,
     SubmitButton,
   };
-
-})(mumuki);
+})();

--- a/app/assets/javascripts/mumuki_laboratory/application/submission.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/submission.js
@@ -12,28 +12,27 @@ mumuki.submission = (() => {
       .play();
   }
 
-  function ResultsBox(submissionsResults) {
-    this.submissionsResultsArea = submissionsResults;
-    this.processingTemplate = $('#processing-template');
-    this.submissionsErrorTemplate = $(".submission-result-error");
-  }
-
-  ResultsBox.prototype = {
-    waiting: function () {
+  class ResultsBox {
+    constructor(submissionsResults) {
+      this.submissionsResultsArea = submissionsResults;
+      this.processingTemplate = $('#processing-template');
+      this.submissionsErrorTemplate = $(".submission-result-error");
+    }
+    waiting() {
       this.submissionsResultsArea.html(this.processingTemplate.html());
       this.submissionsErrorTemplate.hide();
-    },
-    success: function (data, submitButton) {
+    }
+    success(data, submitButton) {
       this.submissionsResultsArea.html(data.html);
       data.status === 'aborted' ? this.error(submitButton) : submitButton.enable();
       mumuki.updateProgressBarAndShowModal(data);
-    },
-    error: function (submitButton) {
+    }
+    error(submitButton) {
       this.submissionsResultsArea.html('');
       this.submissionsErrorTemplate.show();
       animateTimeoutError(submitButton);
-    },
-    done: function (data, submitButton) {
+    }
+    done(data, submitButton) {
       submitButton.updateAttemptsLeft(data);
       mumuki.pin.scroll();
     }

--- a/app/assets/javascripts/mumuki_laboratory/application/submission.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/submission.js
@@ -212,7 +212,7 @@ mumuki.submission = (() => {
   // Entry Point
   // ===========
 
-  mumuki.load(function () {
+  mumuki.load(() => {
     var $submissionsResults = $('.submission-results');
     if (!$submissionsResults) return;
 

--- a/app/assets/javascripts/mumuki_laboratory/application/timer.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/timer.js
@@ -1,7 +1,5 @@
-var mumuki = mumuki || {};
-
-(function (mumuki) {
-  mumuki.startTimer = function (endDate) {
+mumuki.startTimer = (() => {
+  function startTimer(endDate) {
     var endTime = new Date(endDate).getTime();
     var currentTime = Date.now();
     var diffTime = endTime - currentTime;
@@ -18,4 +16,5 @@ var mumuki = mumuki || {};
       }
     }, intervalDuration);
   };
-})(mumuki);
+  return startTimer
+})();

--- a/app/assets/javascripts/mumuki_laboratory/application/tooltip.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/tooltip.js
@@ -1,3 +1,3 @@
-mumuki.load(function () {
+mumuki.load(() => {
     $('[title]').tooltip();
 });

--- a/app/assets/javascripts/mumuki_laboratory/application/upload.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/upload.js
@@ -1,4 +1,4 @@
-mumuki.load(function() {
+mumuki.load(() => {
   $('#upload-input').change(function (evt) {
     var file = evt.target.files[0];
     if (!file) return;

--- a/app/assets/javascripts/mumuki_laboratory/application/user.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/user.js
@@ -1,4 +1,4 @@
-mumuki.load(function () {
+mumuki.load(() => {
   var hash = document.location.hash;
   if (hash) {
     $(".nav-tabs a[data-target='" + hash + "']").tab('show');


### PR DESCRIPTION
# :dart: Goal

This PR just refactors JS modules so that

- they assume that `mumuki` is loaded
- they provide better type inference and autocompletition of IDEs by returning modules inside the scope-lambda instead assigning them
- ES6 classes are used when possible

# :warning:  Warnings

Rebase after https://github.com/mumuki/mumuki-laboratory/pull/1443

# :camera: Screenshots

## Before 

![Screenshot_2020-08-10_09-58-22](https://user-images.githubusercontent.com/677436/89785004-0b9bfd80-daf0-11ea-830b-f35ef4741e52.png)


## After

![Screenshot_2020-08-10_09-55-34](https://user-images.githubusercontent.com/677436/89784799-acd68400-daef-11ea-8b0a-6d226d13bffe.png)
