### PR TITLE
Chore decouple central usages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,14 +40,17 @@ class ApplicationController < ActionController::Base
                 :extension_javascript_url
 
   def should_redirect_to_main_organization?
+    # TODO use immersive contexts here
     should_choose_organization? && current_user.has_immersive_main_organization?
   end
 
   def redirect_to_main_organization!
+    # TODO use immersive contexts here
     redirect_to current_user.main_organization.url_for(request.path)
   end
 
   def should_choose_organization?
+    # TODO use immersive contexts here
     current_user? &&
       current_user.has_student_granted_organizations? &&
       Mumukit::Platform.implicit_organization?(request)

--- a/app/helpers/open_graph_helper.rb
+++ b/app/helpers/open_graph_helper.rb
@@ -3,7 +3,7 @@ module OpenGraphHelper
     %Q{
       <meta property="og:site_name" content="#{Organization.current.site_name}" />
       <meta property="og:title" content="#{h page_title(subject)}"/>
-      <meta property="og:description" content="#{Organization.current.central? ? t(:mumuki_short_description) : Organization.current.description}"/>
+      <meta property="og:description" content="#{Organization.current.description}"/>
       <meta property="og:type" content="website"/>
       <meta property="og:image" content="#{Organization.current.open_graph_image_url}"/>
       <meta property="og:url" content="#{request.original_url}"/>

--- a/app/helpers/organization_list_helper.rb
+++ b/app/helpers/organization_list_helper.rb
@@ -1,5 +1,6 @@
 module OrganizationListHelper
   def organizations_for(user)
+    # TODO use immersive contexts here
     (user.student_granted_organizations + [Organization.central]).uniq.compact
   end
 end

--- a/app/helpers/page_title_helper.rb
+++ b/app/helpers/page_title_helper.rb
@@ -5,7 +5,7 @@ module PageTitleHelper
     if subject && !subject.new_record?
       "#{subject.friendly} - #{name}"
     else
-      "#{name} - #{t :mumuki_catchphrase}"
+      "#{name}"
     end
   end
 end

--- a/app/views/book/_header.html.erb
+++ b/app/views/book/_header.html.erb
@@ -1,7 +1,7 @@
 <div class="book-header <%= current_user? ? '' : 'logged' %>">
   <h1>ム mumuki<%= Organization.current.title_suffix %></h1>
 
-  <img src="<%= Organization.current.banner_url %>" alt="<%= Organization.current.display_name %> - Mumuki">
+  <img src="<%= Organization.current.banner_url %>" alt="<%= Organization.current.display_name %>">
   <h2><%= @book.name %></h2>
 
   <% unless Organization.current.central? %>

--- a/app/views/book/_header.html.erb
+++ b/app/views/book/_header.html.erb
@@ -4,13 +4,7 @@
   <img src="<%= Organization.current.banner_url %>" alt="<%= Organization.current.display_name %>">
   <h2><%= @book.name %></h2>
 
-  <% unless Organization.current.central? %>
-    <h3>
-      <small><%= Organization.current.description %></small>
-      <br>
-      <small><%= t :powered_by_mumuki_html %></small>
-    </h3>
-  <% end %>
+  <h3><small><%= Organization.current.description %></small></h3>
 </div>
 
 <div class="text-box">

--- a/app/views/book/_header.html.erb
+++ b/app/views/book/_header.html.erb
@@ -1,7 +1,7 @@
 <div class="book-header <%= current_user? ? '' : 'logged' %>">
   <h1>ム mumuki<%= Organization.current.title_suffix %></h1>
 
-  <img src="<%= Organization.current.banner_url %>" alt="<%= Organization.current.name %> - Mumuki">
+  <img src="<%= Organization.current.banner_url %>" alt="<%= Organization.current.display_name %> - Mumuki">
   <h2><%= @book.name %></h2>
 
   <% unless Organization.current.central? %>

--- a/app/views/layouts/_main.html.erb
+++ b/app/views/layouts/_main.html.erb
@@ -6,7 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <% end %>
 
-  <meta name="description" content="<%= t :mumuki_short_description %>"/>
+  <meta name="description" content="<%= Organization.current.description %>"/>
+
+
 
   <%= open_graph_tags subject %>
   <%= assets_include_tags %>

--- a/app/views/layouts/_organization_chooser.html.erb
+++ b/app/views/layouts/_organization_chooser.html.erb
@@ -10,13 +10,6 @@
           <%= render partial: 'layouts/organizations_listing' %>
         </div>
       </div>
-      <div class="modal-footer">
-        <div class="row">
-          <div class="col-md-12 pull-right">
-            <%= link_to t(:stay_here), Organization.central.url_for(request.path) %>
-          </div>
-        </div>
-      </div>
     </div>
   </div>
 </div>

--- a/lib/mumuki/laboratory/controllers/current_organization.rb
+++ b/lib/mumuki/laboratory/controllers/current_organization.rb
@@ -2,7 +2,7 @@ module Mumuki::Laboratory::Controllers::CurrentOrganization
   def set_current_organization!
     Organization.find_by!(name: organization_name).switch!
   rescue => e
-    Organization.central.switch!
+    Organization.base.switch!
     raise e
   end
 

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -149,7 +149,6 @@ en:
   more_messages: More
   moderator: Mentor
   mumuki_catchphrase: Improve your programming skills
-  mumuki_short_description: Mumuki is a simple, open and collaborative platform for sharing and solving programming exercises. It is aimed to help people with learning and teaching programing languages and paradigms
   my_doubts: My doubts
   my_submissions: My Submissions
   name: Name

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -233,7 +233,6 @@ en:
   start_practicing: Start Practicing!
   start_using_mumuki: Start using Mumuki!
   status: Status
-  stay_here: I want to stay here
   stop_emails?: Want to stop getting emails?
   submission: submission
   submission_date: Submission date

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -189,7 +189,6 @@ en:
   permissions: Permissions
   please_fill_profile_data: Please complete your profile data to continue!
   please_validate: 'Please validate your data before continue:'
-  powered_by_mumuki_html: "powered by <span class=\"da da-mumuki-circle\"></span> mumuki"
   previous_exercise: Previous
   problem_with_exercise: '[Mumuki] Problem with exercise: %{title}'
   processing_your_solution: We are processing you solution

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -148,7 +148,6 @@ en:
   messages_error: Previous messages are unavailable. Please try again later.
   more_messages: More
   moderator: Mentor
-  mumuki_catchphrase: Improve your programming skills
   my_doubts: My doubts
   my_submissions: My Submissions
   name: Name

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -244,7 +244,6 @@ es-CL:
   start_practicing: ¡Empieza ahora!
   start_using_mumuki: ¡Empieza a usar Mumuki!
   status: Estado
-  stay_here: No, quiero quedarme acá
   stop_emails?: ¿Quieres dejar de recibir estos mails?
   subscribe: Recibir notificaciones
   submission: solución

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -154,7 +154,6 @@ es-CL:
   more_messages: Ver mensajes anteriores
   moderator: Moderador
   mumuki_catchphrase: Aprende a programar
-  mumuki_short_description: Mumuki es la plataforma libre y gratuita para aprender a programar, de la práctica a la teoría y en tu idioma
   my_doubts: Mis consultas
   name: Nombre
   navigation_continue: 'Siguiente %{kind}: %{sibling}'

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -199,7 +199,6 @@ es-CL:
   permissions: Permisos
   please_fill_profile_data: ¡Completa tus datos personales para continuar!
   please_validate: 'Estás a punto de ingresar al curso. Para poder ofrecerte una mejor experiencia, por favor valida que tus datos a continuación sean reales y correctos.'
-  powered_by_mumuki_html: "por <span class=\"da da-mumuki-circle\"></span> mumuki"
   previous_exercise: Anterior
   problem_with_exercise: '[Mumuki] Error con el ejercicio: %{title}'
   processing_your_solution: Estamos procesando tu solución

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -153,7 +153,6 @@ es-CL:
   minutes: minutos
   more_messages: Ver mensajes anteriores
   moderator: Moderador
-  mumuki_catchphrase: Aprende a programar
   my_doubts: Mis consultas
   name: Nombre
   navigation_continue: 'Siguiente %{kind}: %{sibling}'

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -161,7 +161,6 @@ es:
   more_messages: Ver mensajes anteriores
   moderator: Mentor
   mumuki_catchphrase: Aprendé a programar
-  mumuki_short_description: Mumuki es la plataforma libre y gratuita para aprender a programar, de la práctica a la teoría y en tu idioma
   my_doubts: Mis consultas
   name: Nombre
   navigation_continue: 'Siguiente %{kind}: %{sibling}'

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -160,7 +160,6 @@ es:
   minutes: minutos
   more_messages: Ver mensajes anteriores
   moderator: Mentor
-  mumuki_catchphrase: Aprendé a programar
   my_doubts: Mis consultas
   name: Nombre
   navigation_continue: 'Siguiente %{kind}: %{sibling}'

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -255,7 +255,6 @@ es:
   start_practicing: ¡Empezá ahora!
   start_using_mumuki: ¡Empezá a usar Mumuki!
   status: Estado
-  stay_here: No, quiero quedarme acá
   stop_emails?: ¿Querés dejar de recibir estos mails?
   subscribe: Recibir notificaciones
   submission: solución

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -206,7 +206,6 @@ es:
   permissions: Permisos
   please_fill_profile_data: ¡Completá tus datos personales para continuar!
   please_validate: 'Estás a punto de ingresar al curso. Para poder ofrecerte una mejor experiencia, por favor validá que tus datos a continuación sean reales y correctos.'
-  powered_by_mumuki_html: "por <span class=\"da da-mumuki-circle\"></span> mumuki"
   previous_exercise: Anterior
   problem_with_exercise: '[Mumuki] Error con el ejercicio: %{title}'
   processing_your_solution: Estamos procesando tu solución

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -241,7 +241,6 @@ pt:
   start_lesson: Comece esta lição!
   start_practicing: Comece agora!
   status: Estado
-  stay_here: Não, eu quero ficar aqui
   submission: solução
   submission_date: Data de envio
   submission_for_exercise: Solução para exercício

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -197,7 +197,6 @@ pt:
   permissions: Permissões
   please_fill_profile_data: Preencha suas informações pessoais para continuar!
   please_validate: Você está prestes a entrar no curso. Para oferecer uma experiência melhor, valide que seus dados abaixo sejam reais e corretos.
-  powered_by_mumuki_html: por <span class = "da da-mumuki-circle"> </ span> mumuki
   previous_exercise: Anterior
   problem_with_exercise: '[Mumuki] Erro com exercício %{title}'
   processing_your_solution: Estamos processando sua solução

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -154,7 +154,6 @@ pt:
   minutes: minutos
   more_messages: Ver as mensagens anteriores
   moderator: Mentor
-  mumuki_catchphrase: Aprendi a programar
   my_doubts: Minhas duvidas
   name: Nome
   navigation_continue: "Próximo %{kind}: %{sibling}"

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -155,7 +155,6 @@ pt:
   more_messages: Ver as mensagens anteriores
   moderator: Mentor
   mumuki_catchphrase: Aprendi a programar
-  mumuki_short_description: Mumuki é a plataforma gratuita e gratuita para aprender a programar, desde a prática até a teoria e no seu idioma
   my_doubts: Minhas duvidas
   name: Nome
   navigation_continue: "Próximo %{kind}: %{sibling}"

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -7,6 +7,7 @@ def set_subdomain_host!(subdomain)
 end
 
 def set_implicit_central!
+  warn "Implicit behaviour is going to be removed soon"
   @request.try { |it| it.host = Mumukit::Platform.laboratory.domain }
   Capybara.app_host = Mumukit::Platform.laboratory.url
 end

--- a/spec/features/choose_organization_spec.rb
+++ b/spec/features/choose_organization_spec.rb
@@ -8,7 +8,7 @@ feature 'Choose organization Flow' do
   let(:user4) { create(:user, permissions: {student: 'immersive-orga/*'}) }
 
   before do
-    %w(pdep central foo immersive-orga).each do |it|
+    %w(pdep central foo immersive-orga base).each do |it|
       create(:organization,
              name: it,
              book: create(:book,

--- a/spec/features/home_private_flow_spec.rb
+++ b/spec/features/home_private_flow_spec.rb
@@ -59,7 +59,6 @@ feature 'private org' do
       visit '/'
 
       expect(student.reload.last_organization).to eq current_organization
-      expect(page).to have_text('powered by mumuki')
       expect(page).to have_text(current_organization.description)
       expect(page).to have_text(current_organization.book.description)
     end
@@ -70,7 +69,6 @@ feature 'private org' do
       visit '/'
 
       expect(teacher.reload.last_organization).to eq current_organization
-      expect(page).to have_text('powered by mumuki')
       expect(page).to have_text(current_organization.description)
       expect(page).to have_text(current_organization.book.description)
     end

--- a/spec/features/not_found_public_flow_spec.rb
+++ b/spec/features/not_found_public_flow_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 feature 'not found public on app' do
   let!(:central) { create(:organization, name: 'central') }
+  let!(:base) { create(:organization, name: 'base') }
   let!(:some_orga) { create(:public_organization, name: 'someorga', profile: profile) }
 
   let(:profile) { Mumuki::Domain::Organization::Profile.parse json  }

--- a/spec/features/not_found_public_flow_spec.rb
+++ b/spec/features/not_found_public_flow_spec.rb
@@ -8,12 +8,6 @@ feature 'not found public on app' do
   let(:profile) { Mumuki::Domain::Organization::Profile.parse json  }
   let(:json) { { contact_email: 'some@email.com', locale: 'en', errors_explanations: { 404 => 'Some explanation'} } }
 
-  scenario 'when routes does not exist in implicit central' do
-    visit '/foo'
-
-    expect(page).to have_text('You may have mistyped the address')
-  end
-
   scenario 'when route does not exist in explicit central' do
     set_subdomain_host! 'test'
 

--- a/spec/helpers/page_title_helper_spec.rb
+++ b/spec/helpers/page_title_helper_spec.rb
@@ -12,8 +12,8 @@ describe PageTitleHelper, organization_workspace: :test do
 
     before { reindex_current_organization! }
 
-    it { expect(page_title nil).to eq 'Mumuki - test - Improve your programming skills' }
-    it { expect(page_title Problem.new).to eq 'Mumuki - test - Improve your programming skills' }
+    it { expect(page_title nil).to eq 'Mumuki - test' }
+    it { expect(page_title Problem.new).to eq 'Mumuki - test' }
     it { expect(page_title exercise).to eq 'C1: A Guide - An Exercise - Mumuki - test' }
   end
 end


### PR DESCRIPTION
# :dart: Goal

To remove code that depends either syntactically or semantically from `central` concept

# :memo: Details

* `central` or very mumuki.io-specific translations have been removed
* `display_name` was favored over `name` for organizations
* some implicit-organization-related TODOs have been added 
* now mumuki switches to `base` instead of `central` when an organization is not found before raising the error
* `powered_by` tag has been removed on non-central organizations, and organization has been added in all contexts

# :camera: Screenshots

## :arrow_backward: Before

![image](https://user-images.githubusercontent.com/677436/97052701-e009aa80-1557-11eb-958e-ae7f3ea3dc5c.png)


![image](https://user-images.githubusercontent.com/677436/97052592-a89afe00-1557-11eb-963f-56d0f34e3e53.png)


## :arrow_forward: After

![image](https://user-images.githubusercontent.com/677436/97052668-cf593480-1557-11eb-8f27-04a9c23d6f3b.png)


![image](https://user-images.githubusercontent.com/677436/97052621-b51f5680-1557-11eb-89d8-58f7e3239322.png)


# :soon: Future work

We should review usages and implementation of `site_name` and `title_suffix` methods from `Organization`, whose semantics are not clear - particularly after central concerns removal. 

# :eyes: See also 

* https://github.com/mumuki/mumuki-domain/issues/147
* https://github.com/mumuki/mumuki-domain/commit/0f1357252effad4dfaeea4bf05284a3b4810bd5d
