### PR TITLE
Feature save profile when completed

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/profile.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/profile.js
@@ -26,11 +26,9 @@ mumuki.load(function() {
   });
 
   function toggleEditButtonIfThereAreChanges() {
-    if (requiredFieldsAreFilled() && (dataChanged() || avatarChanged())) {
-      $editButton.prop('disabled', false);
-    } else {
-      $editButton.prop('disabled', true);
-    }
+    let shouldEnable = requiredFieldsAreFilled() && (dataChanged() || avatarChanged());
+
+    $editButton.prop('disabled', !shouldEnable);
   }
 
   function requiredFieldsAreFilled() {

--- a/app/assets/javascripts/mumuki_laboratory/application/profile.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/profile.js
@@ -31,20 +31,15 @@ mumuki.load(function() {
     $editButton.prop('disabled', !shouldEnable);
   }
 
-  function requiredFieldsAreFilled() {
-    return $userForm.find('select, textarea, input').toArray().every(elem => {
+  const requiredFieldsAreFilled = () =>
+    $userForm.find('select, textarea, input').toArray().every(elem => {
       const $elem = $(elem);
       return !($elem.prop('required')) || !!$elem.val();
     });
-  }
 
-  function dataChanged() {
-    return $userForm.serialize() != originalData;
-  }
+  const dataChanged = () => $userForm.serialize() !== originalData;
 
-  function avatarChanged() {
-    return ($userAvatar.attr('src') != originalProfilePicture);
-  }
+  const avatarChanged = () => $userAvatar.attr('src') !== originalProfilePicture;
 
   $('#mu-user-image').on('click', function(){
     userImage = $userAvatar.attr('src');

--- a/app/assets/javascripts/mumuki_laboratory/application/profile.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/profile.js
@@ -26,11 +26,18 @@ mumuki.load(function() {
   });
 
   function toggleEditButtonIfThereAreChanges() {
-    if (dataChanged() || avatarChanged()) {
+    if (requiredFieldsAreFilled() && (dataChanged() || avatarChanged())) {
       $editButton.prop('disabled', false);
     } else {
       $editButton.prop('disabled', true);
     }
+  }
+
+  function requiredFieldsAreFilled() {
+    return $userForm.find('select, textarea, input').toArray().every(elem => {
+      const $elem = $(elem);
+      return !($elem.prop('required')) || !!$elem.val();
+    });
   }
 
   function dataChanged() {


### PR DESCRIPTION
## :dart: Goal 

Don't enable save profile button until all required fields in the profile form are filled.

I thought it was confusing to have the save button become enabled as soon as a new user started filling up their name, because the form is not completed yet and more fields are required.

## :movie_camera: How it works

https://youtu.be/PLFDJQ3bIsY

## :memo: Message to reviewers

~`requiredFieldsAreFilled()` is a bit ugly :man_shrugging: help me improve it, if possible.~ It's better now
