### PR TITLE
Fixing icon-font-path url

### DIFF
--- a/app/assets/stylesheets/mumuki_laboratory/application.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application.scss
@@ -1,4 +1,4 @@
-$icon-font-path: asset-path('assets/bootstrap');
+$icon-font-path: asset-path('assets/bootstrap/');
 $fa-font-path: asset-path('assets');
 $da-font-path: asset-path('assets');
 


### PR DESCRIPTION
Urls for Glyphicons were being generated like assets/bootstrapglyphicons...
After this fix: assets/bootstrap/glyphicons