### PR TITLE
Fix avatar outline

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/profile.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/profile.js
@@ -64,8 +64,13 @@ mumuki.load(function() {
     form.append(`<input type="hidden" name="user[avatar_id]" value=${id}/>`);
   }
 
-  $("#mu-edit-avatar-icon").on('click', function(){
-    $avatarPicker.modal();
+  $("#mu-edit-avatar-icon").on('keypress click', function(e) {
+    if (isEnterOrSpacePress(e) || e.type === 'click') {
+      $avatarPicker.modal();
+    }
   });
 
+  function isEnterOrSpacePress(press) {
+    return press.which === 13 || press.which === 32;
+  }
 });

--- a/app/assets/javascripts/mumuki_laboratory/application/profile.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/profile.js
@@ -16,7 +16,7 @@ mumuki.load(function() {
   });
 
   $avatarItem.on('keypress click', function(e) {
-    if (isEnterOrSpacePress(e) || e.type === 'click') {
+    onClickOrSpacebarOrEnter($(this), e, function() {
       $userAvatar.attr('src', $(this).attr('src'));
       $avatarPicker.modal('hide');
 
@@ -24,7 +24,7 @@ mumuki.load(function() {
       avatarId = clickedAvatarId || "";
 
       toggleEditButtonIfThereAreChanges();
-    }
+    });
   });
 
   function toggleEditButtonIfThereAreChanges() {
@@ -44,9 +44,9 @@ mumuki.load(function() {
   const avatarChanged = () => $userAvatar.attr('src') !== originalProfilePicture;
 
   $('#mu-user-image').on('keypress click', function(e){
-    if (isEnterOrSpacePress(e) || e.type === 'click') {
+    onClickOrSpacebarOrEnter($(this), e, function() {
       userImage = $userAvatar.attr('src');
-    }
+    });
   });
 
   $userForm.on('submit', function(){
@@ -69,12 +69,14 @@ mumuki.load(function() {
   }
 
   $("#mu-edit-avatar-icon").on('keypress click', function(e) {
-    if (isEnterOrSpacePress(e) || e.type === 'click') {
+    onClickOrSpacebarOrEnter($(this), e, function() {
       $avatarPicker.modal();
-    }
+    });
   });
 
-  function isEnterOrSpacePress(press) {
-    return press.which === 13 || press.which === 32;
+  function onClickOrSpacebarOrEnter(element, e, func) {
+    if (e.which === 13 || e.which === 32 || e.type === 'click') {
+      func.apply(element);
+    }
   }
 });

--- a/app/assets/javascripts/mumuki_laboratory/application/profile.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/profile.js
@@ -15,14 +15,16 @@ mumuki.load(function() {
     toggleEditButtonIfThereAreChanges();
   });
 
-  $avatarItem.on('click', function() {
-    $userAvatar.attr('src', $(this).attr('src'));
-    $avatarPicker.modal('hide');
+  $avatarItem.on('keypress click', function(e) {
+    if (isEnterOrSpacePress(e) || e.type === 'click') {
+      $userAvatar.attr('src', $(this).attr('src'));
+      $avatarPicker.modal('hide');
 
-    const clickedAvatarId = $(this).attr('mu-avatar-id');
-    avatarId = clickedAvatarId || "";
+      const clickedAvatarId = $(this).attr('mu-avatar-id');
+      avatarId = clickedAvatarId || "";
 
-    toggleEditButtonIfThereAreChanges();
+      toggleEditButtonIfThereAreChanges();
+    }
   });
 
   function toggleEditButtonIfThereAreChanges() {
@@ -41,8 +43,10 @@ mumuki.load(function() {
 
   const avatarChanged = () => $userAvatar.attr('src') !== originalProfilePicture;
 
-  $('#mu-user-image').on('click', function(){
-    userImage = $userAvatar.attr('src');
+  $('#mu-user-image').on('keypress click', function(e){
+    if (isEnterOrSpacePress(e) || e.type === 'click') {
+      userImage = $userAvatar.attr('src');
+    }
   });
 
   $userForm.on('submit', function(){

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_avatar.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_avatar.scss
@@ -48,4 +48,10 @@
     box-shadow: -3px 3px 10px -3px $mu-color-primary;
     transform: scale(1.025);
   }
+
+  &:focus {
+    outline: none;
+    box-shadow: -3px 3px 10px -3px $mu-color-primary;
+    transform: scale(1.025);
+  }
 }

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_avatar.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_avatar.scss
@@ -12,6 +12,16 @@
   position: relative;
   top: 100px;
   right: 15px;
+
+  &:hover {
+    outline: none;
+    opacity: 0.5;
+  }
+
+  &:focus {
+    outline: none;
+    opacity: 0.5;
+  }
 }
 
 .mu-avatar-list {

--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -4,6 +4,6 @@ module AvatarHelper
   end
 
   def show_avatar_item(item)
-    avatar_image(item.image_url, alt: item.description, 'mu-avatar-id': item.id, class: 'mu-avatar-item')
+    avatar_image(item.image_url, alt: item.description, 'mu-avatar-id': item.id, class: 'mu-avatar-item', tabindex: 0)
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,9 +27,10 @@
             </span>
           </div>
           <div class="dropdown">
-            <span id="profileDropdown" class="profile-dropdown" data-toggle="dropdown" aria-label="<%= t(:user) %>" role="menu" tabindex="0">
+            <div id="profileDropdown" class="profile-dropdown" data-toggle="dropdown" aria-label="<%= t(:user) %>" role="menu" tabindex="0">
               <%= profile_picture_for current_user %>
-            </span>
+              <span class="caret"></span>
+            </div>
             <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="profileDropdown">
               <%= menu_bar_list_items %>
               <li class="divider"></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
             </span>
           </div>
           <div class="dropdown">
-            <span id="profileDropdown" data-toggle="dropdown" aria-label="<%= t(:user) %>" role="menu" tabindex="0">
+            <span id="profileDropdown" class="profile-dropdown" data-toggle="dropdown" aria-label="<%= t(:user) %>" role="menu" tabindex="0">
               <%= profile_picture_for current_user %>
             </span>
             <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="profileDropdown">

--- a/app/views/users/_avatar_list.html.erb
+++ b/app/views/users/_avatar_list.html.erb
@@ -5,7 +5,7 @@
     <% end %>
 
     <% if @user.image_url %>
-      <%= avatar_image @user.image_url, class: 'mu-avatar-item', id: 'mu-user-image' %>
+      <%= avatar_image @user.image_url, class: 'mu-avatar-item', id: 'mu-user-image', tabindex: 0 %>
     <% end %>
   </div>
 </div>

--- a/app/views/users/_edit_user_form.html.erb
+++ b/app/views/users/_edit_user_form.html.erb
@@ -9,7 +9,7 @@
   <div class="row mu-tab-body">
     <div class="col-md-4 text-center">
       <%= profile_picture_for(@user, id: 'mu-user-avatar', class: 'mu-user-avatar') %>
-      <i class="fa fa-pencil fa-2x pointer mu-edit-avatar" id="mu-edit-avatar-icon"></i>
+      <i class="fa fa-pencil fa-2x pointer mu-edit-avatar" id="mu-edit-avatar-icon" tabindex="0"></i>
     </div>
     <div class="col-md-8">
       <%= render partial: 'profile_fields', locals: {form: f} %>

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'mumukit-auth', '~> 7.8'
   s.add_dependency 'mumukit-content-type', '~> 1.9'
 
-  s.add_dependency 'mumuki-styles', '~> 1.21.3'
+  s.add_dependency 'mumuki-styles', '~> 1.22'
   s.add_dependency 'muvment', '~> 1.2'
 
   s.add_dependency 'rack', '~> 2.1'


### PR DESCRIPTION
## :dart: Goal 

Replace an ugly outline that appeared recently when clicking on the profile dropdown on Chrome. 

![image](https://user-images.githubusercontent.com/11304439/93644127-bbaa3380-f9d7-11ea-8188-5117df2cc261.png)

## :books: Some discoveries on accesibility

When Chrome 83 launched in May it added a couple accesibility improvements, including adding blue outlines for focused elements (either through clicking or tabbing, or any other form of keyboard navigation). More info here: https://blog.chromium.org/2020/03/updates-to-form-controls-and-focus.html

Keyboard navigation is traditionally represented with a 1px black dotted line, as in this Firefox screenshot,

![image](https://user-images.githubusercontent.com/11304439/93644437-5efb4880-f9d8-11ea-93fd-383769a4a819.png)

but from what I've been reading, Chrome was already using a solid blue outline - albeit more subtle. With this update, though, something else apart from the visual aspect must have changed, because we used to have no outline before when clicking on the profile dropdown. 

We're not alone here because there are a million blog posts and questions on how to remove them, though doing so would incur in a less-accessible website, because setting `outline: none` makes it impossible to know where you are when navigating through keyboard. More can be read here: https://coryrylan.com/blog/dont-override-css-outline-focus-styles

So I've added a few other visual cues to indicate positioning, such as reducing opacity when focusing or hovering. We don't usually give much thought to accesibility, so I made sure some previously unfocusable elements can be navigated through keyboard, such as the edit avatar button or the avatars themselves. (That required adding even more visual cues to those elements, as making them navigable also comes with the blue outline on clicking).

We _could_ keep the native browser outline for keyboard navigation but hide it for mouse clicks. For example, try tabbing on GitHub; you'll see a white outline around the profile dropdown, but it's not seen if clicked. However, the current state of this is as follows:
- it'd require more JS than I'd like to write
- there's a `focus-visible` pseudo-class for this specific use case, but it's not enabled by the default on the latest Chrome version as of now - it should come by default on version 86 which is the next one. Support is nil on other browsers and Firefox has its own implementation through `-moz-focusring`. So currently a no-no. See more: https://caniuse.com/css-focus-visible

I've also added a caret to indicate there's a dropdown when clicking.

## :movie_camera: See it in action

https://youtu.be/OtdYlNR4ntk

## :spiral_notepad: Note to reviewers

We need a new `mumuki-styles` version for this to work. See https://github.com/mumuki/mumuki-styles/pull/56

## :question: What about the tab panel

Keyboard navigation on the profile/messages/organizations tabs on the profile can't be done with pure HTML/CSS from what I've tried.

Also, the X when closing a modal can be briefly seen outlined when clicked, but it goes away quickly so I'm not worrying much about it.