### PR TITLE
Avoid kindergarten exercise workspace overflow

### DIFF
--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_kids.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_kids.scss
@@ -96,7 +96,7 @@ $kids-speech-tabs-width: 40px;
   }
 
   .mu-kids-character-animation {
-    width: 120px;
+    width: $kids-characters-height;
   }
 
   .mu-kids-character {

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_kindergarten.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_kindergarten.scss
@@ -8,7 +8,7 @@
   .mu-kids-exercise-workspace {
     display: flex;
     flex-flow: row;
-    height: 100%;
+    height: calc(100% - #{$kids-characters-height});
     width: 100%;
   }
 

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_kindergarten.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_kindergarten.scss
@@ -41,6 +41,7 @@
 
   .mu-kids-state.mu-state-initial {
     height: 100%;
+    width: 100%;
   }
 
   .mu-kids-state.mu-state-final {


### PR DESCRIPTION
# :dart: Goal 

Fix bug in kindergarten that makes the workspace taller than intended - it was taking the 100% without considering the bubble height. 

# :back: Backward compatibility 

This PR should be 100% backwards compatible. It only affects `kindergarten` - although a marginal refactor of scss was done in kids. 

# :camera_flash: Screenshots
 
## :arrow_backward:  Before

### Small image

![image](https://user-images.githubusercontent.com/677436/92784656-2676c180-f37d-11ea-97c3-88ff471725a4.png)

### Big image

> Notice that image overflows the footer

![image](https://user-images.githubusercontent.com/677436/92784802-46a68080-f37d-11ea-92ac-dc4e139082bb.png)


## :arrow_forward: After

### Small image

> Notice there was no change

![image](https://user-images.githubusercontent.com/677436/92784717-342c4700-f37d-11ea-9e4b-729586f96226.png)

### Big image

> Notice the image does not overflow now. Piece positions are accidental - no change on that were intended

![image](https://user-images.githubusercontent.com/677436/92784943-62aa2200-f37d-11ea-99ed-b27271fd5686.png)
