### PR TITLE
Fix tooltip level up

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/bridge.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/bridge.js
@@ -113,7 +113,7 @@ mumuki.bridge = (() => {
      * @returns {SubmissionResult}
      */
     _preRenderResult(result) {
-      result.class_for_progress_list_item = mumuki.renderers.progressListItemClassForStatus(result.status, true)
+      result.class_for_progress_list_item = mumuki.renderers.progressListItemClassForStatus(result.status, true);
       return result;
     }
   }

--- a/app/assets/javascripts/mumuki_laboratory/application/button.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/button.js
@@ -36,7 +36,7 @@ mumuki.Button = class {
       e.preventDefault();
       main();
     };
-    this.$button.on('click', this.main)
+    this.$button.on('click', this.main);
   }
 
   // ==============
@@ -80,7 +80,7 @@ mumuki.Button = class {
 
     this.enable();
 
-    this.$button.on('click', this.main)
+    this.$button.on('click', this.main);
   }
 
   // =============

--- a/app/assets/javascripts/mumuki_laboratory/application/codemirror-builder.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/codemirror-builder.js
@@ -38,7 +38,7 @@
             mumuki.editor.toggleFullscreen();
           },
           'Tab': function (cm) {
-            mumuki.editor.indentWithSpaces(cm)
+            mumuki.editor.indentWithSpaces(cm);
           }
         }
       });
@@ -53,7 +53,7 @@
           'Cmd-Enter': submitMessage,
           'Ctrl-Enter': submitMessage,
           'Tab': function (cm) {
-            mumuki.editor.indentWithSpaces(cm)
+            mumuki.editor.indentWithSpaces(cm);
           }
         }
       });

--- a/app/assets/javascripts/mumuki_laboratory/application/codemirror.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/codemirror.js
@@ -23,14 +23,14 @@ mumuki.page.editors = [];
   function resetEditor() {
     mumuki.page.dynamicEditors.forEach(function (e) {
       setDefaultContent(e, $('#default_content').val());
-    })
+    });
   }
 
   function formatContent() {
     mumuki.page.editors.each(function (_, editor) {
-      editor.setSelection({line: 0, ch: 0}, {line: editor.lineCount()})
-      editor.indentSelection("smart")
-      editor.setSelection({line: 0})
+      editor.setSelection({line: 0, ch: 0}, {line: editor.lineCount()});
+      editor.indentSelection("smart");
+      editor.setSelection({line: 0});
     });
   }
 
@@ -56,7 +56,7 @@ mumuki.page.editors = [];
     if (language !== undefined) {
       mumuki.page.dynamicEditors.forEach(function (e) {
         setEditorLanguage(e, language);
-      })
+      });
     }
   }
 

--- a/app/assets/javascripts/mumuki_laboratory/application/console.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/console.js
@@ -32,7 +32,7 @@
   function clearConsole() {
     $('.jquery-console-message-error').remove();
     $('.jquery-console-message-value').remove();
-    $('.jquery-console-prompt-box:not(:last)').remove()
+    $('.jquery-console-prompt-box:not(:last)').remove();
   }
 
   class QueryConsole {
@@ -134,7 +134,7 @@
         url: self._requestUrl,
         type: 'POST',
         data: self._requestData
-      })
+      });
     }
     get _requestUrl() {
       return this.console.endpoint;

--- a/app/assets/javascripts/mumuki_laboratory/application/discussions.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/discussions.js
@@ -34,33 +34,33 @@ mumuki.load(() => {
     },
     token: new mumuki.CsrfToken(),
     tokenRequest: function (data) {
-      return $.ajax(Forum.token.newRequest(data))
+      return $.ajax(Forum.token.newRequest(data));
     },
     discussionPost: function (url) {
       return Forum.tokenRequest({
         url: url,
         method: 'POST',
         xhrFields: {withCredentials: true}
-      })
+      });
     },
     discussionSubscription: function (url) {
-      Forum.discussionPostAndToggle(url, $subscriptionSpans)
+      Forum.discussionPostAndToggle(url, $subscriptionSpans);
     },
     discussionUpvote: function (url) {
-      Forum.discussionPostAndToggle(url, $upvoteSpans)
+      Forum.discussionPostAndToggle(url, $upvoteSpans);
     },
     discussionPostAndToggle: function (url, elem) {
-      Forum.discussionPost(url).done(Forum.toggleButton(elem))
+      Forum.discussionPost(url).done(Forum.toggleButton(elem));
     },
     discussionMessageToggleApprove: function (url, elem) {
       Forum.discussionPost(url).done(function () {
         elem.toggleClass("selected");
-      })
+      });
     },
     discussionMessageToggleNotActuallyAQuestion: function (url, elem) {
       Forum.discussionPost(url).done(function () {
         elem.toggleClass("selected");
-      })
+      });
     },
     discussionsToggleCheckbox: function (elem) {
       const key = elem.attr('name');

--- a/app/assets/javascripts/mumuki_laboratory/application/editors.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/editors.js
@@ -99,6 +99,6 @@ mumuki.editors = {
    * @param {CustomEditorSource} source
    */
   addCustomSource(source) {
-    mumuki.CustomEditor.addSource(source)
+    mumuki.CustomEditor.addSource(source);
   }
 };

--- a/app/assets/javascripts/mumuki_laboratory/application/elipsis.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/elipsis.js
@@ -21,7 +21,7 @@ mumuki.elipsis = (() => {
     $elipsis.each((it, e) =>  {
       let $e = $(e);
       $e.html(mumuki.elipsis($e.html()));
-    })
+    });
   };
 
   mumuki.load(() => {

--- a/app/assets/javascripts/mumuki_laboratory/application/events.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/events.js
@@ -34,7 +34,7 @@ mumuki.events = {
    */
   fire(eventName, value = null) {
     if (this._handlers[eventName]) {
-      this._handlers[eventName].forEach(it => it(value))
+      this._handlers[eventName].forEach(it => it(value));
     }
   },
 
@@ -48,4 +48,4 @@ mumuki.events = {
       this._handlers[eventName] = [];
     }
   }
-}
+};

--- a/app/assets/javascripts/mumuki_laboratory/application/exercise.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/exercise.js
@@ -63,6 +63,6 @@ mumuki.exercise = {
       this._current = null;
     }
   }
-}
+};
 
-mumuki.load(() => mumuki.exercise.load())
+mumuki.load(() => mumuki.exercise.load());

--- a/app/assets/javascripts/mumuki_laboratory/application/gamification.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/gamification.js
@@ -112,7 +112,8 @@ mumuki.gamification = (() => {
 
       $('#mu-solve-more-exercises span').text(this.exercisesToNextLevel());
       $('.mu-level-number').html(this.currentLevel());
-      $('.mu-level-tooltip').attr("title", (_, value) => `${value} ${this.currentLevel()}`);
+
+      this.updateTooltip();
 
       if (this.currentLevelProgress() === 0) {
         $muLevelProgress.attr("display", "none");
@@ -127,6 +128,13 @@ mumuki.gamification = (() => {
           },
           duration: 1000
         });
+    }
+
+    updateTooltip() {
+      const $muLevelTooltip = $('.mu-level-tooltip');
+
+      $muLevelTooltip.attr("data-original-title", `${$muLevelTooltip.attr("level")} ${this.currentLevel()}`);
+      $muLevelTooltip.attr("title", "");
     }
   }
 

--- a/app/assets/javascripts/mumuki_laboratory/application/gamification.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/gamification.js
@@ -108,13 +108,22 @@ mumuki.gamification = (() => {
     }
 
     updateLevel() {
-      const $muLevelProgress = $('#mu-level-progress');
-
       $('#mu-solve-more-exercises span').text(this.exercisesToNextLevel());
       $('.mu-level-number').html(this.currentLevel());
 
       this.updateTooltip();
+      this.animateProgressIfAny();
+    }
 
+    updateTooltip() {
+      const $muLevelTooltip = $('.mu-level-tooltip');
+
+      $muLevelTooltip.attr("data-original-title", `${$muLevelTooltip.attr("level")} ${this.currentLevel()}`);
+      $muLevelTooltip.attr("title", "");
+    }
+
+    animateProgressIfAny() {
+      const $muLevelProgress = $('#mu-level-progress');
       if (this.currentLevelProgress() === 0) {
         $muLevelProgress.attr("display", "none");
       }
@@ -128,13 +137,6 @@ mumuki.gamification = (() => {
           },
           duration: 1000
         });
-    }
-
-    updateTooltip() {
-      const $muLevelTooltip = $('.mu-level-tooltip');
-
-      $muLevelTooltip.attr("data-original-title", `${$muLevelTooltip.attr("level")} ${this.currentLevel()}`);
-      $muLevelTooltip.attr("title", "");
     }
   }
 

--- a/app/assets/javascripts/mumuki_laboratory/application/inputs.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/inputs.js
@@ -7,7 +7,7 @@ mumuki.onInputsReady = (() => {
 			if ($(inputsSelector).length === 0) return;
 
 			callback(event);
-		})
+		});
 	}
 
 	return onInputsReady;

--- a/app/assets/javascripts/mumuki_laboratory/application/kids.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/kids.js
@@ -61,11 +61,11 @@ mumuki.Kids = class {
   // ==================
 
   _showSuccessPopup() {
-    this._mustImplementThisMethod()
+    this._mustImplementThisMethod();
   }
 
   _showFailurePopup() {
-    this._mustImplementThisMethod()
+    this._mustImplementThisMethod();
   }
 
   // ====================
@@ -141,7 +141,7 @@ mumuki.Kids = class {
   // ============
 
   _mustImplementThisMethod() {
-    throw new Error('TODO: implement method')
+    throw new Error('TODO: implement method');
   }
 
   // ============
@@ -214,4 +214,4 @@ mumuki.Kids = class {
     $blockSvg.height($blocks.height());
   }
 
-}
+};

--- a/app/assets/javascripts/mumuki_laboratory/application/kindergarten.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/kindergarten.js
@@ -103,27 +103,27 @@ mumuki.load(() => {
           this._action('play', 'stop', true, (speech) => {
             mumuki.presenterCharacter.playAnimation('talk', mumuki.kids.$bubbleCharacterAnimation);
             speech.speak(msg);
-          })
+          });
         },
         stop() {
-          this._action('stop', 'play', false, (speech) => speech.cancel())
+          this._action('stop', 'play', false, (speech) => speech.cancel());
         },
         _action(add, remove, isPlaying, callback) {
           callback(window.speechSynthesis);
-          const $button = $('.mu-kindergarten-play-description')
+          const $button = $('.mu-kindergarten-play-description');
           $button.find(`.mu-kindergarten-${add}`).addClass('hidden');
           $button.find(`.mu-kindergarten-${remove}`).removeClass('hidden');
           this._isPlaying = isPlaying;
         },
         verifyBrowserSupport() {
           if (!window.speechSynthesis) {
-            const $button = $('.mu-kindergarten-play-description')
+            const $button = $('.mu-kindergarten-play-description');
             $button.prop('disabled', true);
             $button.css('cursor', 'not-allowed');
-            this._action('play', 'stop', false)
+            this._action('play', 'stop', false);
           }
         }
-      }
+      };
 
     }
 
@@ -143,7 +143,7 @@ mumuki.load(() => {
           const $hintMedia = $('.mu-kindergarten-hint-media');
           if (!$hintMedia.get(0)) $button.addClass('hidden');
         },
-      }
+      };
     }
 
     get context() {

--- a/app/assets/javascripts/mumuki_laboratory/application/messages.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/messages.js
@@ -1,7 +1,7 @@
 mumuki.load(() => {
   var Chat = {
     $body: function () {
-      return $('body')
+      return $('body');
     },
     $newMessageModal: function () {
       return $('.new-message-modal');
@@ -18,7 +18,7 @@ mumuki.load(() => {
       $('.notifications-box').toggleClass('notifications-box-empty', !data.has_messages);
       $('.pending-messages-filter').removeClass('pending-messages-filter');
       $('button.btn-submit').removeClass('disabled');
-      $('.pending-messages-text').remove()
+      $('.pending-messages-text').remove();
     },
     readMessages: function (url) {
       Chat.tokenRequest({
@@ -26,10 +26,10 @@ mumuki.load(() => {
         method: 'POST',
         success: Chat.setMessages,
         xhrFields: {withCredentials: true}
-      })
+      });
     },
     tokenRequest: function (data) {
-      $.ajax(Chat.token.newRequest(data))
+      $.ajax(Chat.token.newRequest(data));
     },
     getMessages: function () {
       if ($('.badge-messages').length == 0) {
@@ -74,7 +74,7 @@ mumuki.load(() => {
         success: success,
         error: error,
         xhrFields: {withCredentials: true}
-      })
+      });
     },
     openNewMessageModal: function () {
       Chat.$newMessageModal().modal({backdrop: false, keyboard: false});
@@ -89,5 +89,5 @@ mumuki.load(() => {
   Chat.setMessagesInterval();
   mumuki.Chat = Chat;
 
-})
+});
 

--- a/app/assets/javascripts/mumuki_laboratory/application/mu-modal-carrousel.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/mu-modal-carrousel.js
@@ -41,7 +41,7 @@ mumuki.ModalCarrousel = (() => {
 
     _hidePreviousButtonIfFirstSlide() {
       const $prev = $('.mu-kids-modal-button.mu-previous');
-      this._addClassIf($prev, 'hidden', () => this._activeSlide().is(':first-child'))
+      this._addClassIf($prev, 'hidden', () => this._activeSlide().is(':first-child'));
     }
 
     _showFirstSlide() {

--- a/app/assets/javascripts/mumuki_laboratory/application/multiple-choice.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/multiple-choice.js
@@ -1,7 +1,7 @@
 mumuki.load(() => {
 	function dumpChoices(_evt) {
 		var indexes = $('.solution-choice:checked').map(function () {
-			return $(this).data('index')
+			return $(this).data('index');
 		}).get().join(':');
 		$('#solution_content').attr('value', indexes);
 	}

--- a/app/assets/javascripts/mumuki_laboratory/application/multiple-files.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/multiple-files.js
@@ -103,11 +103,11 @@ mumuki.load(() => {
     }
 
     get highlightModes() {
-      return this._getDataFromHiddenInput('#highlight-modes')
+      return this._getDataFromHiddenInput('#highlight-modes');
     }
 
     get locales() {
-      return this._getDataFromHiddenInput('#multifile-locales')
+      return this._getDataFromHiddenInput('#multifile-locales');
     }
 
     setUpAddFile() {
@@ -131,7 +131,7 @@ mumuki.load(() => {
 
       this._setVisibility(this._addFileButton, filesCount < this.MAX_TABS);
       this.files.toArray().forEach(file => {
-        this._setVisibility(file.deleteButton, file.name !== this.mainFile && filesCount > 1)
+        this._setVisibility(file.deleteButton, file.name !== this.mainFile && filesCount > 1);
       });
     }
 

--- a/app/assets/javascripts/mumuki_laboratory/application/multiple-scenarios.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/multiple-scenarios.js
@@ -73,7 +73,7 @@ mumuki.MultipleScenarios = (() => {
         if (this.validScenarioIndex(newScenarioIndex)) {
           this.setActiveIndex(newScenarioIndex);
         }
-      })
+      });
     }
 
     createControls () {

--- a/app/assets/javascripts/mumuki_laboratory/application/pin.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/pin.js
@@ -11,5 +11,5 @@ mumuki.pin = (() => {
         smoothScrollToElement(scrollPin);
       }
     }
-  }
+  };
 })();

--- a/app/assets/javascripts/mumuki_laboratory/application/primary.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/primary.js
@@ -83,7 +83,7 @@ mumuki.load(() => {
             this._$texts.hide();
             this.$characterSpeechBubbleNormal.children('.' + $tab.data('target')).show();
             this._updateSpeechParagraphs();
-          })
+          });
         }
       });
 

--- a/app/assets/javascripts/mumuki_laboratory/application/progress.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/progress.js
@@ -17,7 +17,7 @@ mumuki.progress = (() => {
   function updateWholeProgressBar(f) {
     $('.progress-list-item').each((_, it) => {
       const $anchor = $(it);
-      $anchor.attr('class', f($anchor))
+      $anchor.attr('class', f($anchor));
     });
   }
 

--- a/app/assets/javascripts/mumuki_laboratory/application/results-renderer.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/results-renderer.js
@@ -49,7 +49,7 @@ mumuki.renderers.results = (() => {
     classForStatus,
     iconForStatus,
     progressListItemClassForStatus
-  }
+  };
 })();
 
 /** @deprecated use {@code mumuki.renderers.results.classForStatus} instead */

--- a/app/assets/javascripts/mumuki_laboratory/application/speech-bubble-renderer.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/speech-bubble-renderer.js
@@ -20,7 +20,7 @@ mumuki.renderers.speechBubble = (()=> {
 
     _chooseResultItem() {
       if (this._responseStatus() !== 'passed' && this._hasTips()) {
-        this._appendFirstTip()
+        this._appendFirstTip();
       } else if (this._responseStatus() === 'failed') {
         this._appendFirstFailedTestResultSummary();
       } else if (this._responseStatus() === 'passed_with_warnings') {
@@ -29,7 +29,7 @@ mumuki.renderers.speechBubble = (()=> {
     }
 
     _appendFirstFailedTestResultSummary() {
-      const failedTestResult = this._failedTestResults()[0]
+      const failedTestResult = this._failedTestResults()[0];
       if (failedTestResult && failedTestResult.summary) {
         this._appendResultItem(mumuki.renderers.renderSpeechBubbleResultItem(failedTestResult.summary));
       }
@@ -67,7 +67,7 @@ mumuki.renderers.speechBubble = (()=> {
     }
 
     _hasTips() {
-      return this.responseData.tips && this.responseData.tips.length
+      return this.responseData.tips && this.responseData.tips.length;
     }
 
     _failedTestResults() {
@@ -97,7 +97,7 @@ mumuki.renderers.speechBubble = (()=> {
   return {
     SpeechBubbleRenderer,
     renderSpeechBubbleResultItem
-  }
+  };
 })();
 
 /** @deprecated use {@code mumuki.renderers.speechBubble.SpeechBubbleRenderer} instead */

--- a/app/assets/javascripts/mumuki_laboratory/application/submission.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/submission.js
@@ -101,7 +101,7 @@ mumuki.submission = (() => {
         });
         mumuki.kids.showResult(data);
       });
-    }
+    };
   }
 
   /** Processor for non-kids layouts */
@@ -118,7 +118,7 @@ mumuki.submission = (() => {
         $(document).renderMuComponents();
         resultsBox.done(data, submitButton);
       });
-    }
+    };
   }
 
   /** Selects the most appropriate solution processor */

--- a/app/assets/javascripts/mumuki_laboratory/application/submissions-store.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/submissions-store.js
@@ -96,7 +96,7 @@ mumuki.SubmissionsStore = (() => {
     _keyFor(exerciseId) {
       return `/exercise/${exerciseId}/submission`;
     }
-  };
+  }();
 
   return SubmissionsStore;
 })();
@@ -106,5 +106,5 @@ mumuki.load(() => {
     if (e.detail[0]) {
       mumuki.SubmissionsStore.clear();
     }
-  })
-})
+  });
+});

--- a/app/assets/javascripts/mumuki_laboratory/application/sync-mode.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/sync-mode.js
@@ -65,11 +65,11 @@ mumuki.syncMode = (() => {
 
     /** @type {ClientSyncMode|ServerSyncMode}*/
     _current: null
-  }
+  };
 })();
 
 mumuki.load(() => {
   mumuki.syncMode._selectSyncMode();
   mumuki.syncMode._current.syncProgress();
   mumuki.syncMode._current.syncEditorContent();
-})
+});

--- a/app/assets/javascripts/mumuki_laboratory/application/timer.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/timer.js
@@ -16,5 +16,5 @@ mumuki.startTimer = (() => {
       }
     }, intervalDuration);
   }
-  return startTimer
+  return startTimer;
 })();

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
       <div class="mu-navbar-avatar">
         <% if current_logged_user? %>
           <% if in_gamified_context? %>
-            <i class="fa fa-star fa-fw fa-2x navbar-icon mu-level-tooltip" data-toggle="tooltip" data-placement="bottom" title="<%= t(:level) %>"></i>
+            <i class="fa fa-star fa-fw fa-2x navbar-icon mu-level-tooltip" data-toggle="tooltip" data-placement="bottom" level="<%= t(:level) %>"></i>
             <span class="mu-level-number"></span>
           <% end %>
           <div class="dropdown">


### PR DESCRIPTION
## :dart: Goal

Fix a bug where, when leveling up, the level tooltip on navbar would show the previous level until the next refresh.

No longer
![image](https://user-images.githubusercontent.com/11304439/101215499-b49cd400-365c-11eb-8b34-d1396d01d584.png)

I have to modify both `title` _and_ `data-original-title` because [bootstrap tooltips act a bit funny](https://stackoverflow.com/questions/15487562/why-is-html-title-attribute-and-twitter-bootstrap-data-original-title-mutually-e). `title` works as long as it's not modified; when it is, `data-original-title` starts being used in its place. However, we can't just use `data-original-title` because it won't work unless there's a `title` attr defined. Ouch.

Also all this stuff is on `gamification.js`. I went on a semicolon adding spree on the other files. We can remove that commit if it's too over the top. :smile: 
