### PR TITLE
Feature show medals as avatars

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,4 +36,4 @@ group :development, :test do
   gem "selenium-webdriver"
 end
 
-gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'master'
+gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'feature-medals'

--- a/app/assets/javascripts/mumuki_laboratory/application/profile.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/profile.js
@@ -3,7 +3,7 @@ mumuki.load(function() {
   let $userAvatar = $('#mu-user-avatar');
   let $editButton = $('#mu-edit-profile-btn');
   let $avatarPicker = $('#mu-avatar-picker');
-  let $avatarItem = $('.mu-avatar-item');
+  let $avatarItem = $('.mu-avatar-item:not(.mu-locked)');
 
   let userImage = "";
   let avatarId = "";

--- a/app/assets/javascripts/mumuki_laboratory/application/profile.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/profile.js
@@ -7,6 +7,7 @@ mumuki.load(function() {
 
   let userImage = "";
   let avatarId = "";
+  let avatarType = "";
 
   let originalData = $userForm.serialize();
   let originalProfilePicture = $userAvatar.attr('src');
@@ -20,7 +21,9 @@ mumuki.load(function() {
     $avatarPicker.modal('hide');
 
     const clickedAvatarId = $(this).attr('mu-avatar-id');
+    const clickedAvatarType = $(this).attr('type');
     avatarId = clickedAvatarId || "";
+    avatarType = clickedAvatarType || "";
 
     toggleEditButtonIfThereAreChanges();
   });
@@ -48,11 +51,11 @@ mumuki.load(function() {
   $userForm.on('submit', function(){
     if (userImage) {
       setImageUrl($(this), userImage);
-      setAvatarId($(this), "");
+      setAvatarIdAndType($(this), "", "");
     }
 
     if (avatarId) {
-      setAvatarId($(this), avatarId);
+      setAvatarIdAndType($(this), avatarId, avatarType);
     }
   });
 
@@ -60,8 +63,9 @@ mumuki.load(function() {
     form.append(`<input type="hidden" name="user[image_url]" value="${url}"/>`);
   }
 
-  function setAvatarId(form, id) {
-    form.append(`<input type="hidden" name="user[avatar_id]" value=${id}/>`);
+  function setAvatarIdAndType(form, id, type) {
+    form.append(`<input type="hidden" name="user[avatar_id]" value="${id}"/>`);
+    form.append(`<input type="hidden" name="user[avatar_type]" value="${type}"/>`);
   }
 
   $("#mu-edit-avatar-icon").on('click', function(){

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_avatar.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_avatar.scss
@@ -38,4 +38,9 @@
     box-shadow: -3px 3px 10px -3px $mu-color-primary;
     transform: scale(1.025);
   }
+
+  &.mu-locked {
+    filter: grayscale(100%);
+    cursor: default;
+  }
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,7 +22,7 @@ class UsersController < ApplicationController
   end
 
   def permissible_params
-    super << :avatar_id
+    super << [:avatar_id, :avatar_type]
   end
 
   private

--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -1,9 +1,9 @@
 module AvatarHelper
   def avatars_for(user)
-    (Avatar.with_current_audience_for(user) + [user.avatar]).compact.uniq
+    (Avatar.with_current_audience_for(user) + user.acquired_medals + [user.avatar]).compact.uniq
   end
 
   def show_avatar_item(item)
-    avatar_image(item.image_url, alt: item.description, 'mu-avatar-id': item.id, class: 'mu-avatar-item')
+    avatar_image(item.image_url, alt: item.description, 'mu-avatar-id': item.id, class: 'mu-avatar-item', type: item.class.name)
   end
 end

--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -3,7 +3,15 @@ module AvatarHelper
     (Avatar.with_current_audience_for(user) + user.acquired_medals + [user.avatar]).compact.uniq
   end
 
-  def show_avatar_item(item)
-    avatar_image(item.image_url, alt: item.description, 'mu-avatar-id': item.id, class: 'mu-avatar-item', type: item.class.name)
+  def locked_avatars_for(user)
+    user.unacquired_medals.compact.uniq
+  end
+
+  def show_locked_avatar_item(item)
+    show_avatar_item(item, class: 'mu-avatar-item mu-locked')
+  end
+
+  def show_avatar_item(item, **options)
+    avatar_image(item.image_url, alt: item.description, 'mu-avatar-id': item.id, class: 'mu-avatar-item', type: item.class.name, **options)
   end
 end

--- a/app/views/users/_avatar_list.html.erb
+++ b/app/views/users/_avatar_list.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="mu-avatar-list">
-    <% avatars_for(@user).sort_by(&:id).each do |avatar| %>
+    <% avatars_for(@user).each do |avatar| %>
       <%= show_avatar_item(avatar) %>
     <% end %>
 

--- a/app/views/users/_avatar_list.html.erb
+++ b/app/views/users/_avatar_list.html.erb
@@ -4,6 +4,10 @@
       <%= show_avatar_item(avatar) %>
     <% end %>
 
+    <% locked_avatars_for(@user).sort_by(&:id).each do |avatar| %>
+      <%= show_locked_avatar_item(avatar) %>
+    <% end %>
+
     <% if @user.image_url %>
       <%= avatar_image @user.image_url, class: 'mu-avatar-item', id: 'mu-user-image' %>
     <% end %>

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200804191643) do
+ActiveRecord::Schema.define(version: 20200915123020) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,6 +66,7 @@ ActiveRecord::Schema.define(version: 20200804191643) do
     t.text "description"
     t.string "slug"
     t.boolean "private", default: false
+    t.bigint "medal_id"
     t.index ["slug"], name: "index_books_on_slug", unique: true
   end
 
@@ -218,6 +219,7 @@ ActiveRecord::Schema.define(version: 20200804191643) do
     t.text "learn_more"
     t.text "settings"
     t.text "custom_expectations"
+    t.bigint "medal_id"
     t.index ["name"], name: "index_guides_on_name"
     t.index ["slug"], name: "index_guides_on_slug", unique: true
   end
@@ -289,6 +291,11 @@ ActiveRecord::Schema.define(version: 20200804191643) do
     t.integer "topic_id"
   end
 
+  create_table "medals", force: :cascade do |t|
+    t.string "image_url"
+    t.string "description"
+  end
+
   create_table "messages", id: :serial, force: :cascade do |t|
     t.string "submission_id"
     t.text "content"
@@ -343,6 +350,7 @@ ActiveRecord::Schema.define(version: 20200804191643) do
     t.text "appendix"
     t.string "slug"
     t.boolean "private", default: false
+    t.bigint "medal_id"
     t.index ["slug"], name: "index_topics_on_slug", unique: true
   end
 
@@ -398,6 +406,8 @@ ActiveRecord::Schema.define(version: 20200804191643) do
     t.bigint "avatar_id"
     t.datetime "disabled_at"
     t.boolean "trusted_for_forum"
+    t.string "avatar_type", default: "Avatar"
+    t.index ["avatar_type", "avatar_id"], name: "index_users_on_avatar_type_and_avatar_id"
     t.index ["disabled_at"], name: "index_users_on_disabled_at"
     t.index ["last_organization_id"], name: "index_users_on_last_organization_id"
     t.index ["uid"], name: "index_users_on_uid", unique: true


### PR DESCRIPTION
## :dart: Goal 

Show obtained medals as selectable avatars for an user

## :soon: Screenshot~s~

![image](https://user-images.githubusercontent.com/11304439/93798901-c56caa80-fc14-11ea-8859-05be11e9301c.png)

First two are avatars, the third one is an obtained medal, the fourth one (in greyscale) is yet to be unlocked and can't be selected. (We could also add a little :lock: to make it clearer and a tooltip/message explaining what content should be solved to unlock it). Read more on unlockable avatars on [the related Domain PR](https://github.com/mumuki/mumuki-domain/pull/128)

Since avatars and medals are part of the same list, sorting by ID was making the list a bit messy (it'd show like Medal 1, Avatar 1, Medal 2, Avatar 2, and so on). I removed it [here](https://github.com/mumuki/mumuki-laboratory/commit/641e89349ec77356bec33a2edcf509cd4ad014ff) - I don't know if there was a good reason why you added it @luchotc as there's no natural order for avatars. We could move the sort elsewhere or change some logic if it's needed.
