### PR TITLE
Fix notification dropdown

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,13 +25,11 @@
               <span class="mu-level-number"></span>
             </div>
           <% end %>
-          <div class="dropdown mu-navbar-element">
-            <span>
-              <a class="notifications-box <%= has_notifications? ? '' : 'notifications-box-empty' %>" href=<%= "#{user_notifications_path}" %>>
-                <i class="fa fa-bell fa-fw fa-2x navbar-icon"></i>
-                  <span class="badge badge-notifications"><%= notifications_count %></span>
-              </a>
-            </span>
+          <div class="dropdown mu-navbar-element notifications-box <%= 'notifications-box-empty' unless has_notifications? %>">
+            <a href=<%= "#{user_notifications_path}" %>>
+              <i class="fa fa-bell fa-fw fa-2x navbar-icon"></i>
+                <span class="badge badge-notifications"><%= notifications_count %></span>
+            </a>
           </div>
           <div class="dropdown mu-navbar-element">
             <div id="profileDropdown" class="profile-dropdown navbar-icon" data-toggle="dropdown" aria-label="<%= t(:user) %>" role="menu" tabindex="0">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,10 +20,12 @@
       <div class="mu-navbar-avatar">
         <% if current_logged_user? %>
           <% if in_gamified_context? %>
-            <i class="fa fa-star fa-fw fa-2x navbar-icon mu-level-tooltip" data-toggle="tooltip" data-placement="bottom" level="<%= t(:level) %>"></i>
-            <span class="mu-level-number"></span>
+            <div class="mu-navbar-element">
+              <i class="fa fa-star fa-fw fa-2x navbar-icon mu-level-tooltip" data-toggle="tooltip" data-placement="bottom" level="<%= t(:level) %>"></i>
+              <span class="mu-level-number"></span>
+            </div>
           <% end %>
-          <div class="dropdown">
+          <div class="dropdown mu-navbar-element">
             <span>
               <a class="notifications-box <%= has_notifications? ? '' : 'notifications-box-empty' %>" href=<%= "#{user_notifications_path}" %>>
                 <i class="fa fa-bell fa-fw fa-2x navbar-icon"></i>
@@ -31,7 +33,7 @@
               </a>
             </span>
           </div>
-          <div class="dropdown">
+          <div class="dropdown mu-navbar-element">
             <div id="profileDropdown" class="profile-dropdown navbar-icon" data-toggle="dropdown" aria-label="<%= t(:user) %>" role="menu" tabindex="0">
               <%= profile_picture_for current_user %>
               <span class="caret"></span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,18 +21,18 @@
         <% if current_logged_user? %>
           <% if in_gamified_context? %>
             <div class="mu-navbar-element">
-              <i class="fa fa-star fa-fw fa-2x navbar-icon mu-level-tooltip" data-toggle="tooltip" data-placement="bottom" level="<%= t(:level) %>"></i>
+              <i class="fa fa-star fa-fw fa-2x mu-navbar-icon mu-level-tooltip" data-toggle="tooltip" data-placement="bottom" level="<%= t(:level) %>"></i>
               <span class="mu-level-number"></span>
             </div>
           <% end %>
           <div class="dropdown mu-navbar-element notifications-box <%= 'notifications-box-empty' unless has_notifications? %>">
             <a href=<%= "#{user_notifications_path}" %>>
-              <i class="fa fa-bell fa-fw fa-2x navbar-icon"></i>
+              <i class="fa fa-bell fa-fw fa-2x mu-navbar-icon"></i>
                 <span class="badge badge-notifications"><%= notifications_count %></span>
             </a>
           </div>
           <div class="dropdown mu-navbar-element">
-            <div id="profileDropdown" class="profile-dropdown navbar-icon" data-toggle="dropdown" aria-label="<%= t(:user) %>" role="menu" tabindex="0">
+            <div id="profileDropdown" class="profile-dropdown" data-toggle="dropdown" aria-label="<%= t(:user) %>" role="menu" tabindex="0">
               <%= profile_picture_for current_user %>
               <span class="caret"></span>
             </div>


### PR DESCRIPTION
## :warning: Requirements :warning:

Requires mumuki-styles 1.24 after merging https://github.com/mumuki/mumuki-styles/pull/61

## :dart: Goal

Fix a bug where the notification box had a larger clickable area than it should.

## :camera_flash: Screenshots

### Before
![image](https://user-images.githubusercontent.com/11304439/101208546-1b1bf500-3651-11eb-82ef-f16a2bb4946e.png)
___

### Now
![image](https://user-images.githubusercontent.com/11304439/101208957-b3b27500-3651-11eb-91a0-b1fbc996c7de.png)
