### PR TITLE
Use new display and page methods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'puma'
 gem 'execjs'
 gem 'therubyracer', platforms: :ruby
 gem 'uglifier', '~> 2.7'
+gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'feature-display-and-page-fields'
 
 group :test do
   gem 'rspec-rails', '~> 3.6'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'puma'
 gem 'execjs'
 gem 'therubyracer', platforms: :ruby
 gem 'uglifier', '~> 2.7'
-gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'feature-display-and-page-fields'
+gem 'mumuki-domain', github: 'mumuki/mumuki-domain', ref: 'ddcdafd2fc95aefe49948cbe5e04b5b32943b9b3'
 
 group :test do
   gem 'rspec-rails', '~> 3.6'

--- a/app/helpers/open_graph_helper.rb
+++ b/app/helpers/open_graph_helper.rb
@@ -1,7 +1,7 @@
 module OpenGraphHelper
   def open_graph_tags(subject)
     %Q{
-      <meta property="og:site_name" content="#{Organization.current.site_name}" />
+      <meta property="og:site_name" content="#{Organization.current.display_name}" />
       <meta property="og:title" content="#{h page_title(subject)}"/>
       <meta property="og:description" content="#{Organization.current.description}"/>
       <meta property="og:type" content="website"/>

--- a/app/helpers/page_title_helper.rb
+++ b/app/helpers/page_title_helper.rb
@@ -1,6 +1,6 @@
 module PageTitleHelper
   def page_title(subject)
-    name = "Mumuki#{Organization.current.title_suffix}"
+    name = Organization.current.page_name
 
     if subject && !subject.new_record?
       "#{subject.friendly} - #{name}"

--- a/app/views/book/_header.html.erb
+++ b/app/views/book/_header.html.erb
@@ -1,12 +1,17 @@
+<% @organization = Organization.current %>
 <div class="book-header <%= current_user? ? '' : 'logged' %>">
-  <h1>ム mumuki<%= Organization.current.title_suffix %></h1>
+  <%#
+    H1 is not actually displayed.
+    This weird title structure is kept for backward compatibility only
+  %>
+  <h1><%= @organization.page_name %></h1>
 
-  <img src="<%= Organization.current.banner_url %>" alt="<%= Organization.current.display_name %>">
-  <h2><%= @book.name %></h2>
+  <img src="<%= @organization.banner_url %>" alt="<%= @organization.display_name %>">
+  <h2><%= @organization.page_name %></h2>
 
-  <h3><small><%= Organization.current.description %></small></h3>
+  <h3><small><%= @organization.description %></small></h3>
 </div>
 
 <div class="text-box">
-  <%= @book.description_html %>
+  <%= @organization.page_description_html %>
 </div>

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200804191643) do
+ActiveRecord::Schema.define(version: 20201026225312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,7 +44,8 @@ ActiveRecord::Schema.define(version: 20200804191643) do
     t.bigint "organization_id"
     t.datetime "submitted_at"
     t.bigint "parent_id"
-    t.integer "top_submission_status"
+    t.integer "top_submission_status", default: 0
+    t.boolean "misplaced"
     t.index ["exercise_id"], name: "index_assignments_on_exercise_id"
     t.index ["organization_id"], name: "index_assignments_on_organization_id"
     t.index ["parent_id"], name: "index_assignments_on_parent_id"
@@ -124,9 +125,12 @@ ActiveRecord::Schema.define(version: 20200804191643) do
     t.boolean "requires_moderator_response", default: true
     t.string "last_moderator_access_by_id"
     t.datetime "last_moderator_access_at"
+    t.bigint "status_updated_by_id"
+    t.datetime "status_updated_at"
     t.index ["initiator_id"], name: "index_discussions_on_initiator_id"
     t.index ["item_type", "item_id"], name: "index_discussions_on_item_type_and_item_id"
     t.index ["organization_id"], name: "index_discussions_on_organization_id"
+    t.index ["status_updated_by_id"], name: "index_discussions_on_status_updated_by_id"
   end
 
   create_table "exam_authorizations", force: :cascade do |t|
@@ -311,8 +315,11 @@ ActiveRecord::Schema.define(version: 20200804191643) do
     t.text "theme", default: "{}", null: false
     t.text "profile", default: "{}", null: false
     t.integer "progressive_display_lookahead"
-    t.integer "target_audience", default: 0
     t.boolean "incognito_mode_enabled"
+    t.integer "target_audience", default: 0
+    t.text "display_name"
+    t.text "display_description"
+    t.boolean "wins_page"
     t.index ["book_id"], name: "index_organizations_on_book_id"
     t.index ["name"], name: "index_organizations_on_name", unique: true
   end

--- a/spec/features/disable_user_flow_spec.rb
+++ b/spec/features/disable_user_flow_spec.rb
@@ -17,7 +17,6 @@ feature 'disable user flow', organization_workspace: :test do
     scenario 'enabled visitor' do
       visit '/'
 
-      expect(page).to have_text('ム mumuki')
       expect(page).to have_text(current_organization.book.name)
       expect(user.reload.last_organization).to eq current_organization
     end
@@ -27,7 +26,6 @@ feature 'disable user flow', organization_workspace: :test do
 
       visit '/'
 
-      expect(page).to_not have_text('ム mumuki')
       expect(page).to_not have_text(current_organization.book.name)
       expect(page).to have_text('You are trying to visit a permamently disabled or deleted resource')
     end

--- a/spec/features/disabled_organization_flow_spec.rb
+++ b/spec/features/disabled_organization_flow_spec.rb
@@ -17,7 +17,6 @@ feature 'disable user flow', organization_workspace: :test do
   scenario 'enabled organization' do
     visit '/'
 
-    expect(page).to have_text('ム mumuki')
     expect(page).to have_text(current_organization.book.name)
     expect(user.reload.last_organization).to eq current_organization
   end
@@ -29,7 +28,6 @@ feature 'disable user flow', organization_workspace: :test do
     scenario 'visit /' do
       visit '/'
 
-      expect(page).to_not have_text('ム mumuki')
       expect(page).to_not have_text(current_organization.book.name)
       expect(page).to have_text(I18n.t(:unprepared_organization_explanation))
     end
@@ -37,7 +35,6 @@ feature 'disable user flow', organization_workspace: :test do
     scenario 'visit /user' do
       visit '/test/user'
 
-      expect(page).to_not have_text('ム mumuki')
       expect(page).to_not have_text(current_organization.book.name)
       expect(page).to have_text(I18n.t(:unprepared_organization_explanation))
     end
@@ -51,7 +48,6 @@ feature 'disable user flow', organization_workspace: :test do
     scenario 'visit /' do
       visit '/'
 
-      expect(page).to_not have_text('ム mumuki')
       expect(page).to_not have_text(current_organization.book.name)
       expect(page).to have_text(I18n.t(:disabled_organization_explanation))
     end
@@ -59,7 +55,6 @@ feature 'disable user flow', organization_workspace: :test do
     scenario 'visit /user' do
       visit '/test/user'
 
-      expect(page).to_not have_text('ム mumuki')
       expect(page).to_not have_text(current_organization.book.name)
       expect(page).to have_text(I18n.t(:disabled_organization_explanation))
     end

--- a/spec/features/home_public_flow_spec.rb
+++ b/spec/features/home_public_flow_spec.rb
@@ -21,7 +21,6 @@ feature 'public org', organization_workspace: :test do
 
       visit '/'
 
-      expect(page).to have_text('ム mumuki')
       expect(page).to have_text('First Steps')
       expect(page).to have_selector('.chapter', text: 'Functional Programming')
       expect(page).to have_text(current_organization.book.name)
@@ -33,7 +32,6 @@ feature 'public org', organization_workspace: :test do
 
       visit '/'
 
-      expect(page).to have_text('ム mumuki')
       expect(page).to have_text('First Steps')
       expect(page).to have_selector('.chapter', text: 'Functional Programming')
       expect(page).to have_text(current_organization.book.name)
@@ -50,7 +48,6 @@ feature 'public org', organization_workspace: :test do
 
       visit '/'
 
-      expect(page).to have_text('ム mumuki')
       expect(page).to have_text('First Steps')
       expect(page).to have_selector('.chapter', text: 'Functional Programming')
       expect(page).to have_text(current_organization.book.name)
@@ -63,7 +60,6 @@ feature 'public org', organization_workspace: :test do
 
       visit '/'
 
-      expect(page).to have_text('ム mumuki')
       expect(page).to have_text('First Steps')
       expect(page).to have_selector('.chapter', text: 'Functional Programming')
       expect(page).to_not have_selector('.chapter.mu-locked', text: 'Functional Programming')
@@ -84,7 +80,6 @@ feature 'public org', organization_workspace: :test do
 
       visit '/'
 
-      expect(page).to have_text('ム mumuki')
       expect(page).to have_text('First Steps')
       expect(page).to have_selector('.chapter.mu-locked', text: 'Functional Programming')
       expect(page).to have_text(current_organization.book.name)
@@ -99,7 +94,6 @@ feature 'public org', organization_workspace: :test do
 
       visit '/'
 
-      expect(page).to have_text('ム mumuki')
       expect(page).to have_text('First Steps')
       expect(page).to have_selector('.chapter', text: 'Functional Programming')
       expect(page).to have_text(current_organization.book.name)

--- a/spec/helpers/page_title_helper_spec.rb
+++ b/spec/helpers/page_title_helper_spec.rb
@@ -12,8 +12,8 @@ describe PageTitleHelper, organization_workspace: :test do
 
     before { reindex_current_organization! }
 
-    it { expect(page_title nil).to eq 'Mumuki - test' }
-    it { expect(page_title Problem.new).to eq 'Mumuki - test' }
-    it { expect(page_title exercise).to eq 'C1: A Guide - An Exercise - Mumuki - test' }
+    it { expect(page_title nil).to eq 'test' }
+    it { expect(page_title Problem.new).to eq 'test' }
+    it { expect(page_title exercise).to eq 'C1: A Guide - An Exercise - test' }
   end
 end


### PR DESCRIPTION
# :dart: Goal

To use the `display` and `page` methods  consistently in the UI. 

# :back: Backward compatibility

This PR introduces new features, but is mostly backward compatible. The only visible change is the ム and _mumuki_ work will no longer appear in organization names. 

# :warning: Warnings

Depends on https://github.com/mumuki/mumuki-domain/pull/148

# :camera: Screenshots

## When organization does not win page

![image](https://user-images.githubusercontent.com/677436/97242610-1737c000-17d3-11eb-8a56-1556a96c65b1.png)

## When organization wins page

![image](https://user-images.githubusercontent.com/677436/97242764-77c6fd00-17d3-11eb-85b4-31d582f618cd.png)
