### PR TITLE
Fixing non-clickable issue in error messages

### DIFF
--- a/app/assets/stylesheets/mumuki_laboratory/application/_errors.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/_errors.scss
@@ -13,9 +13,7 @@
       margin: 30px auto;
       max-height: 350px;
       &.error-code-img {
-        margin-top: -80px;
-        margin-left: 0;
-        margin-bottom: 0;
+        margin: 0;
         min-height: 310px;
         max-height: 500px;
         width: calc(100%);

--- a/app/views/layouts/_error.html.erb
+++ b/app/views/layouts/_error.html.erb
@@ -2,9 +2,6 @@
     <%= home_breadcrumb %>
 <% end %>
 
-
-<%= content_for :no_container do %>
-  <div class="error-message">
-    <%= yield %>
-  </div>
-<% end %>
+<div class="error-message">
+  <%= yield %>
+</div>


### PR DESCRIPTION
# :dart: Goal 

Make login and breadcrumbs clickeable on error messages

# :memo: Details

Currently profile button is clickeable on error messages, but login and breadcrumbs `<a>` are not, because of a negative margin of the error image. This PR just remove that negative margin. 

# :camera_flash: Screenshots

## :arrow_backward: Before

![Screenshot_2020-10-14_22-44-17](https://user-images.githubusercontent.com/677436/96066159-f4bab400-0e6e-11eb-8bad-2abbd86eb7aa.png)

![Screenshot_2020-10-14_22-48-02](https://user-images.githubusercontent.com/677436/96067127-67c42a80-0e6f-11eb-97d4-f694564a80ff.png)



## :arrow_forward: After

![Screenshot_2020-10-14_22-45-12](https://user-images.githubusercontent.com/677436/96066149-f4221d80-0e6e-11eb-851e-ff23f4e650a2.png)

![Screenshot_2020-10-14_22-48-21](https://user-images.githubusercontent.com/677436/96067122-6692fd80-0e6f-11eb-954e-be167efa3563.png)