### PR TITLE
Chore run selenium in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ services:
 - postgresql
 addons:
   addons:
-    firefox: latest
+    firefox: '79.0'
   code_climate:
     repo_token: 820e155f1bff3d5cfcb84eae1caace7cd9ec5a27540f52222620896dc010b3ee
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,12 @@ before_script:
 script:
 - bundle exec rake db:schema:load
 - bundle exec rake
+- bundle exec rake teaspoon
 services:
 - postgresql
 addons:
+  addons:
+    firefox: latest
   code_climate:
     repo_token: 820e155f1bff3d5cfcb84eae1caace7cd9ec5a27540f52222620896dc010b3ee
 env:
@@ -21,6 +24,8 @@ env:
   - RACK_ENV=test CODECLIMATE_REPO_TOKEN=820e155f1bff3d5cfcb84eae1caace7cd9ec5a27540f52222620896dc010b3ee
   global:
   - secure: IW65qMjgbuuj4kUsBwaY+iV+jaIedgf2V3W7bTLj1SjaNdc8hC9SXBiNWQrT9Ygu5Q67mKzXuu5GTyAvAGftF02UKgT+yDE43p+a9w2+Onx5dGTIXCCREIE9fgmQhAkqgt9+1E99fRWsQzqkpEVINOMvumk+HM/Rxg8B9e5jvB8=
+    global:
+      - MOZ_HEADLESS=1
 deploy:
   - provider: rubygems
     api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ rvm:
 - 2.6.3
 before_install:
 - gem install -v 2.0.2 bundler
+- wget https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz
+- mkdir geckodriver && tar -xzf geckodriver-v0.27.0-linux64.tar.gz -C geckodriver && rm geckodriver-v0.27.0-linux64.tar.gz
+- export PATH=$PATH:$PWD/geckodriver
 before_script:
 - psql -c 'create database travis_ci_test;' -U postgres
 - cp spec/dummy/config/database.travis.yml spec/dummy/config/database.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ before_script:
 - cp spec/dummy/config/database.travis.yml spec/dummy/config/database.yml
 script:
 - bundle exec rake db:schema:load
-- bundle exec rake
 - bundle exec rake teaspoon
+- bundle exec rake
 services:
 - postgresql
 addons:

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ bundle exec rspec
 > it and add it to your path
 
 ```bash
-bundle exec rake teaspoon
+MOZ_HEADLESS=1 bundle exec rake teaspoon
 ```
 
 ## JavaScript API Docs

--- a/Rakefile
+++ b/Rakefile
@@ -27,8 +27,14 @@ require 'rspec/core/rake_task'
 desc "Run all specs in spec directory (excluding plugin specs)"
 RSpec::Core::RakeTask.new(:spec => 'app:db:test:prepare')
 
+desc "Force development environment, required by javascript specs"
+task :development do
+  ENV['RACK_ENV'] = 'development'
+  ENV['RAILS_ENV'] = 'development'
+end
+
 desc "Run the javascript specs"
-task :teaspoon => "app:teaspoon"
+task teaspoon: [:development, "app:teaspoon"]
 
 task default: :spec
 


### PR DESCRIPTION
# :dart: Goal

Make `teaspoon` tests run on Travis

# :memo: Details

Making this work is a bit tricky, since you don't only need `geckdriver`, but also Firefox installed and running on headless mode. 
I addition, teaspoon requires laboratory server to run on development mode, in order to replace default `auth0` login provider with `developer` provider. Perhaps we could make `developer` mode work in test environment, too. 

