### PR TITLE
Feature visual level and experience

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/gamification.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/gamification.js
@@ -62,11 +62,13 @@ mumuki.gamification = (() => {
     }
 
     updateLevel() {
+      const $muLevelProgress = $('#mu-level-progress');
+
       $('.mu-level-number').html(this.currentLevel());
-      $('#mu-level-progress').attr("stroke-dasharray", `${this.currentLevelProgress() * 250}, 999`);
+      $('.mu-level-tooltip').attr("title", (_, value) => `${value} ${this.currentLevel()}`);
 
       if (this.currentLevelProgress() == 0) {
-        $('#mu-level-progress').attr("display", "none");
+        $muLevelProgress.attr("display", "none");
       }
     }
   }

--- a/app/assets/javascripts/mumuki_laboratory/application/gamification.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/gamification.js
@@ -70,6 +70,16 @@ mumuki.gamification = (() => {
       if (this.currentLevelProgress() == 0) {
         $muLevelProgress.attr("display", "none");
       }
+
+      $muLevelProgress.animate(
+        {'progress': this.currentLevelProgress() * 250},
+        {
+          step: function(progress) {
+            let pattern = progress + ", 999";
+            $(this).attr("stroke-dasharray", pattern);
+          },
+          duration: 1000
+        });
     }
   }
 

--- a/app/assets/javascripts/mumuki_laboratory/application/gamification.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/gamification.js
@@ -63,6 +63,7 @@ mumuki.gamification = (() => {
 
     updateLevel() {
       $('.mu-level-number').html(this.currentLevel());
+      $('#mu-level-progress').attr("stroke-dasharray", `${this.currentLevelProgress() * 250}, 999`);
     }
   }
 

--- a/app/assets/javascripts/mumuki_laboratory/application/gamification.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/gamification.js
@@ -56,8 +56,13 @@ mumuki.gamification = (() => {
       if (expGained > 0) {
         this.currentExp = exp;
         $('#mu-exp-points').html(expGained);
-        $('#mu-level-number').html(this.currentLevel());
+
+        this.updateLevel();
       }
+    }
+
+    updateLevel() {
+      $('.mu-level-number').html(this.currentLevel());
     }
   }
 
@@ -82,4 +87,5 @@ mumuki.gamification = (() => {
 
 mumuki.load(() => {
   mumuki.gamification._setUpCurrentLevelProgression();
+  mumuki.gamification._currentLevelProgression.updateLevel();
 });

--- a/app/assets/javascripts/mumuki_laboratory/application/gamification.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/gamification.js
@@ -64,6 +64,10 @@ mumuki.gamification = (() => {
     updateLevel() {
       $('.mu-level-number').html(this.currentLevel());
       $('#mu-level-progress').attr("stroke-dasharray", `${this.currentLevelProgress() * 250}, 999`);
+
+      if (this.currentLevelProgress() == 0) {
+        $('#mu-level-progress').attr("display", "none");
+      }
     }
   }
 

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_profile.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_profile.scss
@@ -36,6 +36,21 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
+
+  .mu-level-number {
+    position: absolute;
+    margin-top: 11px;
+    margin-left: -86px;
+    width: 87px;
+
+    text-align: center;
+    font-size: 1.5em;
+    font-weight: bold;
+    color: white;
+
+    user-select: none;
+    pointer-events: none;
+  }
 }
 
 .mu-profile-info-right {

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_profile.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_profile.scss
@@ -31,7 +31,14 @@
   }
 }
 
-.mu-profile-info {
+.mu-profile-info-left {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.mu-profile-info-right {
   font-size: 20px;
   margin-top: 5px;
   div {
@@ -40,6 +47,4 @@
       font-style: italic;
     }
   }
-
-
 }

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_profile.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_profile.scss
@@ -37,6 +37,12 @@
   align-items: center;
   text-align: center;
 
+  .mu-level-progress {
+    position: relative;
+    top: -275px;
+    margin-bottom: -275px;
+  }
+
   .mu-level-number {
     position: absolute;
     margin-top: 11px;

--- a/app/views/exercises/show.html.erb
+++ b/app/views/exercises/show.html.erb
@@ -48,7 +48,6 @@
 <%= hidden_field_tag "mu-exercise-id", @exercise.id %>
 <%= hidden_field_tag "mu-exercise-layout", @exercise.layout %>
 <%= hidden_field_tag "mu-exercise-settings", @exercise.settings.to_json %>
-<%= hidden_field_tag "mu-current-exp", UserStats.exp_for(@current_user) %>
 
 <div style="display: none" id="processing-template">
   <div class="bs-callout bs-callout-info">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,10 @@
       </div>
       <div class="mu-navbar-avatar">
         <% if current_logged_user? %>
-          <i class="fa fa-star fa-fw fa-2x navbar-icon"></i>
+          <% if Organization.current.gamification_enabled? %>
+            <i class="fa fa-star fa-fw fa-2x navbar-icon"></i>
+            <span class="mu-level-number"></span>
+          <% end %>
           <div class="dropdown">
             <span>
               <a class="notifications-box <%= has_notifications? ? '' : 'notifications-box-empty' %>" href=<%= "#{user_notifications_path}" %>>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
       <div class="mu-navbar-avatar">
         <% if current_logged_user? %>
           <% if Organization.current.gamification_enabled? %>
-            <i class="fa fa-star fa-fw fa-2x navbar-icon"></i>
+            <i class="fa fa-star fa-fw fa-2x navbar-icon mu-level-tooltip" data-toggle="tooltip" data-placement="bottom" title="<%= t(:level) %>"></i>
             <span class="mu-level-number"></span>
           <% end %>
           <div class="dropdown">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,10 +18,11 @@
       </div>
       <div class="mu-navbar-avatar">
         <% if current_logged_user? %>
+          <i class ="fa fa-star fa-fw fa-2x"></i>
           <div class="dropdown">
             <span>
               <a class="notifications-box <%= has_notifications? ? '' : 'notifications-box-empty' %>" href=<%= "#{user_notifications_path}" %>>
-                <i class="fa fa-bell fa-fw fa-lg"></i>
+                <i class="fa fa-bell fa-fw fa-2x"></i>
                   <span class="badge badge-notifications"><%= notifications_count %></span>
               </a>
             </span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,17 +19,17 @@
       </div>
       <div class="mu-navbar-avatar">
         <% if current_logged_user? %>
-          <i class ="fa fa-star fa-fw fa-2x"></i>
+          <i class="fa fa-star fa-fw fa-2x navbar-icon"></i>
           <div class="dropdown">
             <span>
               <a class="notifications-box <%= has_notifications? ? '' : 'notifications-box-empty' %>" href=<%= "#{user_notifications_path}" %>>
-                <i class="fa fa-bell fa-fw fa-2x"></i>
+                <i class="fa fa-bell fa-fw fa-2x navbar-icon"></i>
                   <span class="badge badge-notifications"><%= notifications_count %></span>
               </a>
             </span>
           </div>
           <div class="dropdown">
-            <div id="profileDropdown" class="profile-dropdown" data-toggle="dropdown" aria-label="<%= t(:user) %>" role="menu" tabindex="0">
+            <div id="profileDropdown" class="profile-dropdown navbar-icon" data-toggle="dropdown" aria-label="<%= t(:user) %>" role="menu" tabindex="0">
               <%= profile_picture_for current_user %>
               <span class="caret"></span>
             </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :navbar do %>
+  <%= hidden_field_tag "mu-current-exp", UserStats.exp_for(@current_user) %>
   <div class="<%= exercise_container_type %>">
     <nav class="mu-navbar">
       <div class="mu-navbar-breadcrumb hidden-xs">
@@ -77,3 +78,4 @@
 <% end %>
 
 <%= render partial: 'layouts/main' %>
+

--- a/app/views/users/_user_form.html.erb
+++ b/app/views/users/_user_form.html.erb
@@ -8,6 +8,9 @@
   <div class="col-md-4 mu-profile-info-left">
     <%= profile_picture_for(@user, id: 'mu-user-avatar', class: 'mu-user-avatar') %>
     <% if Organization.current.gamification_enabled? %>
+      <svg class="mu-level-progress" width="300" height="300" viewBox="0 0 100 100">
+        <path id="mu-level-progress" stroke-linecap="round" stroke="#24b8aa" stroke-width="4" stroke-dasharray="0, 999" fill="none" d="M50 10 a 40 40 0 0 1 0 80 a 40 40 0 0 1 0 -80"></path>
+      </svg>
       <div>
         <i class="fa fa-star fa-fw fa-4x"></i>
         <span class="mu-level-number"></span>

--- a/app/views/users/_user_form.html.erb
+++ b/app/views/users/_user_form.html.erb
@@ -7,6 +7,12 @@
 <div class="row mu-tab-body">
   <div class="col-md-4 mu-profile-info-left">
     <%= profile_picture_for(@user, id: 'mu-user-avatar', class: 'mu-user-avatar') %>
+    <% if Organization.current.gamification_enabled? %>
+      <div>
+        <i class="fa fa-star fa-fw fa-4x"></i>
+        <span class="mu-level-number"></span>
+      </div>
+    <% end %>
   </div>
   <div class="col-md-8 mu-profile-info-right">
     <% if @user.age.present? %>

--- a/app/views/users/_user_form.html.erb
+++ b/app/views/users/_user_form.html.erb
@@ -5,10 +5,10 @@
   </div>
 </div>
 <div class="row mu-tab-body">
-  <div class="col-md-4 text-center">
+  <div class="col-md-4 mu-profile-info-left">
     <%= profile_picture_for(@user, id: 'mu-user-avatar', class: 'mu-user-avatar') %>
   </div>
-  <div class="col-md-8 mu-profile-info">
+  <div class="col-md-8 mu-profile-info-right">
     <% if @user.age.present? %>
       <div>
         <span> <strong><%= t :age %>:</strong> <%= "#{@user.age} #{t :years}" %> </span>

--- a/app/views/users/_user_form.html.erb
+++ b/app/views/users/_user_form.html.erb
@@ -11,6 +11,7 @@
       <div>
         <i class="fa fa-star fa-fw fa-4x"></i>
         <span class="mu-level-number"></span>
+        <p><%= t :level %></p>
       </div>
     <% end %>
   </div>

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -139,6 +139,7 @@ en:
   lessons: Lessons
   lesson_number: Lesson %{number}
   let_us_know: please let us know!
+  level: Level
   loading: Loading
   load_solution_into_console: Load your solution into the console
   locked_content: 'This content will be unlocked when you finish previous chapters'

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -139,6 +139,7 @@ es-CL:
   lessons: Lecciones
   lesson_number: Lección %{number}
   let_us_know: ¡Por favor avísanos!
+  level: Nivel
   loading: Cargando
   load_solution_into_console: Cargar la solución en la consola
   locked_content: 'Éste contenido se desbloqueará cuando termines los capítulos anteriores'

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -149,6 +149,7 @@ es:
   lessons: Lecciones
   lesson_number: Lección %{number}
   let_us_know: ¡Por favor avisanos!
+  level: Nivel
   loading: Cargando
   load_solution_into_console: Cargar la solución en la consola
   locked_content: 'Este contenido se desbloqueará cuando termines los capítulos anteriores'

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -143,6 +143,7 @@ pt:
   lessons: Lições
   lesson_number: Lição %{number}
   let_us_know: Por favor, avise-nos!
+  level: Nível
   loading: Carregando
   load_solution_into_console: Carregue a solução no console
   locked_content: 'Este conteúdo será desbloqueado quando você terminar os capítulos anteriores'

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'mumukit-auth', '~> 7.8'
   s.add_dependency 'mumukit-content-type', '~> 1.9'
 
-  s.add_dependency 'mumuki-styles', '~> 1.22'
+  s.add_dependency 'mumuki-styles', '~> 1.23'
   s.add_dependency 'muvment', '~> 1.2'
 
   s.add_dependency 'rack', '~> 2.1'


### PR DESCRIPTION
## :warning: Requirements
* [x] https://github.com/mumuki/mumuki-styles/pull/58 for navbar styling.
* [x] https://github.com/mumuki/mumuki-styles/pull/59 for level icon truer to the original design

## :dart: Goal

Add level icon on navbar (for gamified organizations). Add level and level progress on profile.

## :camera_flash: Screenshots (with nicer icons)

![image](https://user-images.githubusercontent.com/11304439/100110459-b63fee00-2e4b-11eb-9641-32cd655b84fd.png)

_____

![image](https://user-images.githubusercontent.com/11304439/100110651-facb8980-2e4b-11eb-9573-1996a07bbd21.png)

_____

See navbar screenshot on https://github.com/mumuki/mumuki-styles/pull/58, though fontawesome 4 icons are used there
