### PR TITLE
Chore terms redirection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,3 +35,5 @@ group :development, :test do
   gem 'teaspoon-jasmine'
   gem "selenium-webdriver"
 end
+#
+gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'chore-terms-redirection'

--- a/Gemfile
+++ b/Gemfile
@@ -35,5 +35,5 @@ group :development, :test do
   gem 'teaspoon-jasmine'
   gem "selenium-webdriver"
 end
-#
-gem 'mumuki-domain', github: 'mumuki/mumuki-domain', ref: 'e3e24a162e52565c4a1ab281dfd70bfb4e28286d'
+
+gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'master'

--- a/Gemfile
+++ b/Gemfile
@@ -36,4 +36,4 @@ group :development, :test do
   gem "selenium-webdriver"
 end
 #
-gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'chore-terms-redirection'
+gem 'mumuki-domain', github: 'mumuki/mumuki-domain', ref: 'e3e24a162e52565c4a1ab281dfd70bfb4e28286d'

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_terms.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_terms.scss
@@ -29,7 +29,13 @@
   padding: 1.25rem;
 }
 
-.terms-acceptance-btn {
-  margin-top: 10px;
-  display: block
+.terms-acceptance {
+  margin-top: 30px;
+
+  .terms-acceptance-btn {
+    margin-top: 10px;
+    display: block
+  }
 }
+
+

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_terms.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_terms.scss
@@ -1,12 +1,3 @@
-summary.terms-summary {
-  font-size: 29px;
-  outline: 0;
-  cursor: pointer;
-  .terms-summary-title {
-    display: inline;
-  }
-}
-
 .terms-card {
   position: relative;
   display: -ms-flexbox;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -106,9 +106,9 @@ class ApplicationController < ActionController::Base
   end
 
   def validate_accepted_role_terms!
-    if current_user.has_role_terms_to_accept?
+    if current_user&.has_role_terms_to_accept?
       flash.notice = I18n.t :accept_terms_to_continue
-      redirect_to user_terms_path
+      redirect_to terms_user_path
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,6 +24,7 @@ class ApplicationController < ActionController::Base
   before_action :authorize_if_private!
   before_action :validate_active_organization!
   before_action :validate_user_profile!, if: :current_user?
+  before_action :validate_accepted_role_terms!, if: :current_user?
 
   before_action :visit_organization!, if: :current_user?
 
@@ -101,6 +102,13 @@ class ApplicationController < ActionController::Base
     unless current_user.profile_completed?
       flash.notice = I18n.t :please_fill_profile_data
       redirect_to edit_user_path
+    end
+  end
+
+  def validate_accepted_role_terms!
+    if current_user.has_role_terms_to_accept?
+      flash.notice = I18n.t :accept_terms_to_continue
+      redirect_to user_terms_path
     end
   end
 

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -3,6 +3,7 @@ class AssetsController < ApplicationController
   protect_from_forgery except: [:theme_stylesheet, :extension_javascript]
   skip_before_action :authorize_if_private!
   skip_before_action :validate_user_profile!
+  skip_before_action :validate_accepted_role_terms!
   skip_before_action :validate_active_organization!
 
   def theme_stylesheet

--- a/app/controllers/book_discussions_controller.rb
+++ b/app/controllers/book_discussions_controller.rb
@@ -2,7 +2,7 @@ class BookDiscussionsController < DiscussionsController
   def terms
     @forum_terms ||= Term.forum_related_terms
   end
-  
+
   private
 
   def set_debatable

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -6,6 +6,7 @@ class InvitationsController < ApplicationController
   before_action :set_user!
 
   skip_before_action :validate_user_profile!
+  skip_before_action :validate_accepted_role_terms!
   skip_before_action :authorize_if_private!
   skip_before_action :validate_active_organization!
 

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -3,6 +3,7 @@ class LoginController < ApplicationController
 
   skip_before_action :verify_authenticity_token, if: lambda { Rails.env.development? }
   skip_before_action :validate_user_profile!
+  skip_before_action :validate_accepted_role_terms!
   skip_before_action :validate_active_organization!
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
 
   before_action :authenticate!, except: :terms
   before_action :set_user!
+  skip_before_action :validate_accepted_role_terms!
 
   def show
     @messages = current_user.messages.to_a
@@ -13,6 +14,11 @@ class UsersController < ApplicationController
     current_user.update_and_notify! user_params
     current_user.accept_profile_terms!
     redirect_to user_path, notice: I18n.t(:user_data_updated)
+  end
+
+  def accept_profile_terms
+    current_user.accept_profile_terms!
+    redirect_to root_path, notice: I18n.t(:terms_accepted)
   end
 
   def terms

--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -52,7 +52,7 @@ module LinksHelper
   end
 
   def link_to_profile_terms
-    link_to t(:terms_and_conditions).downcase, user_terms_path, target: '_blank'
+    link_to t(:terms_and_conditions).downcase, terms_user_path, target: '_blank'
   end
 
   def link_to_forum_terms

--- a/app/views/users/_edit_user_form.html.erb
+++ b/app/views/users/_edit_user_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for :user, url: update_user_path, :html => { id: 'mu-user-form' }, method: :put do |f| %>
+<%= form_for :user, url: user_path, :html => { id: 'mu-user-form' }, method: :put do |f| %>
   <div class="mu-user-header">
     <h1><%= t(:edit_profile) %></h1>
     <div class="mu-profile-actions hidden-xs">

--- a/app/views/users/terms.html.erb
+++ b/app/views/users/terms.html.erb
@@ -18,7 +18,7 @@
 
 <% if @user&.has_role_terms_to_accept? %>
   <div class="terms-acceptance">
-    <%= form_for :user, url: user_terms_path, method: :post  do |f| %>
+    <%= form_for :user, url: terms_user_path, method: :post  do |f| %>
       <span class="terms-acceptance-checkbox">
         <%= f.check_box :terms_of_service, required: true, onInvalid: "this.setCustomValidity('#{t(:terms_and_conditions_must_be_accepted)}')", onChange: "this.setCustomValidity(validity.valueMissing ? '#{t(:terms_and_conditions_must_be_accepted)}' : '')" %>
         <%= t(:accept_terms) %>

--- a/app/views/users/terms.html.erb
+++ b/app/views/users/terms.html.erb
@@ -16,3 +16,15 @@
   <% end %>
 </div>
 
+<% if @user&.has_role_terms_to_accept? %>
+  <br>
+  <%= form_for :user, url: user_terms_path, method: :post  do |f| %>
+    <span>
+      <%= f.check_box :terms_of_service, required: true, onInvalid: "this.setCustomValidity('#{t(:terms_and_conditions_must_be_accepted)}')", onChange: "this.setCustomValidity(validity.valueMissing ? '#{t(:terms_and_conditions_must_be_accepted)}' : '')" %>
+      <%= t(:accept_terms) %>
+    </span>
+    <br>
+    <%= f.submit t(:accept), class: 'btn btn-success terms-acceptance-btn' %>
+  <% end %>
+<% end %>
+

--- a/app/views/users/terms.html.erb
+++ b/app/views/users/terms.html.erb
@@ -17,14 +17,14 @@
 </div>
 
 <% if @user&.has_role_terms_to_accept? %>
-  <br>
-  <%= form_for :user, url: user_terms_path, method: :post  do |f| %>
-    <span>
-      <%= f.check_box :terms_of_service, required: true, onInvalid: "this.setCustomValidity('#{t(:terms_and_conditions_must_be_accepted)}')", onChange: "this.setCustomValidity(validity.valueMissing ? '#{t(:terms_and_conditions_must_be_accepted)}' : '')" %>
-      <%= t(:accept_terms) %>
-    </span>
-    <br>
-    <%= f.submit t(:accept), class: 'btn btn-success terms-acceptance-btn' %>
-  <% end %>
+  <div class="terms-acceptance">
+    <%= form_for :user, url: user_terms_path, method: :post  do |f| %>
+      <span class="terms-acceptance-checkbox">
+        <%= f.check_box :terms_of_service, required: true, onInvalid: "this.setCustomValidity('#{t(:terms_and_conditions_must_be_accepted)}')", onChange: "this.setCustomValidity(validity.valueMissing ? '#{t(:terms_and_conditions_must_be_accepted)}' : '')" %>
+        <%= t(:accept_terms) %>
+      </span>
+      <%= f.submit t(:accept), class: 'btn btn-success terms-acceptance-btn' %>
+    <% end %>
+  </div>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
     # All users
     resource :user, only: [:show, :edit]
     get '/user/terms' => 'users#terms'
+    post '/user/terms' => 'users#accept_profile_terms'
 
     # Current user
     resources :messages, only: [:index, :create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,12 +52,15 @@ Rails.application.routes.draw do
     resources :complements, only: :show
     resources :exams, only: :show
 
-    # All users
-    resource :user, only: [:show, :edit]
-    get '/user/terms' => 'users#terms'
-    post '/user/terms' => 'users#accept_profile_terms'
-
     # Current user
+    resource :user, only: [:show, :edit, :update] do
+      get :terms
+      post :terms, to: 'users#accept_profile_terms'
+
+      # Notification subscriptions
+      get :unsubscribe
+    end
+
     resources :messages, only: [:index, :create]
     get '/messages/errors' => 'messages#errors'
 
@@ -69,10 +72,6 @@ Rails.application.routes.draw do
     # Join to course
     get '/join/:code' => 'invitations#show', as: :invitation
     post '/join/:code' => 'invitations#join'
-
-    # Notification subscriptions
-    get '/user/unsubscribe' => 'users#unsubscribe'
-    put '/user' => 'users#update', as: :update_user
 
     # Route for reading messages
     post '/messages/read_messages/:exercise_id' => 'messages#read_messages', as: :read_messages

--- a/spec/features/terms_flow_spec.rb
+++ b/spec/features/terms_flow_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+feature 'Terms Flow', organization_workspace: :test do
+  let(:forum_terms_scopes) { Term::FORUM_RELATED }
+  let(:general_terms_scopes) { Term::GENERAL }
+  let(:role_terms_scopes) { Term::ROLE_SPECIFIC }
+
+  let(:all_terms_scopes) { forum_terms_scopes + general_terms_scopes + role_terms_scopes }
+  let!(:terms) { all_terms_scopes.map { |it| create(:term, scope: it, locale: Organization.current.locale) } }
+
+  let(:test_organization) { Organization.locate!("test") }
+
+  let(:expected_terms) { [] }
+  let(:unexpected_terms) { all_terms_scopes - expected_terms }
+
+  shared_context 'has expected terms' do
+    scenario 'with expected terms' do
+      visit terms_path
+
+      expected_terms.each do |it|
+        expect(page).to have_text(Term.find_by(scope: it).content)
+      end
+
+      unexpected_terms.each do |it|
+        expect(page).not_to have_text(Term.find_by(scope: it).content)
+      end
+    end
+  end
+
+  context 'with student logged in' do
+    let(:student) { create(:user, uid: 'test@mumuki.org', permissions: {student: 'test/*'}) }
+
+    before { set_current_user! student }
+
+    describe 'visit user terms path' do
+      let(:terms_path) { '/user/terms' }
+      let(:expected_terms) { general_terms_scopes }
+
+      it_behaves_like 'has expected terms'
+    end
+
+    context 'visit forum' do
+      let(:terms_path) { '/discussions/terms' }
+
+      context 'with disabled forum' do
+
+        it_behaves_like 'has expected terms'
+      end
+
+      context 'with enabled forum' do
+        let(:expected_terms) { forum_terms_scopes }
+        before { test_organization.update! forum_enabled: true }
+
+        it_behaves_like 'has expected terms'
+      end
+    end
+  end
+
+  context 'with janitor logged in' do
+    let(:janitor) { create(:user, uid: 'test@mumuki.org', permissions: {student: 'test/*', janitor: 'other/*'}) }
+
+    before { set_current_user! janitor }
+
+    describe 'visit user terms path' do
+      let(:terms_path) { '/user/terms' }
+      let(:expected_terms) { general_terms_scopes + [:janitor] }
+
+      it_behaves_like 'has expected terms'
+    end
+
+    context 'visit forum' do
+      let(:terms_path) { '/discussions/terms' }
+
+      context 'with disabled forum' do
+        it_behaves_like 'has expected terms'
+      end
+
+      context 'with enabled forum' do
+        let(:expected_terms) { forum_terms_scopes }
+        before { test_organization.update! forum_enabled: true }
+
+        it_behaves_like 'has expected terms'
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Depends on https://github.com/mumuki/mumuki-domain/pull/161

This one it's a mix between what we've talked about in the beginning and what we've released last time.

With this one we are only forcing a redirection when user hasn't accepted some role terms. These doesn't include student role term which is considered as a general term, not a role one.
This applies for new role terms or new ones. **This means that every teacher or above or moderator user will be forced to accept the terms, for all organizarions**

When you are redirected, you are forced to accept the terms in order to continue.
We are still accepting all terms when going to the user profile, so there isn't a change in that flow. New users shouldn't ever be redirected as the profile completion is validated before terms redirection.  