### PR TITLE
Fix mobile profile buttons

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/profile.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/profile.js
@@ -1,7 +1,7 @@
 mumuki.load(function() {
   let $userForm = $("#mu-user-form");
   let $userAvatar = $('#mu-user-avatar');
-  let $editButton = $('#mu-edit-profile-btn');
+  let $editButton = $('.mu-edit-profile-btn');
   let $avatarPicker = $('#mu-avatar-picker');
   let $avatarItem = $('.mu-avatar-item');
 

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_profile.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_profile.scss
@@ -20,6 +20,15 @@
       border-color: lighten($mu-color-complementary, 15%);
     }
   }
+
+  &.mobile {
+    text-align: center;
+    margin: 20px 5px -20px -10px;
+
+    .btn {
+      width: calc(50% - 20px);
+    }
+  }
 }
 
 .mu-profile-info {

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -1,10 +1,10 @@
 module ProfileHelper
   def edit_profile_button
-    link_to t(:edit_profile), edit_user_path, class: 'btn btn-success'
+    link_to t(:edit_profile), :edit_user, class: 'btn btn-success'
   end
 
   def cancel_edit_profile_button
-    link_to t(:cancel), :user_path, class: 'btn btn-default' if current_user.profile_completed?
+    link_to t(:cancel), :user, class: 'btn btn-default' if current_user.profile_completed?
   end
 
   def save_edit_profile_button(form)

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -4,7 +4,7 @@ module ProfileHelper
   end
 
   def cancel_edit_profile_button
-    link_to t(:cancel), :back, class: 'btn btn-default' if current_user.profile_completed?
+    link_to t(:cancel), :user_path, class: 'btn btn-default' if current_user.profile_completed?
   end
 
   def save_edit_profile_button(form)

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -2,4 +2,12 @@ module ProfileHelper
   def edit_profile_button
     link_to t(:edit_profile), edit_user_path, class: 'btn btn-success'
   end
+
+  def cancel_edit_profile_button
+    link_to t(:cancel), :back, class: 'btn btn-default' if current_user.profile_completed?
+  end
+
+  def save_edit_profile_button(form)
+    form.submit t(:save), disabled: true, class: 'btn btn-success mu-edit-profile-btn'
+  end
 end

--- a/app/views/users/_edit_user_form.html.erb
+++ b/app/views/users/_edit_user_form.html.erb
@@ -1,9 +1,9 @@
 <%= form_for :user, url: update_user_path, :html => { id: 'mu-user-form' }, method: :put do |f| %>
   <div class="mu-user-header">
     <h1><%= t(:edit_profile) %></h1>
-    <div class="mu-profile-actions">
+    <div class="mu-profile-actions hidden-xs">
       <%= link_to t(:cancel), :back, class: 'btn btn-default' if @user.profile_completed? %>
-      <%= f.submit t(:save), disabled: true, class: 'btn btn-success', id: 'mu-edit-profile-btn' %>
+      <%= f.submit t(:save), disabled: true, class: 'btn btn-success mu-edit-profile-btn' %>
     </div>
   </div>
   <div class="row mu-tab-body">
@@ -14,6 +14,10 @@
     <div class="col-md-8">
       <%= render partial: 'profile_fields', locals: {form: f} %>
     </div>
+  </div>
+  <div class="mu-profile-actions mobile visible-xs">
+    <%= link_to t(:cancel), :back, class: 'btn btn-default' if @user.profile_completed? %>
+    <%= f.submit t(:save), disabled: true, class: 'btn btn-success mu-edit-profile-btn' %>
   </div>
 <% end %>
 

--- a/app/views/users/_edit_user_form.html.erb
+++ b/app/views/users/_edit_user_form.html.erb
@@ -2,8 +2,8 @@
   <div class="mu-user-header">
     <h1><%= t(:edit_profile) %></h1>
     <div class="mu-profile-actions hidden-xs">
-      <%= link_to t(:cancel), :back, class: 'btn btn-default' if @user.profile_completed? %>
-      <%= f.submit t(:save), disabled: true, class: 'btn btn-success mu-edit-profile-btn' %>
+      <%= cancel_edit_profile_button %>
+      <%= save_edit_profile_button f %>
     </div>
   </div>
   <div class="row mu-tab-body">
@@ -16,8 +16,8 @@
     </div>
   </div>
   <div class="mu-profile-actions mobile visible-xs">
-    <%= link_to t(:cancel), :back, class: 'btn btn-default' if @user.profile_completed? %>
-    <%= f.submit t(:save), disabled: true, class: 'btn btn-success mu-edit-profile-btn' %>
+    <%= cancel_edit_profile_button %>
+    <%= save_edit_profile_button f %>
   </div>
 <% end %>
 

--- a/app/views/users/_user_form.html.erb
+++ b/app/views/users/_user_form.html.erb
@@ -1,6 +1,6 @@
 <div class="mu-user-header">
   <h1><%= @user.name %></h1>
-  <div class="mu-profile-actions">
+  <div class="mu-profile-actions hidden-xs">
     <%= edit_profile_button %>
   </div>
 </div>
@@ -20,5 +20,9 @@
     <div>
       <span> <strong><%= t :programming_since %>:</strong> <%= t(:time_since, time: time_ago_in_words(@user.created_at)) %> </span>
     </div>
+  </div>
+
+  <div class="mu-profile-actions mobile visible-xs">
+    <%= edit_profile_button %>
   </div>
 </div>


### PR DESCRIPTION
Closes #1470

I moved the buttons to the bottom. The edit profile button didn't look good between the name and the avatar, and I tried between the avatar and the profile fields too and it didn't look good either. An edit icon next to the name is another option, but even then there might be long names + small screens where it'll still look wrong.

For the cancel / save edition buttons it makes the most sense to have them at the bottom, too. Scroll to edit, keep scrolling and save. On mobile, they look out of place at the top, and it makes you scroll down to edit then up to save.

I'm keeping stuff as it is on larger screens, of course.

____

This is the edit profile view on a very thin iPhone 5

<img src="https://user-images.githubusercontent.com/11304439/95884267-47527e00-0d52-11eb-83f0-b7217481628d.png" width="320" height="568">

_____

This is the profile view on a wider phone

<img src="https://user-images.githubusercontent.com/11304439/95884236-3e61ac80-0d52-11eb-98c3-b722422c3199.png" width="411" height="823">
