### PR TITLE
Chore run tests on common browsers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,15 @@ env:
   global:
   - secure: IW65qMjgbuuj4kUsBwaY+iV+jaIedgf2V3W7bTLj1SjaNdc8hC9SXBiNWQrT9Ygu5Q67mKzXuu5GTyAvAGftF02UKgT+yDE43p+a9w2+Onx5dGTIXCCREIE9fgmQhAkqgt9+1E99fRWsQzqkpEVINOMvumk+HM/Rxg8B9e5jvB8=
   - MOZ_HEADLESS=1
+jobs:
+  include:
+    - {}
+    - script: bundle exec rake capybara
+      addons:
+        chrome: stable
+      env: MUMUKI_CAPYBARA_DRIVER=selenium_chrome_headless
+    - script: bundle exec rake capybara
+      env: MUMUKI_CAPYBARA_DRIVER=selenium_headless
 deploy:
   - provider: rubygems
     api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,10 +62,9 @@ jobs:
         postgresql: "10"
         <<: *hosts
       before_script:
-        - export PG_DATA=$(brew --prefix)/var/postgres
-        - rm -rf $PG_DATA
-        - initdb $PG_DATA -E utf8
-        - pg_ctl -w start -l postgres.log --pgdata ${PG_DATA}
+        - rm -rf /usr/local/var/postgres
+        - initdb /usr/local/var/postgres
+        - pg_ctl -D /usr/local/var/postgres start
         - createuser -s postgres
         - sudo /usr/bin/safaridriver --enable
         - psql -c 'create database travis_ci_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,56 +4,53 @@ rvm:
 - 2.6.3
 before_install:
 - gem install -v 2.0.2 bundler
-- wget https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz
-- mkdir geckodriver && tar -xzf geckodriver-v0.27.0-linux64.tar.gz -C geckodriver && rm geckodriver-v0.27.0-linux64.tar.gz
-- export PATH=$PATH:$PWD/geckodriver
 before_script:
 - psql -c 'create database travis_ci_test;' -U postgres
 - cp spec/dummy/config/database.travis.yml spec/dummy/config/database.yml
-script:
 - bundle exec rake db:schema:load
-- bundle exec rake teaspoon
-- bundle exec rake
 services:
 - postgresql
-addons:
-  firefox: '79.0'
+_shared_addons: &shared_addons
   hosts:
     - localmumuki.io
-    - base.localmumuki.io
-    - central.localmumuki.io
-    - empty.localmumuki.io
-    - foo.localmumuki.io
-    - immersive-orga.localmumuki.io
-    - private.localmumuki.io
-    - someorga.localmumuki.io
     - test.localmumuki.io
     - the-public-org.localmumuki.io
-env:
-  global:
-  - secure: IW65qMjgbuuj4kUsBwaY+iV+jaIedgf2V3W7bTLj1SjaNdc8hC9SXBiNWQrT9Ygu5Q67mKzXuu5GTyAvAGftF02UKgT+yDE43p+a9w2+Onx5dGTIXCCREIE9fgmQhAkqgt9+1E99fRWsQzqkpEVINOMvumk+HM/Rxg8B9e5jvB8=
-  - MOZ_HEADLESS=1
+    - private.localmumuki.io
 jobs:
   include:
-    - {}
-    - script: bundle exec rake capybara
+    # All Ruby tests, including Capybara with default driver
+    - script: bundle exec rake
+
+    # Capybara and Teaspoon tests on Chrome
+    - script:
+        - bundle exec rake capybara
+        - bundle exec rake teaspoon
       addons:
+        <<: *shared_addons
         chrome: stable
         apt:
           packages:
             - chromium-chromedriver
-        hosts:
-        - localmumuki.io
-        - test.localmumuki.io
-        - the-public-org.localmumuki.io
-        - private.localmumuki.io
       env: MUMUKI_CAPYBARA_DRIVER=selenium_chrome_headless
+      before_install:
+        - gem install -v 2.0.2 bundler
+        - ln -s /usr/lib/chromium-browser/chromedriver "${HOME}/bin/chromedriver"
+
+    # Capybara and Teaspoon tests on Firefox
+    - script:
+        - bundle exec rake capybara
+        - bundle exec rake teaspoon
+      addons:
+        <<: *shared_addons
+        firefox: '79.0'
+      env: MUMUKI_CAPYBARA_DRIVER=selenium_headless MOZ_HEADLESS=1
       before_script:
         - psql -c 'create database travis_ci_test;' -U postgres
         - cp spec/dummy/config/database.travis.yml spec/dummy/config/database.yml
-        - ln -s /usr/lib/chromium-browser/chromedriver "${HOME}/bin/chromedriver"
-    - script: bundle exec rake capybara
-      env: MUMUKI_CAPYBARA_DRIVER=selenium_headless
+        - bundle exec rake db:schema:load
+        - wget https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz
+        - mkdir geckodriver && tar -xzf geckodriver-v0.27.0-linux64.tar.gz -C geckodriver && rm geckodriver-v0.27.0-linux64.tar.gz
+        - export PATH=$PATH:$PWD/geckodriver
 deploy:
   - provider: rubygems
     api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,24 @@
 language: ruby
-cache: bundler
+cache:
+  bundler: true
+  directories:
+    - ~/.webdrivers
 rvm:
 - 2.6.3
+env:
+  global:
+    - WD_CACHE_TIME=0
 before_install:
 - gem install -v 2.0.2 bundler
 before_script:
 - psql -c 'create database travis_ci_test;' -U postgres
 - cp spec/dummy/config/database.travis.yml spec/dummy/config/database.yml
 - bundle exec rake db:schema:load
+- export PATH=~/.webdrivers:$PATH
 services:
 - postgresql
-_shared_addons: &shared_addons
+- xvfb
+_hosts: &hosts
   hosts:
     - localmumuki.io
     - test.localmumuki.io
@@ -22,35 +30,22 @@ jobs:
     - script: bundle exec rake
 
     # Capybara and Teaspoon tests on Chrome
-    - script:
+    - env: MUMUKI_CAPYBARA_DRIVER=selenium_chrome_headless
+      script:
         - bundle exec rake capybara
         - bundle exec rake teaspoon
       addons:
-        <<: *shared_addons
         chrome: stable
-        apt:
-          packages:
-            - chromium-chromedriver
-      env: MUMUKI_CAPYBARA_DRIVER=selenium_chrome_headless
-      before_install:
-        - gem install -v 2.0.2 bundler
-        - ln -s /usr/lib/chromium-browser/chromedriver "${HOME}/bin/chromedriver"
+        <<: *hosts
 
     # Capybara and Teaspoon tests on Firefox
-    - script:
+    - env: MUMUKI_CAPYBARA_DRIVER=selenium_headless MOZ_HEADLESS=1
+      script:
         - bundle exec rake capybara
         - bundle exec rake teaspoon
       addons:
-        <<: *shared_addons
         firefox: '79.0'
-      env: MUMUKI_CAPYBARA_DRIVER=selenium_headless MOZ_HEADLESS=1
-      before_script:
-        - psql -c 'create database travis_ci_test;' -U postgres
-        - cp spec/dummy/config/database.travis.yml spec/dummy/config/database.yml
-        - bundle exec rake db:schema:load
-        - wget https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz
-        - mkdir geckodriver && tar -xzf geckodriver-v0.27.0-linux64.tar.gz -C geckodriver && rm geckodriver-v0.27.0-linux64.tar.gz
-        - export PATH=$PATH:$PWD/geckodriver
+        <<: *hosts
 deploy:
   - provider: rubygems
     api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,27 @@ jobs:
       addons:
         firefox: '79.0'
         <<: *hosts
+
+    # Capybara and Teaspoon tests on Safari
+    - env: MUMUKI_CAPYBARA_DRIVER=selenium_safari
+      os: osx
+      osx_image: xcode10.2
+      addons:
+        postgresql: "9.5"
+        <<: *hosts
+      before_install:
+        - rm -rf /usr/local/var/postgres
+        - initdb /usr/local/var/postgres
+        - pg_ctl -D /usr/local/var/postgres start
+        - createuser -s postgres
+        - gem install -v 2.0.2 bundler
+      before_script:
+        - sudo /usr/bin/safaridriver --enable
+        - psql -c 'create database travis_ci_test;' -U postgres
+        - cp ./spec/dummy/config/database.travis.yml ./spec/dummy/config/database.yml
+        - bundle exec rake db:schema:load
+        - export PATH=~/.webdrivers:$PATH
+      script: bundle exec rake capybara
 deploy:
   - provider: rubygems
     api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ jobs:
         - gem install -v 2.0.2 bundler
       before_script:
         - sudo /usr/bin/safaridriver --enable
-        - psql -c 'create database travis_ci_test;' -U postgres
+        - psql -c 'create database travis_ci_test; create database development;' -U postgres
         - cp ./spec/dummy/config/database.travis.yml ./spec/dummy/config/database.yml
         - bundle exec rake db:schema:load
         - export PATH=~/.webdrivers:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,17 @@ services:
 - postgresql
 addons:
   firefox: '79.0'
+  hosts:
+    - localmumuki.io
+    - base.localmumuki.io
+    - central.localmumuki.io
+    - empty.localmumuki.io
+    - foo.localmumuki.io
+    - immersive-orga.localmumuki.io
+    - private.localmumuki.io
+    - someorga.localmumuki.io
+    - test.localmumuki.io
+    - the-public-org.localmumuki.io
 env:
   global:
   - secure: IW65qMjgbuuj4kUsBwaY+iV+jaIedgf2V3W7bTLj1SjaNdc8hC9SXBiNWQrT9Ygu5Q67mKzXuu5GTyAvAGftF02UKgT+yDE43p+a9w2+Onx5dGTIXCCREIE9fgmQhAkqgt9+1E99fRWsQzqkpEVINOMvumk+HM/Rxg8B9e5jvB8=

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,19 @@ jobs:
     - script: bundle exec rake capybara
       addons:
         chrome: stable
+        apt:
+          packages:
+            - chromium-chromedriver
+        hosts:
+        - localmumuki.io
+        - test.localmumuki.io
+        - the-public-org.localmumuki.io
+        - private.localmumuki.io
       env: MUMUKI_CAPYBARA_DRIVER=selenium_chrome_headless
+      before_script:
+        - psql -c 'create database travis_ci_test;' -U postgres
+        - cp spec/dummy/config/database.travis.yml spec/dummy/config/database.yml
+        - ln -s /usr/lib/chromium-browser/chromedriver "${HOME}/bin/chromedriver"
     - script: bundle exec rake capybara
       env: MUMUKI_CAPYBARA_DRIVER=selenium_headless
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,15 +61,13 @@ jobs:
       addons:
         postgresql: "10"
         <<: *hosts
-      before_install:
+      before_script:
         - rm -rf /usr/local/var/postgres
         - initdb /usr/local/var/postgres
         - pg_ctl -D /usr/local/var/postgres start
         - createuser -s postgres
-        - gem install -v 2.0.2 bundler
-      before_script:
         - sudo /usr/bin/safaridriver --enable
-        - psql -c 'create database travis_ci_test; create database development;' -U postgres
+        - psql -c 'create database travis_ci_test;' -U postgres
         - cp ./spec/dummy/config/database.travis.yml ./spec/dummy/config/database.yml
         - bundle exec rake db:schema:load
         - export PATH=~/.webdrivers:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
     - script: bundle exec rake
 
     # Capybara and Teaspoon tests on Chrome
-    - env: MUMUKI_CAPYBARA_DRIVER=selenium_chrome_headless
+    - env: MUMUKI_CAPYBARA_DRIVER=chrome
       script:
         - bundle exec rake capybara
         - bundle exec rake teaspoon
@@ -45,7 +45,7 @@ jobs:
         <<: *hosts
 
     # Capybara and Teaspoon tests on Firefox
-    - env: MUMUKI_CAPYBARA_DRIVER=selenium_headless MOZ_HEADLESS=1
+    - env: MUMUKI_CAPYBARA_DRIVER=firefox
       script:
         - bundle exec rake capybara
         - bundle exec rake teaspoon
@@ -54,7 +54,7 @@ jobs:
         <<: *hosts
 
     # Capybara and Teaspoon tests on Safari
-    - env: MUMUKI_CAPYBARA_DRIVER=selenium_safari RACK_ENV=test RAILS_ENV=test
+    - env: MUMUKI_CAPYBARA_DRIVER=safari RACK_ENV=test RAILS_ENV=test
       os: osx
       osx_image: xcode10.2
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,13 @@ services:
 _hosts: &hosts
   hosts:
     - localmumuki.io
+    - base.localmumuki.io
+    - central.localmumuki.io
+    - empty.localmumuki.io
+    - foo.localmumuki.io
+    - immersive-orga.localmumuki.io
+    - private.localmumuki.io
+    - someorga.localmumuki.io
     - test.localmumuki.io
     - the-public-org.localmumuki.io
     - private.localmumuki.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ jobs:
       os: osx
       osx_image: xcode10.2
       addons:
-        postgresql: "9.5"
+        postgresql: "10"
         <<: *hosts
       before_install:
         - rm -rf /usr/local/var/postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ _hosts: &hosts
     - the-public-org.localmumuki.io
     - private.localmumuki.io
 jobs:
+  allow_failures:
+    - os: osx
   include:
     # All Ruby tests, including Capybara with default driver
     - script: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
         <<: *hosts
 
     # Capybara and Teaspoon tests on Safari
-    - env: MUMUKI_CAPYBARA_DRIVER=selenium_safari
+    - env: MUMUKI_CAPYBARA_DRIVER=selenium_safari RACK_ENV=test RAILS_ENV=test
       os: osx
       osx_image: xcode10.2
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,9 @@ jobs:
         - cp ./spec/dummy/config/database.travis.yml ./spec/dummy/config/database.yml
         - bundle exec rake db:schema:load
         - export PATH=~/.webdrivers:$PATH
-      script: bundle exec rake capybara
+      script:
+        - bundle exec rake capybara
+        - bundle exec rake teaspoon
 deploy:
   - provider: rubygems
     api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ rvm:
 env:
   global:
     - WD_CACHE_TIME=0
-before_install:
-- gem install -v 2.0.2 bundler
 before_script:
 - psql -c 'create database travis_ci_test;' -U postgres
 - cp spec/dummy/config/database.travis.yml spec/dummy/config/database.yml
@@ -37,43 +35,34 @@ jobs:
     # All Ruby tests, including Capybara with default driver
     - script: bundle exec rake
 
-    # Capybara and Teaspoon tests on Chrome
+    # Web tests on Chrome
     - env: MUMUKI_SELENIUM_DRIVER=chrome
-      script:
-        - bundle exec rake capybara
-        - bundle exec rake teaspoon
+      script: bundle exec rake spec:web
       addons:
         chrome: stable
         <<: *hosts
 
-    # Capybara and Teaspoon tests on Firefox
+    # Web tests on Firefox
     - env: MUMUKI_SELENIUM_DRIVER=firefox
-      script:
-        - bundle exec rake capybara
-        - bundle exec rake teaspoon
+      script: bundle exec rake spec:web
       addons:
         firefox: '79.0'
         <<: *hosts
 
-    # Capybara and Teaspoon tests on Safari
+    # Web tests on Safari
     - env: MUMUKI_SELENIUM_DRIVER=safari RACK_ENV=test RAILS_ENV=test
       os: osx
       osx_image: xcode10.2
       addons:
-        postgresql: "10"
+        postgresql: '10'
         <<: *hosts
-      before_script:
+      before_install:
         - rm -rf /usr/local/var/postgres
         - initdb /usr/local/var/postgres
         - pg_ctl -D /usr/local/var/postgres start
         - createuser -s postgres
         - sudo /usr/bin/safaridriver --enable
-        - psql -c 'create database travis_ci_test;' -U postgres
-        - cp ./spec/dummy/config/database.travis.yml ./spec/dummy/config/database.yml
-        - bundle exec rake db:schema:load
-      script:
-        - bundle exec rake capybara
-        - bundle exec rake teaspoon
+      script: bundle exec rake spec:web
 deploy:
   - provider: rubygems
     api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
     - script: bundle exec rake
 
     # Capybara and Teaspoon tests on Chrome
-    - env: MUMUKI_CAPYBARA_DRIVER=chrome
+    - env: MUMUKI_SELENIUM_DRIVER=chrome
       script:
         - bundle exec rake capybara
         - bundle exec rake teaspoon
@@ -45,7 +45,7 @@ jobs:
         <<: *hosts
 
     # Capybara and Teaspoon tests on Firefox
-    - env: MUMUKI_CAPYBARA_DRIVER=firefox
+    - env: MUMUKI_SELENIUM_DRIVER=firefox
       script:
         - bundle exec rake capybara
         - bundle exec rake teaspoon
@@ -54,7 +54,7 @@ jobs:
         <<: *hosts
 
     # Capybara and Teaspoon tests on Safari
-    - env: MUMUKI_CAPYBARA_DRIVER=safari RACK_ENV=test RAILS_ENV=test
+    - env: MUMUKI_SELENIUM_DRIVER=safari RACK_ENV=test RAILS_ENV=test
       os: osx
       osx_image: xcode10.2
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ before_script:
 - psql -c 'create database travis_ci_test;' -U postgres
 - cp spec/dummy/config/database.travis.yml spec/dummy/config/database.yml
 - bundle exec rake db:schema:load
-- export PATH=~/.webdrivers:$PATH
 services:
 - postgresql
 - xvfb
@@ -70,7 +69,6 @@ jobs:
         - psql -c 'create database travis_ci_test;' -U postgres
         - cp ./spec/dummy/config/database.travis.yml ./spec/dummy/config/database.yml
         - bundle exec rake db:schema:load
-        - export PATH=~/.webdrivers:$PATH
       script:
         - bundle exec rake capybara
         - bundle exec rake teaspoon

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ rvm:
 env:
   global:
     - WD_CACHE_TIME=0
+before_install:
+ - gem install bundler
 before_script:
 - psql -c 'create database travis_ci_test;' -U postgres
 - cp spec/dummy/config/database.travis.yml spec/dummy/config/database.yml
@@ -62,6 +64,7 @@ jobs:
         - pg_ctl -D /usr/local/var/postgres start
         - createuser -s postgres
         - sudo /usr/bin/safaridriver --enable
+        - gem install bundler
       script: bundle exec rake spec:web
 deploy:
   - provider: rubygems

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,9 +62,10 @@ jobs:
         postgresql: "10"
         <<: *hosts
       before_script:
-        - rm -rf /usr/local/var/postgres
-        - initdb /usr/local/var/postgres
-        - pg_ctl -D /usr/local/var/postgres start
+        - export PG_DATA=$(brew --prefix)/var/postgres
+        - rm -rf $PG_DATA
+        - initdb $PG_DATA -E utf8
+        - pg_ctl -w start -l postgres.log --pgdata ${PG_DATA}
         - createuser -s postgres
         - sudo /usr/bin/safaridriver --enable
         - psql -c 'create database travis_ci_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 cache: bundler
-sudo: false
 rvm:
 - 2.6.3
 before_install:
@@ -18,17 +17,11 @@ script:
 services:
 - postgresql
 addons:
-  addons:
-    firefox: '79.0'
-  code_climate:
-    repo_token: 820e155f1bff3d5cfcb84eae1caace7cd9ec5a27540f52222620896dc010b3ee
+  firefox: '79.0'
 env:
-  matrix:
-  - RACK_ENV=test CODECLIMATE_REPO_TOKEN=820e155f1bff3d5cfcb84eae1caace7cd9ec5a27540f52222620896dc010b3ee
   global:
   - secure: IW65qMjgbuuj4kUsBwaY+iV+jaIedgf2V3W7bTLj1SjaNdc8hC9SXBiNWQrT9Ygu5Q67mKzXuu5GTyAvAGftF02UKgT+yDE43p+a9w2+Onx5dGTIXCCREIE9fgmQhAkqgt9+1E99fRWsQzqkpEVINOMvumk+HM/Rxg8B9e5jvB8=
-    global:
-      - MOZ_HEADLESS=1
+  - MOZ_HEADLESS=1
 deploy:
   - provider: rubygems
     api_key:

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'factory_bot_rails', '~> 5.0'
   gem 'faker', '~> 2.2'
   gem 'rake', '~> 12.3'
-  gem 'capybara', '~> 2.3.0'
+  gem 'capybara', '~> 3.33.0'
 end
 
 group :development do

--- a/README.md
+++ b/README.md
@@ -139,21 +139,21 @@ bundle exec rspec
 
 The Capybara config of this project supports running tests on Firefox, Chrome and Safari via Selenium. The [`webdrivers`](https://github.com/titusfortner/webdrivers) gem automatically installs (and updates) all the necessary Selenium webdrivers.
 
-By default, Capybara tests will run with the default dummy-driver (Rack test). If you want to run on a real browser, you should set `MUMUKI_CAPYBARA_DRIVER` variable to `firefox`, `chrome` or `safari`. Also, a Rake task to run just the Capybara tests is available.
+By default, Capybara tests will run with the default dummy-driver (Rack test). If you want to run on a real browser, you should set `MUMUKI_SELENIUM_DRIVER` variable to `firefox`, `chrome` or `safari`. Also, a Rake task to run just the Capybara tests is available.
 
 Some examples:
 
 ```bash
 # Run all tests, using Firefox for Capybara
-MUMUKI_CAPYBARA_DRIVER=firefox bundle exec rake
+MUMUKI_SELENIUM_DRIVER=firefox bundle exec rake
 
 # Run Capybara tests on Chrome
-MUMUKI_CAPYBARA_DRIVER=chrome bundle exec rake capybara
+MUMUKI_SELENIUM_DRIVER=chrome bundle exec rake capybara
 ```
 
 ## Running JS tests
 
-The [`webdrivers`](https://github.com/titusfortner/webdrivers) gem also works with Teaspoon, no need to install anything manually.
+The [`webdrivers`](https://github.com/titusfortner/webdrivers) gem also works with Teaspoon, no need to install anything manually. By default tests run on Firefox, but this behavior can be changed by setting `MUMUKI_SELENIUM_DRIVER` (see section above).
 
 ```bash
 bundle exec rake teaspoon

--- a/README.md
+++ b/README.md
@@ -132,7 +132,11 @@ rails s
 ## Running tests
 
 ```bash
-bundle exec rspec
+# Run all tests
+bundle exec rake
+
+# Run only web tests (i.e. Capybara and Teaspoon)
+bundle exec rake spec:web
 ```
 
 ## Running Capybara tests with Selenium
@@ -144,11 +148,11 @@ By default, Capybara tests will run with the default dummy-driver (Rack test). I
 Some examples:
 
 ```bash
-# Run all tests, using Firefox for Capybara
-MUMUKI_SELENIUM_DRIVER=firefox bundle exec rake
+# Run web tests, using Firefox
+MUMUKI_SELENIUM_DRIVER=firefox bundle exec rake spec:web
 
 # Run Capybara tests on Chrome
-MUMUKI_SELENIUM_DRIVER=chrome bundle exec rake capybara
+MUMUKI_SELENIUM_DRIVER=chrome bundle exec rake spec:web:capybara
 ```
 
 ## Running JS tests
@@ -156,7 +160,7 @@ MUMUKI_SELENIUM_DRIVER=chrome bundle exec rake capybara
 The [`webdrivers`](https://github.com/titusfortner/webdrivers) gem also works with Teaspoon, no need to install anything manually. By default tests run on Firefox, but this behavior can be changed by setting `MUMUKI_SELENIUM_DRIVER` (see section above).
 
 ```bash
-bundle exec rake teaspoon
+bundle exec rake spec:web:teaspoon
 ```
 
 ## Running `eslint`

--- a/README.md
+++ b/README.md
@@ -137,11 +137,10 @@ bundle exec rspec
 
 ## Running JS tests
 
-> You need first to download [geckodriver](https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz), uncrompress
-> it and add it to your path
+The [`webdrivers`](https://github.com/titusfortner/webdrivers) gem automatically installs (and updates) all the necessary Selenium webdrivers. For Teaspoon to work, the `~/.webdrivers` folder should be in your `PATH` - you can do that on the usual places (`.bashrc`, `.zshrc`, `.bash_profile`, etc) or directly on the command:
 
 ```bash
-MOZ_HEADLESS=1 bundle exec rake teaspoon
+PATH=~/.webdrivers:$PATH MOZ_HEADLESS=1 bundle exec rake teaspoon
 ```
 
 ## Running `eslint`

--- a/README.md
+++ b/README.md
@@ -135,12 +135,28 @@ rails s
 bundle exec rspec
 ```
 
-## Running JS tests
+## Running Capybara tests with Selenium
 
-The [`webdrivers`](https://github.com/titusfortner/webdrivers) gem automatically installs (and updates) all the necessary Selenium webdrivers. For Teaspoon to work, the `~/.webdrivers` folder should be in your `PATH` - you can do that on the usual places (`.bashrc`, `.zshrc`, `.bash_profile`, etc) or directly on the command:
+The Capybara config of this project supports running tests on Firefox, Chrome and Safari via Selenium. The [`webdrivers`](https://github.com/titusfortner/webdrivers) gem automatically installs (and updates) all the necessary Selenium webdrivers.
+
+By default, Capybara tests will run with the default dummy-driver (Rack test). If you want to run on a real browser, you should set `MUMUKI_CAPYBARA_DRIVER` variable to `firefox`, `chrome` or `safari`. Also, a Rake task to run just the Capybara tests is available.
+
+Some examples:
 
 ```bash
-PATH=~/.webdrivers:$PATH MOZ_HEADLESS=1 bundle exec rake teaspoon
+# Run all tests, using Firefox for Capybara
+MUMUKI_CAPYBARA_DRIVER=firefox bundle exec rake
+
+# Run Capybara tests on Chrome
+MUMUKI_CAPYBARA_DRIVER=chrome bundle exec rake capybara
+```
+
+## Running JS tests
+
+The [`webdrivers`](https://github.com/titusfortner/webdrivers) gem also works with Teaspoon, no need to install anything manually.
+
+```bash
+bundle exec rake teaspoon
 ```
 
 ## Running `eslint`

--- a/Rakefile
+++ b/Rakefile
@@ -33,6 +33,10 @@ task :development do
   ENV['RAILS_ENV'] = 'development'
 end
 
+RSpec::Core::RakeTask.new(:capybara => 'app:db:test:prepare') do |t|
+  t.pattern = 'spec/features/*_spec.rb'
+end
+
 desc "Run the javascript specs"
 task teaspoon: [:development, "app:teaspoon"]
 

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ require 'rspec/core'
 require 'rspec/core/rake_task'
 
 desc "Run all specs in spec directory (excluding plugin specs)"
-RSpec::Core::RakeTask.new(:spec => 'app:db:test:prepare')
+RSpec::Core::RakeTask.new(:spec)
 
 desc "Force development environment, required by javascript specs"
 task :development do

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ require 'rspec/core'
 require 'rspec/core/rake_task'
 
 desc "Run all specs in spec directory (excluding plugin specs)"
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new
 
 desc "Force development environment, required by javascript specs"
 task :development do
@@ -33,7 +33,7 @@ task :development do
   ENV['RAILS_ENV'] = 'development'
 end
 
-RSpec::Core::RakeTask.new(:capybara => 'app:db:test:prepare') do |t|
+RSpec::Core::RakeTask.new(:capybara) do |t|
   t.pattern = 'spec/features/*_spec.rb'
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -33,12 +33,15 @@ task :development do
   ENV['RAILS_ENV'] = 'development'
 end
 
-RSpec::Core::RakeTask.new(:capybara) do |t|
+RSpec::Core::RakeTask.new('spec:web:capybara') do |t|
   t.pattern = 'spec/features/*_spec.rb'
 end
 
 desc "Run the javascript specs"
-task teaspoon: [:development, "app:teaspoon"]
+task 'spec:web:teaspoon': [:development, "app:teaspoon"]
+
+desc "Run all the web-related tests"
+task 'spec:web': ['spec:web:capybara', 'spec:web:teaspoon']
 
 task default: :spec
 

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -44,4 +44,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'pg', '~> 0.18.0'
   s.add_development_dependency 'bundler', '~> 2.0'
+  s.add_development_dependency 'webdrivers', '~> 4.4'
 end

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -38,14 +38,8 @@ end
 
 def register_safari_driver!
   # No official docs for this, code was taken from https://github.com/teamcapybara/capybara/blob/master/spec/selenium_spec_safari.rb
-  if ::Selenium::WebDriver::Service.respond_to? :driver_path=
-    ::Selenium::WebDriver::Safari::Service
-  else
-    ::Selenium::WebDriver::Safari
-  end.driver_path = '/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver'
-
   Capybara.register_driver :selenium_safari do |app|
-    Capybara::Selenium::Driver.new(app, browser: :safari, options: browser_options, timeout: 30)
+    Capybara::Selenium::Driver.new(app, browser: :safari, timeout: 30)
   end
 end
 

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -8,8 +8,9 @@ def page_body
 end
 
 def set_request_header!(key, value)
-  if Capybara.current_session.driver.respond_to? :header
-    Capybara.current_session.driver.header key, value
+  current_driver = Capybara.current_session.driver
+  if current_driver.respond_to? :header
+    current_driver.header key, value
   else
     $custom_headers = {key => value}
   end

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -30,7 +30,7 @@ end
 # Config helpers
 
 def selected_driver
-  case ENV['MUMUKI_CAPYBARA_DRIVER']
+  case ENV['MUMUKI_SELENIUM_DRIVER']
   when 'chrome'
     :selenium_chrome_headless
   when 'firefox'

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -30,7 +30,16 @@ end
 # Config helpers
 
 def selected_driver
-  ENV['MUMUKI_CAPYBARA_DRIVER']&.to_sym || :rack_test
+  case ENV['MUMUKI_CAPYBARA_DRIVER']
+  when 'chrome'
+    :selenium_chrome_headless
+  when 'firefox'
+    :selenium_headless
+  when 'safari'
+    :selenium_safari
+  else
+    :rack_test
+  end
 end
 
 def run_with_selenium?

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -1,25 +1,7 @@
 require 'capybara/rails'
 require 'capybara/rspec'
 
-def selected_driver
-  ENV['MUMUKI_CAPYBARA_DRIVER']&.to_sym || :rack_test
-end
-
-def run_with_selenium?
-  selected_driver.to_s.start_with? 'selenium'
-end
-
-Capybara.default_driver = selected_driver
-
-if run_with_selenium?
-  # TODO: fix the tests that depend on hidden elements and remove this
-  Capybara.ignore_hidden_elements = false
-
-  # Include port on the URL, so we don't need to forward it via nginx or so
-  Capybara.always_include_port = true
-end
-
-puts "Running Capybara tests with #{selected_driver}, #{Capybara.ignore_hidden_elements ? '' : 'not '}ignoring hidden elements"
+# Test helpers
 
 def set_subdomain_host!(subdomain)
   @request.try { |it| it.host = Mumukit::Platform.laboratory.organic_domain subdomain }
@@ -31,3 +13,41 @@ def set_implicit_central!
   @request.try { |it| it.host = Mumukit::Platform.laboratory.domain }
   Capybara.app_host = Mumukit::Platform.laboratory.url
 end
+
+# Config helpers
+
+def selected_driver
+  ENV['MUMUKI_CAPYBARA_DRIVER']&.to_sym || :rack_test
+end
+
+def run_with_selenium?
+  selected_driver.to_s.start_with? 'selenium'
+end
+
+def register_safari_driver!
+  # No official docs for this, code was taken from https://github.com/teamcapybara/capybara/blob/master/spec/selenium_spec_safari.rb
+  if ::Selenium::WebDriver::Service.respond_to? :driver_path=
+    ::Selenium::WebDriver::Safari::Service
+  else
+    ::Selenium::WebDriver::Safari
+  end.driver_path = '/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver'
+
+  Capybara.register_driver :selenium_safari do |app|
+    Capybara::Selenium::Driver.new(app, browser: :safari, options: browser_options, timeout: 30)
+  end
+end
+
+# Configuration
+
+register_safari_driver! if selected_driver == :selenium_safari
+Capybara.default_driver = selected_driver
+
+if run_with_selenium?
+  # TODO: fix the tests that depend on hidden elements and remove this
+  Capybara.ignore_hidden_elements = false
+
+  # Include port on the URL, so we don't need to forward it via nginx or so
+  Capybara.always_include_port = true
+end
+
+puts "Running Capybara tests with #{selected_driver}, #{Capybara.ignore_hidden_elements ? '' : 'not '}ignoring hidden elements"

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -1,6 +1,24 @@
 require 'capybara/rails'
 require 'capybara/rspec'
 
+def selected_driver
+  ENV['MUMUKI_CAPYBARA_DRIVER']&.to_sym || :rack_test
+end
+
+def run_with_selenium?
+  selected_driver.to_s.start_with? 'selenium'
+end
+
+Capybara.server_port = 31337
+Capybara.default_driver = selected_driver
+
+# TODO: fix the tests that depend on hidden elements and remove this
+if run_with_selenium?
+  Capybara.ignore_hidden_elements = false
+end
+
+puts "Running Capybara tests with #{selected_driver}, #{Capybara.ignore_hidden_elements ? '' : 'not '}ignoring hidden elements"
+
 def set_subdomain_host!(subdomain)
   @request.try { |it| it.host = Mumukit::Platform.laboratory.organic_domain subdomain }
   Capybara.app_host = Mumukit::Platform.laboratory.organic_url subdomain

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -3,6 +3,14 @@ require 'capybara/rspec'
 
 # Test helpers
 
+def set_request_header!(key, value)
+  if Capybara.current_session.driver.respond_to? :header
+    Capybara.current_session.driver.header key, value
+  else
+    $custom_headers = {key => value}
+  end
+end
+
 def set_subdomain_host!(subdomain)
   @request.try { |it| it.host = Mumukit::Platform.laboratory.organic_domain subdomain }
   Capybara.app_host = Mumukit::Platform.laboratory.organic_url subdomain
@@ -37,14 +45,38 @@ def register_safari_driver!
   end
 end
 
+def register_request_headers_middleware!
+  RSpec.configure do |config|
+    config.after(:suite) do
+      $custom_headers = nil
+    end
+  end
+
+  Object.class_eval <<-EOR
+    module RequestWithExtraHeaders
+      def headers
+        $custom_headers.each { |key, value| self.set_header "HTTP_\#{key}", value } if $custom_headers
+        super
+      end
+    end
+
+    class ActionDispatch::Request
+      prepend RequestWithExtraHeaders
+    end
+  EOR
+end
+
 # Configuration
 
 register_safari_driver! if selected_driver == :selenium_safari
 Capybara.default_driver = selected_driver
 
+# TODO: fix the tests that depend on hidden elements and remove this
+Capybara.ignore_hidden_elements = false
+
 if run_with_selenium?
-  # TODO: fix the tests that depend on hidden elements and remove this
-  Capybara.ignore_hidden_elements = false
+  # Selenium Webdriver has no native support for settings request headers, so this workaround is necessary
+  register_request_headers_middleware!
 
   # Include port on the URL, so we don't need to forward it via nginx or so
   Capybara.always_include_port = true

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -9,12 +9,14 @@ def run_with_selenium?
   selected_driver.to_s.start_with? 'selenium'
 end
 
-Capybara.server_port = 31337
 Capybara.default_driver = selected_driver
 
-# TODO: fix the tests that depend on hidden elements and remove this
 if run_with_selenium?
+  # TODO: fix the tests that depend on hidden elements and remove this
   Capybara.ignore_hidden_elements = false
+
+  # Include port on the URL, so we don't need to forward it via nginx or so
+  Capybara.always_include_port = true
 end
 
 puts "Running Capybara tests with #{selected_driver}, #{Capybara.ignore_hidden_elements ? '' : 'not '}ignoring hidden elements"

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -3,6 +3,10 @@ require 'capybara/rspec'
 
 # Test helpers
 
+def page_body
+  find('body')
+end
+
 def set_request_header!(key, value)
   if Capybara.current_session.driver.respond_to? :header
     Capybara.current_session.driver.header key, value

--- a/spec/features/choose_organization_spec.rb
+++ b/spec/features/choose_organization_spec.rb
@@ -43,7 +43,7 @@ feature 'Choose organization Flow' do
       expect(page).to have_text('Do you want to go there?')
     end
 
-    scenario 'when visiting with implicit subdomain and permissions to only one immersive organization' do
+    scenario 'when visiting with implicit subdomain and permissions to only one immersive organization', :navigation_error do
       set_current_user! user4
       set_implicit_central!
 
@@ -84,7 +84,7 @@ feature 'Choose organization Flow' do
     end
   end
 
-  scenario 'when organization does not exist' do
+  scenario 'when organization does not exist', :http_response_headers do
     visit '/'
 
     expect(page).to have_http_status(404)

--- a/spec/features/disable_user_flow_spec.rb
+++ b/spec/features/disable_user_flow_spec.rb
@@ -17,7 +17,7 @@ feature 'disable user flow', organization_workspace: :test do
     scenario 'enabled visitor' do
       visit '/'
 
-      expect(page).to have_text(current_organization.book.name)
+      expect(page_body).to have_text(current_organization.book.name)
       expect(user.reload.last_organization).to eq current_organization
     end
 
@@ -26,7 +26,7 @@ feature 'disable user flow', organization_workspace: :test do
 
       visit '/'
 
-      expect(page).to_not have_text(current_organization.book.name)
-      expect(page).to have_text('You are trying to visit a permamently disabled or deleted resource')
+      expect(page_body).to_not have_text(current_organization.book.name)
+      expect(page_body).to have_text('You are trying to visit a permamently disabled or deleted resource')
     end
 end

--- a/spec/features/disabled_organization_flow_spec.rb
+++ b/spec/features/disabled_organization_flow_spec.rb
@@ -17,7 +17,7 @@ feature 'disable user flow', organization_workspace: :test do
   scenario 'enabled organization' do
     visit '/'
 
-    expect(page).to have_text(current_organization.book.name)
+    expect(page_body).to have_text(current_organization.book.name)
     expect(user.reload.last_organization).to eq current_organization
   end
 
@@ -28,15 +28,15 @@ feature 'disable user flow', organization_workspace: :test do
     scenario 'visit /' do
       visit '/'
 
-      expect(page).to_not have_text(current_organization.book.name)
-      expect(page).to have_text(I18n.t(:unprepared_organization_explanation))
+      expect(page_body).to_not have_text(current_organization.book.name)
+      expect(page_body).to have_text(I18n.t(:unprepared_organization_explanation))
     end
 
     scenario 'visit /user' do
       visit '/test/user'
 
-      expect(page).to_not have_text(current_organization.book.name)
-      expect(page).to have_text(I18n.t(:unprepared_organization_explanation))
+      expect(page_body).to_not have_text(current_organization.book.name)
+      expect(page_body).to have_text(I18n.t(:unprepared_organization_explanation))
     end
 
   end
@@ -48,15 +48,15 @@ feature 'disable user flow', organization_workspace: :test do
     scenario 'visit /' do
       visit '/'
 
-      expect(page).to_not have_text(current_organization.book.name)
-      expect(page).to have_text(I18n.t(:disabled_organization_explanation))
+      expect(page_body).to_not have_text(current_organization.book.name)
+      expect(page_body).to have_text(I18n.t(:disabled_organization_explanation))
     end
 
     scenario 'visit /user' do
       visit '/test/user'
 
-      expect(page).to_not have_text(current_organization.book.name)
-      expect(page).to have_text(I18n.t(:disabled_organization_explanation))
+      expect(page_body).to_not have_text(current_organization.book.name)
+      expect(page_body).to have_text(I18n.t(:disabled_organization_explanation))
     end
 
     end

--- a/spec/features/exercise_flow_spec.rb
+++ b/spec/features/exercise_flow_spec.rb
@@ -182,7 +182,7 @@ feature 'Exercise Flow', organization_workspace: :test do
       expect(page.find("#mu-exercise-layout")['value']).to eq('input_right')
     end
 
-    scenario 'visit exercise by id, upload layout, not queriable language' do
+    scenario 'visit exercise by id, upload layout, not queriable language', :invalid_selector_error do
       visit "/exercises/#{problem_5.id}"
 
       expect(page).to have_text('Succ5')
@@ -272,7 +272,7 @@ feature 'Exercise Flow', organization_workspace: :test do
       expect(page).not_to have_xpath("//a[@title='Edit']")
     end
 
-    scenario 'writer should see the edit exercise link' do
+    scenario 'writer should see the edit exercise link', :xpath_no_matches do
       set_current_user! writer
 
       visit "/exercises/#{problem_2.id}"

--- a/spec/features/guide_reset_spec.rb
+++ b/spec/features/guide_reset_spec.rb
@@ -39,7 +39,7 @@ feature 'Guide Reset Flow', organization_workspace: :test do
       expect(page).to_not have_xpath(restart_xpath)
     end
 
-    scenario 'visit guide with solutions sent for it' do
+    scenario 'visit guide with solutions sent for it', :xpath_no_matches do
       problem.submit_solution! user
 
       visit "/lessons/#{lesson.id}"

--- a/spec/features/guides_flow_spec.rb
+++ b/spec/features/guides_flow_spec.rb
@@ -115,7 +115,7 @@ feature 'Guides Flow', organization_workspace: :test do
         expect(page).not_to have_xpath("//a[@title='Edit']")
       end
 
-      scenario 'writer should see the edit guide link' do
+      scenario 'writer should see the edit guide link', :xpath_no_matches do
         set_current_user! writer
 
         visit "/guides/#{lesson.guide.id}"

--- a/spec/features/home_private_flow_spec.rb
+++ b/spec/features/home_private_flow_spec.rb
@@ -45,7 +45,7 @@ feature 'private org' do
       allow_any_instance_of(ApplicationController).to receive(:from_sessions?).and_return(false)
     end
 
-    scenario 'visitor should raise forbidden error' do
+    scenario 'visitor should raise forbidden error', :organization_not_nil do
       set_current_user! visitor
 
       visit '/'

--- a/spec/features/home_public_flow_spec.rb
+++ b/spec/features/home_public_flow_spec.rb
@@ -17,7 +17,7 @@ feature 'public org', organization_workspace: :test do
 
   context 'anonymous visitor' do
     scenario 'from outside' do
-      Capybara.current_session.driver.header 'Referer', 'http://google.com'
+      set_request_header! 'Referer', 'http://google.com'
 
       visit '/'
 
@@ -28,7 +28,7 @@ feature 'public org', organization_workspace: :test do
     end
 
     scenario 'from inside' do
-      Capybara.current_session.driver.header 'Referer', 'http://en.mumuki.io/exercises/1'
+      set_request_header! 'Referer', 'http://en.mumuki.io/exercises/1'
 
       visit '/'
 
@@ -44,7 +44,7 @@ feature 'public org', organization_workspace: :test do
     before { exam.authorize! user }
 
     scenario 'from outside' do
-      Capybara.current_session.driver.header 'Referer', 'http://google.com'
+      set_request_header! 'Referer', 'http://google.com'
 
       visit '/'
 
@@ -56,7 +56,7 @@ feature 'public org', organization_workspace: :test do
     end
 
     scenario 'from inside' do
-      Capybara.current_session.driver.header 'Referer', 'http://en.mumuki.io/exercises/1'
+      set_request_header! 'Referer', 'http://en.mumuki.io/exercises/1'
 
       visit '/'
 
@@ -76,7 +76,7 @@ feature 'public org', organization_workspace: :test do
     before { exam.authorize! user }
 
     scenario 'from inside' do
-      Capybara.current_session.driver.header 'Referer', 'http://google.com'
+      set_request_header! 'Referer', 'http://google.com'
 
       visit '/'
 
@@ -90,7 +90,7 @@ feature 'public org', organization_workspace: :test do
   context 'incognito user' do
     before { current_organization.update! incognito_mode_enabled: true }
     scenario 'from inside' do
-      Capybara.current_session.driver.header 'Referer', 'http://google.com'
+      set_request_header! 'Referer', 'http://google.com'
 
       visit '/'
 

--- a/spec/features/invitations_flow_spec.rb
+++ b/spec/features/invitations_flow_spec.rb
@@ -9,7 +9,7 @@ feature 'Invitations Flow', organization_workspace: :test do
       create(:lesson, guide: guide)
     ]) }
   let(:book) { organization.book }
- 
+
   before do
     book.update! chapters: [chapter]
   end
@@ -33,7 +33,7 @@ feature 'Invitations Flow', organization_workspace: :test do
   context 'with existing memberships' do
     let(:permissions) { { student: 'test/nodejs' } }
 
-    scenario 'visit invitation, already joined' do
+    scenario 'visit invitation, already joined', :navigation_error do
       visit '/join/invitacionAlNodejs'
       expect(page).to have_text('Start Practicing!')
     end

--- a/spec/features/login_flow_spec.rb
+++ b/spec/features/login_flow_spec.rb
@@ -24,7 +24,7 @@ feature 'Login Flow', organization_workspace: :test do
     expect(page).to have_text('Sign Out')
   end
 
-  scenario 'can login and keeps session' do
+  scenario 'can login and keeps session', :navigation_error do
     visit '/'
 
     click_on 'Sign in'
@@ -45,7 +45,7 @@ feature 'Login Flow', organization_workspace: :test do
     expect(page).to have_text('awesomeRubyGuide')
   end
 
-  scenario 'can logout' do
+  scenario 'can logout', :element_not_interactable_error do
     visit '/'
 
     click_on 'Sign in'

--- a/spec/features/not_found_private_flow_spec.rb
+++ b/spec/features/not_found_private_flow_spec.rb
@@ -23,7 +23,7 @@ feature 'not found private on app', organization_workspace: :base do
   end
 
   scenario 'api without authorization' do
-    Capybara.current_session.driver.header 'Authorization', "Bearer #{student_api_client.token}"
+    set_request_header! 'Authorization', "Bearer #{student_api_client.token}"
 
     visit '/api/nonexistentroute'
 
@@ -34,7 +34,7 @@ feature 'not found private on app', organization_workspace: :base do
   end
 
   scenario 'api with authentication' do
-    Capybara.current_session.driver.header 'Authorization', "Bearer #{admin_api_client.token}"
+    set_request_header! 'Authorization', "Bearer #{admin_api_client.token}"
 
     visit '/api/nonexistentroute'
 

--- a/spec/features/not_found_private_flow_spec.rb
+++ b/spec/features/not_found_private_flow_spec.rb
@@ -22,7 +22,7 @@ feature 'not found private on app', organization_workspace: :base do
     expect(page).to have_text 'You may have mistyped the address or the page may have moved'
   end
 
-  scenario 'api without authorization' do
+  scenario 'api without authorization', :json_eq_error do
     set_request_header! 'Authorization', "Bearer #{student_api_client.token}"
 
     visit '/api/nonexistentroute'
@@ -33,7 +33,7 @@ feature 'not found private on app', organization_workspace: :base do
       ' with permissions !student:central/*;teacher:;headmaster:;janitor:;admin:;owner:']
   end
 
-  scenario 'api with authentication' do
+  scenario 'api with authentication', :json_eq_error do
     set_request_header! 'Authorization', "Bearer #{admin_api_client.token}"
 
     visit '/api/nonexistentroute'

--- a/spec/features/profile_flow_spec.rb
+++ b/spec/features/profile_flow_spec.rb
@@ -49,7 +49,7 @@ feature 'Profile Flow', organization_workspace: :test do
       expect(page).to have_text('Please complete your profile data to continue!')
     end
 
-    scenario 'is able to log out' do
+    scenario 'is able to log out', :element_not_interactable_error do
       click_on 'Sign in'
       set_automatic_login! false
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'rspec/rails'
 require 'codeclimate-test-reporter'
 require 'mumukit/core/rspec'
 require 'factory_bot_rails'
-require 'webdrivers' if ENV['CI'] || ENV['WEBDRIVERS']
+require 'webdrivers'
 
 require 'mumuki/domain/factories'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'rspec/rails'
 require 'codeclimate-test-reporter'
 require 'mumukit/core/rspec'
 require 'factory_bot_rails'
+require 'webdrivers' if ENV['CI'] || ENV['WEBDRIVERS']
 
 require 'mumuki/domain/factories'
 

--- a/spec/teaspoon_env.rb
+++ b/spec/teaspoon_env.rb
@@ -112,7 +112,7 @@ Teaspoon.configure do |config|
   #  config.driver = :capybara_webkit
   config.driver = :selenium
   config.driver_options =
-    case ENV['MUMUKI_CAPYBARA_DRIVER']
+    case ENV['MUMUKI_SELENIUM_DRIVER']
     when 'chrome'
       {
         client_driver: :chrome,

--- a/spec/teaspoon_env.rb
+++ b/spec/teaspoon_env.rb
@@ -1,3 +1,6 @@
+require 'selenium-webdriver'
+require 'webdrivers'
+
 unless defined?(Rails)
   ENV["RAILS_ROOT"] = File.expand_path("../dummy", __FILE__)
   require File.expand_path("../dummy/config/environment", __FILE__)
@@ -109,12 +112,17 @@ Teaspoon.configure do |config|
   #  config.driver = :capybara_webkit
   config.driver = :selenium
   config.driver_options =
-    if ENV['MUMUKI_CAPYBARA_DRIVER'] == 'selenium_chrome_headless'
+    case ENV['MUMUKI_CAPYBARA_DRIVER']
+    when 'selenium_chrome_headless'
       {
         client_driver: :chrome,
         selenium_options: {
           options: Selenium::WebDriver::Chrome::Options.new(args: ['headless', 'disable-gpu'])
         }
+      }
+    when 'selenium_safari'
+      {
+        client_driver: :safari,
       }
     else
       {

--- a/spec/teaspoon_env.rb
+++ b/spec/teaspoon_env.rb
@@ -113,14 +113,14 @@ Teaspoon.configure do |config|
   config.driver = :selenium
   config.driver_options =
     case ENV['MUMUKI_CAPYBARA_DRIVER']
-    when 'selenium_chrome_headless'
+    when 'chrome'
       {
         client_driver: :chrome,
         selenium_options: {
           options: Selenium::WebDriver::Chrome::Options.new(args: ['headless', 'disable-gpu'])
         }
       }
-    when 'selenium_safari'
+    when 'safari'
       {
         client_driver: :safari,
       }

--- a/spec/teaspoon_env.rb
+++ b/spec/teaspoon_env.rb
@@ -108,12 +108,22 @@ Teaspoon.configure do |config|
   # Capybara Webkit: https://github.com/modeset/teaspoon/wiki/Using-Capybara-Webkit
   #  config.driver = :capybara_webkit
   config.driver = :selenium
-  config.driver_options = {
-    client_driver: :firefox,
-     selenium_options: {
-      options: Selenium::WebDriver::Firefox::Options.new(log_level: :warn)
-    }
-  }
+  config.driver_options =
+    if ENV['MUMUKI_CAPYBARA_DRIVER'] == 'selenium_chrome_headless'
+      {
+        client_driver: :chrome,
+        selenium_options: {
+          options: Selenium::WebDriver::Chrome::Options.new(args: ['headless', 'disable-gpu'])
+        }
+      }
+    else
+      {
+        client_driver: :firefox,
+        selenium_options: {
+          options: Selenium::WebDriver::Firefox::Options.new(log_level: :warn, args: ['-headless'])
+        }
+      }
+    end
 
   # Specify the timeout for the driver. Specs are expected to complete within this time frame or the run will be
   # considered a failure. This is to avoid issues that can arise where tests stall.


### PR DESCRIPTION
# :dart: Goal

Run Capybara and Teaspoon tests on the three common browsers: Chrome, Firefox and Safari.

# :memo: Details

* Browser is selected by settings `MUMUKI_SELENIUM_DRIVER` env variable. 
* All the web drivers are now installed by the [webdrivers gem](https://github.com/titusfortner/webdrivers).
* Migrated Travis configuration to a multi-job build and updated it to remove obsolete attributes.

# :soon: Future work

Unfortunately, some tests were skipped because they didn't work out of the box with the Selenium driver. We should further investigate if they can be fixed or not.

Also, some tests break on Safari due to user session issues. Until this is fixed, Safari builds on Travis are allowed to fail.

# :eyes: See also 

* #1486
* #1492
* #1479 
