### PR TITLE
Feature error pages visual improvements

### DIFF
--- a/app/assets/stylesheets/mumuki_laboratory/application/_errors.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/_errors.scss
@@ -15,6 +15,7 @@
       &.error-code-img {
         margin-top: -80px;
         margin-left: -30px;
+        margin-bottom: 0;
         min-height: 310px;
         max-height: 500px;
         width: calc(100% + 30px);

--- a/app/assets/stylesheets/mumuki_laboratory/application/_errors.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/_errors.scss
@@ -45,6 +45,9 @@
       color: darken($mu-color-disabled, 5%);
       font-size: 18px;
     }
+    .mu-error-status-line {
+      display: none;
+    }
   }
 }
 

--- a/app/assets/stylesheets/mumuki_laboratory/application/_errors.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/_errors.scss
@@ -14,11 +14,11 @@
       max-height: 350px;
       &.error-code-img {
         margin-top: -80px;
-        margin-left: -30px;
+        margin-left: 0;
         margin-bottom: 0;
         min-height: 310px;
         max-height: 500px;
-        width: calc(100% + 30px);
+        width: calc(100%);
         object-position: 50% 50%;
         overflow: hidden;
         @media (max-width: $screen-lg) {

--- a/app/assets/stylesheets/mumuki_laboratory/application/_errors.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/_errors.scss
@@ -37,9 +37,6 @@
       font-size: 25px;
       padding: 0;
       margin: 0;
-      .error-link {
-        text-transform: uppercase;
-      }
       a.btn {
         margin-top: 30px;
       }

--- a/app/assets/stylesheets/mumuki_laboratory/application/_errors.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/_errors.scss
@@ -28,7 +28,7 @@
     }
   }
   .body {
-    width: 50%;
+    width: 60%;
     margin: auto;
     h2 {
       font-size: 42px;

--- a/app/assets/stylesheets/mumuki_laboratory/application/_errors.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/_errors.scss
@@ -41,6 +41,10 @@
         margin-top: 30px;
       }
     }
+    .mu-maybe {
+      color: darken($mu-color-disabled, 5%);
+      font-size: 18px;
+    }
   }
 }
 

--- a/app/assets/stylesheets/mumuki_laboratory/application/_errors.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/_errors.scss
@@ -30,9 +30,11 @@
   .body {
     width: 50%;
     margin: auto;
+    h2 {
+      font-size: 42px;
+    }
     p {
-      color: darken($mu-color-disabled, 5%);
-      font-size: 89%;
+      font-size: 25px;
       padding: 0;
       margin: 0;
       .error-link {

--- a/app/assets/stylesheets/mumuki_laboratory/application/_errors.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/_errors.scss
@@ -27,7 +27,7 @@
     }
   }
   .body {
-    max-width: 500px;
+    width: 50%;
     margin: auto;
     p {
       color: darken($mu-color-disabled, 5%);

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -4,13 +4,13 @@
     </div>
     <div class="body">
       <h2><%= t('error.title.forbidden') %></h2>
-      <p>
+      <p class="mu-error-status-line">
         <%= t(:error_description, error: link_to_status_codes(403)).html_safe %>
       </p>
-      <p>
+      <p class="mu-error-explanation-line">
         <%= Organization.current.explain_error(403, explanation).html_safe %>
       </p>
-      <p>
+      <p class="mu-error-contact-line">
         <%= t(:contact_administrator, link: mail_to_administrator).html_safe %>
       </p>
     </div>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -3,6 +3,7 @@
       <img class="error-code-img" src="/error/403.svg">
     </div>
     <div class="body">
+      <h2><%= t('error.title.forbidden') %></h2>
       <p>
         <%= t(:error_description, error: link_to_status_codes(403)).html_safe %>
       </p>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -10,7 +10,7 @@
       <p class="mu-error-explanation-line">
         <%= Organization.current.explain_error(403, explanation).html_safe %>
       </p>
-      <p class="mu-error-contact-line">
+      <p class="mu-error-contact-line mu-maybe">
         <%= t(:contact_administrator, link: mail_to_administrator).html_safe %>
       </p>
     </div>

--- a/app/views/errors/gone.html.erb
+++ b/app/views/errors/gone.html.erb
@@ -9,9 +9,6 @@
       <p>
         <%= Organization.current.explain_error(410, explanation).html_safe %>
       </p>
-      <p>
-        <a class="btn btn-success" href="/"> <%= t(:back_to_mumuki) %> </a>
-      </p>
     </div>
 <% end %>
 

--- a/app/views/errors/gone.html.erb
+++ b/app/views/errors/gone.html.erb
@@ -3,6 +3,7 @@
       <img class="error-code-img" src="/error/410.svg">
     </div>
     <div class="body">
+      <h2><%= t('error.title.gone') %></h2>
       <p>
         <%= t(:error_description, error: link_to_status_codes(410)).html_safe %>
       </p>

--- a/app/views/errors/gone.html.erb
+++ b/app/views/errors/gone.html.erb
@@ -4,10 +4,10 @@
     </div>
     <div class="body">
       <h2><%= t('error.title.gone') %></h2>
-      <p>
+      <p class="mu-error-status-line">
         <%= t(:error_description, error: link_to_status_codes(410)).html_safe %>
       </p>
-      <p>
+      <p class="mu-error-explanation-line">
         <%= Organization.current.explain_error(410, explanation).html_safe %>
       </p>
     </div>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -7,11 +7,8 @@
       <p class="mu-error-status-line">
         <%= t(:error_description, error: link_to_status_codes(500)).html_safe %>
       </p>
-      <p class="mu-error-explanation-line">
-        <%= Organization.current.explain_error(500, :something_went_wrong_explanation).html_safe %>
-      </p>
       <p class="mu-error-contact-line">
-        <%= t(:tell_us_if_our_error, issues: link_to_issues(:let_us_know)).html_safe %>
+        <%= link_to_issues(:let_us_know).html_safe %>
       </p>
     </div>
 <% end %>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -3,6 +3,7 @@
       <img class="error-code-img" src="/error/500.svg">
     </div>
     <div class="body">
+      <h2><%= t('error.title.internal_server_error') %></h2>
       <p>
         <%= t(:error_description, error: link_to_status_codes(500)).html_safe %>
       </p>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -4,13 +4,13 @@
     </div>
     <div class="body">
       <h2><%= t('error.title.internal_server_error') %></h2>
-      <p>
+      <p class="mu-error-status-line">
         <%= t(:error_description, error: link_to_status_codes(500)).html_safe %>
       </p>
-      <p>
+      <p class="mu-error-explanation-line">
         <%= Organization.current.explain_error(500, :something_went_wrong_explanation).html_safe %>
       </p>
-      <p>
+      <p class="mu-error-contact-line">
         <%= t(:tell_us_if_our_error, issues: link_to_issues(:let_us_know)).html_safe %>
       </p>
     </div>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -12,8 +12,5 @@
       <p>
         <%= t(:tell_us_if_our_error, issues: link_to_issues(:let_us_know)).html_safe %>
       </p>
-      <p>
-        <a class="btn btn-success" href="/"> <%= t(:back_to_mumuki) %> </a>
-      </p>
     </div>
 <% end %>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -3,6 +3,7 @@
       <img class="error-code-img" src="/error/404.svg">
     </div>
     <div class="body">
+      <h2><%= t('error.title.not_found') %></h2>
       <p>
         <%= t(:error_description, error: link_to_error_404).html_safe %>
       </p>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -12,8 +12,5 @@
       <p>
         <%= t(:tell_us_if_our_error, issues: link_to_issues(:let_us_know)).html_safe %>
       </p>
-      <p>
-        <a class="btn btn-success" href="/"> <%= t(:back_to_mumuki) %> </a>
-      </p>
     </div>
 <% end %>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -4,10 +4,10 @@
     </div>
     <div class="body">
       <h2><%= t('error.title.not_found') %></h2>
-      <p>
+      <p class="mu-error-status-line">
         <%= t(:error_description, error: link_to_error_404).html_safe %>
       </p>
-      <p>
+      <p class="mu-error-explanation-line">
         <%= Organization.current.explain_error(404, :not_found_explanation).html_safe %>
       </p>
     </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -9,8 +9,5 @@
       <p>
         <%= Organization.current.explain_error(404, :not_found_explanation).html_safe %>
       </p>
-      <p>
-        <%= t(:tell_us_if_our_error, issues: link_to_issues(:let_us_know)).html_safe %>
-      </p>
     </div>
 <% end %>

--- a/app/views/errors/unauthorized.html.erb
+++ b/app/views/errors/unauthorized.html.erb
@@ -6,9 +6,6 @@
       <p>
         <%= t(:unauthorized_explanation, error: link_to_status_codes(401)).html_safe %>
       </p>
-      <p>
-        <a class="btn btn-success" href="/"> <%= t(:back_to_mumuki) %> </a>
-      </p>
     </div>
 <% end %>
 

--- a/app/views/errors/unauthorized.html.erb
+++ b/app/views/errors/unauthorized.html.erb
@@ -3,7 +3,7 @@
       <img src="/astor.png">
     </div>
     <div class="body">
-      <p>
+      <p class="mu-error-status-line">
         <%= t(:unauthorized_explanation, error: link_to_status_codes(401)).html_safe %>
       </p>
     </div>

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -78,6 +78,12 @@ en:
   error_410: 410 error
   error_500: 500 error
   errored: Oops, your solution didn't work
+  error:
+    title:
+      forbidden: Oops! You are not allowed to see this content
+      gone: Oops! Content has expired
+      internal_server_error: Oops! Something went wrong
+      not_found: Oops! Page was not found
   exam_number: 'Exam %{number}:'
   exams: Exams
   exercise: Exercise
@@ -95,7 +101,7 @@ en:
   female: Female
   finish: Finish
   first_name: First Name
-  forbidden_explanation: You are not allowed to see this content.
+  forbidden_explanation: Please verify you have logged in with the right account
   format: Format
   fullscreen: "Fullscreen"
   gender: Gender

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -228,7 +228,6 @@ en:
   solve_your_doubts: Solve your doubts
   solve_your_doubts_teaser: Do you have any doubts?
   something_went_wrong: Something went wrong!
-  something_went_wrong_explanation: Something is broken in Mumuki.
   sort: Sort
   sources: Sources
   start_lesson: Start this lesson!

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -28,7 +28,7 @@ en:
   back_to_mumuki: Back to Mumuki!
   bibliotheca_ui: Bibliotheca
   birthdate: Birthdate
-  blocked_forum_explanation: You are not allowed to see this content. <br> Are you in the middle of an exam right now?
+  blocked_forum_explanation: Are you in the middle of an exam right now?
   cancel: Cancel
   cancel_subscription: Cancel your subscription.
   chapter: Chapter

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -47,7 +47,7 @@ en:
   confirm_reset: You are about to restart your exercise. Do you want to proceed?
   confirm_restart: You are about to delete your progress for this guide. Do you want to proceed?
   console: Console
-  contact_administrator: 'If you think this is not supposed to happen, please contact the admin: %{link}'
+  contact_administrator: 'If you think this is not supposed to happen, please contact %{link}'
   content: Content
   continue_exercise: "Continue"
   continue_lesson: Continue this lesson!
@@ -80,7 +80,7 @@ en:
   errored: Oops, your solution didn't work
   error:
     title:
-      forbidden: Oops! You are not allowed to see this content
+      forbidden: You are not allowed to see this content
       gone: Oops! Content has expired
       internal_server_error: Oops! Something went wrong
       not_found: Oops! Page was not found

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -177,7 +177,7 @@ es-CL:
   no_submissions: ¡Parece que aún no intentaste resolver este ejercicio!
   no_useful_result: ¿No encontraste lo que estabas buscando?
   not_found: ¡La página que buscaste no existe!
-  not_found_explanation: Fíjate si escribiste bien la dirección. Peeeeero...
+  not_found_explanation: Fíjate si escribiste bien la dirección.
   not_in_any_organizations: ¡Parece que no estás en ninguna organización todavía!
   notify_problem_with_exercise: Reporta un bug
   office: Secretaría

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -239,7 +239,6 @@ es-CL:
   solve_your_doubts: Consulta tus dudas
   solve_your_doubts_teaser: ¿Tienes alguna consulta?
   something_went_wrong: ¡Ups!, algo no anduvo bien...
-  something_went_wrong_explanation: Algo no anduvo como se esperaba.
   sort: Ordenar
   sources: Bibliografía
   start_lesson: ¡Comienza esta lección!

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -27,7 +27,7 @@ es-CL:
   back_to_mumuki: ¡Vuelve a Mumuki!
   bibliotheca_ui: Biblioteca
   birthdate: Fecha de nacimiento
-  blocked_forum_explanation: Es decir que no tienes autorización para ver este contenido. <br> ¿Puede que estés en medio de un examen?
+  blocked_forum_explanation: ¿Puede que estés en medio de un examen?
   cancel_subscription: Cancela tu subscripción.
   chapter: Capítulo
   chapters: Capítulos

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -72,13 +72,19 @@ es-CL:
   edit: Editar
   editor_placeholder: "...escribe tu solución acá..."
   email: Email
-  error_description: ¡Ups! <br> Esto es lo que se conoce como <span class="error-link">%{error}</span>.
+  error_description: Esto es lo que se conoce como <span class="error-link">%{error}</span>.
   error_401: error 401
   error_403: error 403
   error_404: error 404
   error_410: error 410
   error_500: error 500
   errored: ¡Ups! Tu solución no se puede ejecutar
+  error:
+    title:
+      forbidden: ¡Ups! No tienes autorización para ver este contenido
+      gone: ¡Ups! El contenido expiró
+      internal_server_error: ¡Ups! Algo no anduvo bien
+      not_found: ¡Ups!  La página no existe
   exam_number: 'Examen %{number}:'
   exams: Exámenes
   exercise: Ejercicio
@@ -95,7 +101,7 @@ es-CL:
   female: Mujer
   finish: Terminar
   first_name: Nombre
-  forbidden_explanation: Es decir que no tienes autorización para ver este contenido. <br> ¿Puede que hayas ingresado con una cuenta incorrecta?
+  forbidden_explanation: ¿Puede que hayas ingresado con una cuenta incorrecta?
   format: Dar formato
   fullscreen: "Pantalla completa"
   gender: Género

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -46,7 +46,7 @@ es-CL:
   confirm_reset: Estás por reiniciar tu ejercicio. ¿Quieres continuar?
   confirm_restart: Estás por borrar tu progreso en esta guía. ¿Quieres continuar?
   console: Consola
-  contact_administrator: 'Si piensas que es un error, comunícate con la persona que administra esta organización: %{link}'
+  contact_administrator: 'Si piensas que es un error, comunícate con %{link}'
   content: Contenido
   continue_exercise: "Continuar"
   continue_lesson: ¡Continúa esta lección!
@@ -81,7 +81,7 @@ es-CL:
   errored: ¡Ups! Tu solución no se puede ejecutar
   error:
     title:
-      forbidden: ¡Ups! No tienes autorización para ver este contenido
+      forbidden: No tienes autorización para ver este contenido
       gone: ¡Ups! El contenido expiró
       internal_server_error: ¡Ups! Algo no anduvo bien
       not_found: ¡Ups!  La página no existe

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -184,7 +184,7 @@ es:
   no_submissions: ¡Parece que aún no intentaste resolver este ejercicio aún!
   no_useful_result: ¿No encontraste lo que estabas buscando?
   not_found: ¡La página que buscaste no existe!
-  not_found_explanation: Fijate si escribiste bien la dirección. Peeeeero...
+  not_found_explanation: Fijate si escribiste bien la dirección.
   not_in_any_organizations: ¡Parece que no estás en ninguna organización todavía!
   notify_problem_with_exercise: Reportá un bug
   office: Secretaría

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -250,7 +250,6 @@ es:
   solve_your_doubts: Consultá tus dudas
   solve_your_doubts_teaser: ¿Tenés alguna consulta?
   something_went_wrong: ¡Ups!, algo no anduvo bien...
-  something_went_wrong_explanation: Algo no anduvo como se esperaba.
   sort: Ordenar
   sources: Bibliografía
   start_lesson: ¡Comenzá esta lección!

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -29,7 +29,7 @@ es:
   back_to_mumuki: ¡Volvé a Mumuki!
   bibliotheca_ui: Biblioteca
   birthdate: Fecha de nacimiento
-  blocked_forum_explanation: Es decir que no tenés autorización para ver este contenido. <br> ¿Puede que estés en medio de un examen?
+  blocked_forum_explanation: ¿Puede que estés en medio de un examen?
   cancel: Cancelar
   cancel_subscription: Cancelá tu subscripción.
   chapter: Capítulo

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -78,13 +78,19 @@ es:
   edit_profile: Editar perfil
   editor_placeholder: "...escribí tu solución acá..."
   email: Email
-  error_description: ¡Ups! <br> Esto es lo que se conoce como <span class="error-link">%{error}</span>.
+  error_description: Esto es lo que se conoce como <span class="error-link">%{error}</span>.
   error_401: error 401
   error_403: error 403
   error_404: error 404
   error_410: error 410
   error_500: error 500
   errored: ¡Ups! Tu solución no se puede ejecutar
+  error:
+    title:
+      forbidden: ¡Ups! No tenés autorización para ver este contenido
+      gone: ¡Ups! El contenido expiró
+      internal_server_error: ¡Ups! Algo no anduvo bien
+      not_found: ¡Ups!  La página no existe
   exam_number: 'Examen %{number}:'
   exams: Exámenes
   exercise: Ejercicio
@@ -101,7 +107,7 @@ es:
   female: Mujer
   finish: Terminar
   first_name: Nombre
-  forbidden_explanation: Es decir que no tenés autorización para ver este contenido. <br> ¿Puede que hayas ingresado con una cuenta incorrecta?
+  forbidden_explanation: ¿Puede que hayas ingresado con una cuenta incorrecta?
   format: Dar formato
   fullscreen: "Pantalla completa"
   gender: Género

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -50,7 +50,7 @@ es:
   confirm_reset: Estás por reiniciar tu ejercicio. ¿Querés continuar?
   confirm_restart: Estás por borrar tu progreso en esta guía. ¿Querés continuar?
   console: Consola
-  contact_administrator: 'Si pensás que es un error, comunicate con la persona que administra esta organización: %{link}'
+  contact_administrator: 'Si pensás que es un error, comunicate con %{link}'
   content: Contenido
   continue_exercise: "Continuar"
   continue_lesson: ¡Continuá esta lección!
@@ -87,7 +87,7 @@ es:
   errored: ¡Ups! Tu solución no se puede ejecutar
   error:
     title:
-      forbidden: ¡Ups! No tenés autorización para ver este contenido
+      forbidden: No tenés autorización para ver este contenido
       gone: ¡Ups! El contenido expiró
       internal_server_error: ¡Ups! Algo no anduvo bien
       not_found: ¡Ups!  La página no existe

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -45,7 +45,7 @@ pt:
   confirm_reset: Você está prestes a reiniciar seu exercício. Você quer continuar?
   confirm_restart: Você está prestes a apagar o seu progresso neste guia. Você quer continuar?
   console: Consola
-  contact_administrator: Se você acha que é um erro, entre em contato com a pessoa que gerencia essa organização %{link}
+  contact_administrator: Se você acha que é um erro, entre em contato com %{link}
   content: Conteúdo
   continue_exercise: Continuar
   continue_lesson: Continue esta lição!
@@ -83,7 +83,7 @@ pt:
   errored: Opa! Sua solução não pode ser executada
   error:
     title:
-      forbidden: Opa! Você não tem autorização para ver esse conteúdo
+      forbidden: Você não tem autorização para ver esse conteúdo
       gone: Opa! O conteúdo expirou
       internal_server_error: Opa! Algo não estava certo
       not_found: Opa! A página que você pesquisou não existe

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -74,13 +74,19 @@ pt:
   edit_profile: Editar perfil
   editor_placeholder: ... Escreva sua solução aqui ...
   email: E-mail
-  error_description: Opa! <br> Isto é o que é conhecido como <span class = "error-link"> %{error} </ span>.
+  error_description: Isto é o que é conhecido como <span class = "error-link"> %{error} </ span>.
   error_401: erro 401
   error_403: erro 403
   error_404: erro 404
   error_410: erro 410
   error_500: erro 500
   errored: Opa! Sua solução não pode ser executada
+  error:
+    title:
+      forbidden: Opa! Você não tem autorização para ver esse conteúdo
+      gone: Opa! O conteúdo expirou
+      internal_server_error: Opa! Algo não estava certo
+      not_found: Opa! A página que você pesquisou não existe
   exam_number: 'Revise %{number}:'
   exams: Examesca
   exercise: Exercício
@@ -97,7 +103,7 @@ pt:
   female: Feminino
   finish: Terminar
   first_name: Nome
-  forbidden_explanation: Isso significa que você não tem autorização para ver esse conteúdo. <br> Você poderia ter entrado com uma conta incorreta?
+  forbidden_explanation: Você poderia ter entrado com uma conta incorreta?
   format: Formato
   fullscreen: Tela completa
   gender: Gênero

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -237,7 +237,6 @@ pt:
   solve_your_doubts: Consulte suas dúvidas
   solve_your_doubts_teaser: Você tem alguma dúvida?
   something_went_wrong: Oops!, Algo não estava certo ...
-  something_went_wrong_explanation: Algo não foi como esperado.
   sort: Ordenar
   sources: Bibliografia
   start_lesson: Comece esta lição!

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -177,7 +177,7 @@ pt:
   no_submissions: Parece que você ainda não tentou resolver este exercício!
   no_useful_result: Não encontrou o que estava buscando?
   not_found: A página que você pesquisou não existe!
-  not_found_explanation: Olhe se você escreveu o endereço corretamente. Mas...
+  not_found_explanation: Olhe se você escreveu o endereço corretamente.
   not_in_any_organizations: Parece que você ainda não está em nenhuma organização!
   notify_problem_with_exercise: Relatar um erro
   office: Secretariado

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -29,7 +29,7 @@ pt:
   back_to_mumuki: Voltei para Mumuki!
   bibliotheca_ui: Biblioteca
   birthdate: Fecha de nacimiento
-  blocked_forum_explanation: Você não tem permissão para ver este conteúdo. <br> Você está no meio de um exame agora?
+  blocked_forum_explanation: Você está no meio de um exame agora?
   cancel: Cancelar
   chapter: Capítulo
   chapters: Capítulos

--- a/spec/features/home_private_flow_spec.rb
+++ b/spec/features/home_private_flow_spec.rb
@@ -49,7 +49,7 @@ feature 'private org' do
       set_current_user! visitor
 
       visit '/'
-      expect(page).to have_text('You are not allowed to see this content.')
+      expect(page).to have_text('You are not allowed to see this content')
       expect(visitor.reload.last_organization).to be nil
     end
 


### PR DESCRIPTION
# :dart: Goal 

This PR improves error messages by making them more self-explaining, easier to read and reducing unnecessary details. Most error scenarios are now expressed in 2 lines instead of 4.  

# :memo: Details

* _Back to mumuki_ button has been removed, since it pointed to `central` and most of the times that was a terrible idea
* Titles have been added to all errors
* Font size has been maximized 
* Error codes have been hidden - but can be enabled by styling `mu-error-status-line`
* New css classes have been added in order to make customization easier - `mu-error-status-line`, `mu-error-explanation-line` and `mu-error-contact-line`, and `mu-maybe`
* _Contact admin_ messages have been improved and displayed in a smaller size - since we don't want to encourage user to make that contact before actually checking the upper line. 
* Link to github issues has been removed in 404 scenarios


# :camera_flash: Screenshots

## `disabled_organization_explanation`

![screencapture-localhost-3000-central-ssdsds-2020-10-01-17_37_39](https://user-images.githubusercontent.com/677436/94861728-61b16100-040e-11eb-9f6e-f0e07eaabbad.png)

## `unprepared_organization_explanation`

![screencapture-localhost-3000-central-ssdsds-2020-10-01-17_35_05](https://user-images.githubusercontent.com/677436/94861730-62e28e00-040e-11eb-8591-b8b92c478853.png)

## `gone_explanation`

## :arrow_backward:  Before 

![screencapture-localhost-3000-central-ssdsds-2020-10-01-18_43_12](https://user-images.githubusercontent.com/677436/94866688-303c9380-0416-11eb-9ff4-0129b99e7adb.png)

### :arrow_forward:   After

![screencapture-localhost-3000-central-ssdsds-2020-10-01-17_26_41](https://user-images.githubusercontent.com/677436/94861733-637b2480-040e-11eb-9fc7-161fe1b13c8a.png)

##  `blocked_forum_explanation`

![screencapture-localhost-3000-central-ssdsds-2020-10-01-17_10_36](https://user-images.githubusercontent.com/677436/94861736-6413bb00-040e-11eb-8de0-38c09517274c.png)

## `disabled_explanation`

### :arrow_backward: Before

![screencapture-localhost-3000-central-ssdsds-2020-10-01-18_42_47](https://user-images.githubusercontent.com/677436/94866692-316dc080-0416-11eb-85ec-462ff82b8317.png)

### :arrow_forward: After

![screencapture-localhost-3000-central-ssdsds-2020-10-01-17_08_14](https://user-images.githubusercontent.com/677436/94861739-64ac5180-040e-11eb-85dc-4a63b148e27b.png)

## `forbidden_explanation`

![screencapture-localhost-3000-central-ssdsds-2020-10-01-17_04_53](https://user-images.githubusercontent.com/677436/94861749-67a74200-040e-11eb-9ae4-a923f3c56c97.png)

## `not_found_explanation`

### :arrow_backward: Before

![screencapture-localhost-3000-central-ssdsds-2020-10-01-18_40_54](https://user-images.githubusercontent.com/677436/94866696-33378400-0416-11eb-8375-1dfb5b234d9c.png)



### :arrow_forward:  After - With visible status codes

![screencapture-localhost-3000-central-ssdsds-2020-10-01-16_39_34](https://user-images.githubusercontent.com/677436/94861757-6aa23280-040e-11eb-991c-c955cf2de283.png)

### :arrow_forward:  After -  With hidden status codes

![screencapture-localhost-3000-central-ssdsds-2020-10-01-17_07_40](https://user-images.githubusercontent.com/677436/94861742-65dd7e80-040e-11eb-8fb2-9bbaf6d82a23.png)

## `internal_server_error`

### Before

![screencapture-localhost-3000-central-ssdsds-2020-10-01-18_41_25](https://user-images.githubusercontent.com/677436/94866695-329eed80-0416-11eb-9f35-460841293bf3.png)


### :arrow_forward:  After - With hidden status codes

![screencapture-localhost-3000-central-ssdsds-2020-10-01-17_06_16](https://user-images.githubusercontent.com/677436/94861744-66761500-040e-11eb-8762-6a9fcc92f371.png)

### :arrow_forward:  After - With visible status codes


![screencapture-localhost-3000-central-ssdsds-2020-10-01-16_44_38](https://user-images.githubusercontent.com/677436/94861753-683fd880-040e-11eb-9258-6c69c20e091e.png)


