### PR TITLE
Exposing settings

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/exercise.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/exercise.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {"input_right" | "input_bottom" | "input_primary" | "input_kindergarten"} Layout
- * @typedef {{id: number, layout: Layout}} Exercise
+ * @typedef {{id: number, layout: Layout, settings: any}} Exercise
  */
 
 mumuki.exercise = {
@@ -31,6 +31,15 @@ mumuki.exercise = {
   },
 
   /**
+   * The current exercise's settings
+   *
+   * @type {any?}
+   * */
+  get settings() {
+    return this._current ? this._current.settings : null;
+  },
+
+  /**
    * @type {Exercise?}
    */
   get current() {
@@ -46,7 +55,9 @@ mumuki.exercise = {
       this._current = {
         id: Number($muExerciseId.val()),
         // @ts-ignore
-        layout: $('#mu-exercise-layout').val()
+        layout: $('#mu-exercise-layout').val(),
+        // @ts-ignore
+        settings: JSON.parse($('#mu-exercise-settings').val())
       };
     } else {
       this._current = null;

--- a/app/views/exercises/show.html.erb
+++ b/app/views/exercises/show.html.erb
@@ -47,6 +47,7 @@
 <%= hidden_field_tag default_content_tag_id(@exercise), @default_content %>
 <%= hidden_field_tag "mu-exercise-id", @exercise.id %>
 <%= hidden_field_tag "mu-exercise-layout", @exercise.layout %>
+<%= hidden_field_tag "mu-exercise-settings", @exercise.settings %>
 
 <div style="display: none" id="processing-template">
   <div class="bs-callout bs-callout-info">

--- a/app/views/exercises/show.html.erb
+++ b/app/views/exercises/show.html.erb
@@ -47,7 +47,7 @@
 <%= hidden_field_tag default_content_tag_id(@exercise), @default_content %>
 <%= hidden_field_tag "mu-exercise-id", @exercise.id %>
 <%= hidden_field_tag "mu-exercise-layout", @exercise.layout %>
-<%= hidden_field_tag "mu-exercise-settings", @exercise.settings %>
+<%= hidden_field_tag "mu-exercise-settings", @exercise.settings.to_json %>
 
 <div style="display: none" id="processing-template">
   <div class="bs-callout bs-callout-info">

--- a/spec/features/exercise_flow_spec.rb
+++ b/spec/features/exercise_flow_spec.rb
@@ -9,7 +9,9 @@ feature 'Exercise Flow', organization_workspace: :test do
   let(:problem_1) { build(:problem, name: 'Succ1', description: 'Description of Succ1', layout: :input_right, hint: 'lala') }
   let(:problem_2) { build(:problem, name: 'Succ2', description: 'Description of Succ2', layout: :input_right, editor: :hidden, language: gobstones) }
   let(:problem_3) { build(:problem, name: 'Succ3', description: 'Description of Succ3', layout: :input_right, editor: :upload, hint: 'lele') }
-  let(:problem_4) { build(:problem, name: 'Succ4', description: 'Description of Succ4', layout: :input_bottom, extra: 'x = 2') }
+  let(:with_settings_and_extra) do
+    build(:problem, name: 'Succ4', description: 'Description of Succ4', layout: :input_bottom, settings: {foo: 1}, extra: 'x = 2')
+  end
   let(:problem_5) { build(:problem, name: 'Succ5', description: 'Description of Succ5', layout: :input_right, editor: :upload, hint: 'lele', language: gobstones) }
   let(:problem_6) { build(:problem, name: 'Succ6', description: 'Description of Succ6', layout: :input_right, editor: :hidden, language: haskell) }
   let(:problem_7) { build(:problem, name: 'Succ7', description: 'Description of Succ7', editor: :single_choice, choices: [{value: 'some choice', checked: true}]) }
@@ -22,7 +24,7 @@ feature 'Exercise Flow', organization_workspace: :test do
   let!(:chapter) {
     create(:chapter, name: 'Functional Programming', lessons: [
       create(:lesson, name: 'getting-started', description: 'An awesome guide', language: haskell, exercises: [
-        problem_1, problem_2, problem_3, problem_4, reading, problem_5, problem_6, problem_7, playground_1, playground_2, kids_problem
+        problem_1, problem_2, problem_3, with_settings_and_extra, reading, problem_5, problem_6, problem_7, playground_1, playground_2, kids_problem
       ])
     ]) }
 
@@ -194,8 +196,8 @@ feature 'Exercise Flow', organization_workspace: :test do
       expect(page.find("#mu-exercise-layout")['value']).to eq('input_right')
     end
 
-    scenario 'visit exercise by id, input_bottom layout, extra, no hint' do
-      visit "/exercises/#{problem_4.id}"
+    scenario 'visit exercise by id, input_bottom layout, extra, setting, no hint' do
+      visit "/exercises/#{with_settings_and_extra.id}"
 
       expect(page).to have_text('Succ4')
       expect(page).to have_text('x = 2')
@@ -204,8 +206,9 @@ feature 'Exercise Flow', organization_workspace: :test do
       expect(page).to_not have_text('need a hint?')
       expect(page).to_not have_selector('.upload')
 
-      expect(page.find("#mu-exercise-id")['value']).to eq(problem_4.id.to_s)
+      expect(page.find("#mu-exercise-id")['value']).to eq(with_settings_and_extra.id.to_s)
       expect(page.find("#mu-exercise-layout")['value']).to eq('input_bottom')
+      expect(page.find("#mu-exercise-settings")['value']).to eq('{"foo":1}')
     end
 
     scenario 'visit playground by id, no extra, no hint' do

--- a/spec/javascripts/exercise-spec.js
+++ b/spec/javascripts/exercise-spec.js
@@ -18,13 +18,13 @@ describe('exercise', () => {
     $('body').html(`
     <input type="hidden" name="mu-exercise-id" id="mu-exercise-id" value="3361" />
     <input type="hidden" name="mu-exercise-layout" id="mu-exercise-layout" value="input_right" />
-    <input type="hidden" name="mu-exercise-settings" id="mu-exercise-settings" value="{\\\\"game_mode\\\\": true}" />`)
+    <input type="hidden" name="mu-exercise-settings" id="mu-exercise-settings" value="{&quot;game_framework&quot;:true}" />`)
 
     mumuki.exercise.load();
 
     expect(mumuki.exercise.id).toBe(3361);
     expect(mumuki.exercise.layout).toBe('input_right');
-    expect(mumuki.exercise.settings).toEqual({game_mode: true});
+    expect(mumuki.exercise.settings.game_framework).toBe(true);
     expect(mumuki.exercise.current).not.toBe(null);
   })
 

--- a/spec/javascripts/exercise-spec.js
+++ b/spec/javascripts/exercise-spec.js
@@ -3,12 +3,28 @@ describe('exercise', () => {
   it('current exercise information is available when present', () => {
     $('body').html(`
     <input type="hidden" name="mu-exercise-id" id="mu-exercise-id" value="3361" />
-    <input type="hidden" name="mu-exercise-layout" id="mu-exercise-layout" value="input_right" />`)
+    <input type="hidden" name="mu-exercise-layout" id="mu-exercise-layout" value="input_right" />
+    <input type="hidden" name="mu-exercise-settings" id="mu-exercise-settings" value="{}" />`)
 
     mumuki.exercise.load();
 
     expect(mumuki.exercise.id).toBe(3361);
     expect(mumuki.exercise.layout).toBe('input_right');
+    expect(mumuki.exercise.settings).toEqual({});
+    expect(mumuki.exercise.current).not.toBe(null);
+  })
+
+  it('current exercise information is available when present and settings are not empty', () => {
+    $('body').html(`
+    <input type="hidden" name="mu-exercise-id" id="mu-exercise-id" value="3361" />
+    <input type="hidden" name="mu-exercise-layout" id="mu-exercise-layout" value="input_right" />
+    <input type="hidden" name="mu-exercise-settings" id="mu-exercise-settings" value="{\\\\"game_mode\\\\": true}" />`)
+
+    mumuki.exercise.load();
+
+    expect(mumuki.exercise.id).toBe(3361);
+    expect(mumuki.exercise.layout).toBe('input_right');
+    expect(mumuki.exercise.settings).toEqual({game_mode: true});
     expect(mumuki.exercise.current).not.toBe(null);
   })
 
@@ -19,6 +35,7 @@ describe('exercise', () => {
 
     expect(mumuki.exercise.id).toBe(null);
     expect(mumuki.exercise.layout).toBe(null);
+    expect(mumuki.exercise.settings).toBe(null);
     expect(mumuki.exercise.current).toBe(null);
   })
 })


### PR DESCRIPTION
# :dart: Goal

This PR fixes #1465. 

# :memo: Details

This PR adds a new `settings` attribute to the exercise's client object model. No more, no less. 

# :back:  Backward compatibility 

This PR should be 100% backwards compatible 

# :eyes: See also

* Having this at client side may turn easier to test current version of gobstones runner if https://github.com/mumuki/mumuki-gobstones-runner/pull/197 is also merged, since you will be able to easily convert `primary` exercises into `kindergarten` without changing `game_framework` nor any of its preconditions - standard default code can not be used. 