### PR TITLE
Chore footer styles

### DIFF
--- a/app/assets/stylesheets/mumuki_laboratory/application/_layout.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/_layout.scss
@@ -25,16 +25,13 @@ body {
   margin-bottom: 110px;
 }
 
-.footer {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  height: 110px;
-  .container {
-    margin-top: 23px;
+.mu-footer {
+  &.container {
+    margin-top: 45px;
   }
-  .footer-row {
-    margin-top: 10px;
+  .mu-footer-terms {
+    font-size: 15px;
+    text-align: center;
   }
 }
 

--- a/app/assets/stylesheets/mumuki_laboratory/application/_layout.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/_layout.scss
@@ -31,7 +31,10 @@ body {
   width: 100%;
   height: 110px;
   .container {
-    margin-top: 33px;
+    margin-top: 23px;
+  }
+  .footer-row {
+    margin-top: 10px;
   }
 }
 

--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -52,11 +52,11 @@ module LinksHelper
   end
 
   def link_to_profile_terms
-    link_to t(:terms_and_conditions).downcase, terms_user_path, target: '_blank'
+    link_to t(:terms_and_conditions), terms_user_path, target: '_blank'
   end
 
   def link_to_forum_terms
-    link_to t(:forum_terms).downcase, discussions_terms_path, target: '_blank'
+    link_to t(:forum_terms), discussions_terms_path, target: '_blank'
   end
 
   def turbolinks_enable_for(exercise)

--- a/app/views/layouts/_copyright.html.erb
+++ b/app/views/layouts/_copyright.html.erb
@@ -1,2 +1,2 @@
-&copy; Copyright 2015-<%= DateTime.now.year %>
+&copy; 2015-<%= DateTime.now.year %>
 <a href="http://mumuki.org/" class="mu-org-link"><span class="da da-mumuki-circle"></span> Mumuki</a>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,27 +55,36 @@
     <div class="<%= exercise_container_type %>">
       <hr>
 
-      <div class="row">
+      <div class="row footer-row">
         <div class="col-md-12">
           <%= yield :authoring %>
         </div>
       </div>
 
-      <div id="footer-copyright" class="row">
-        <div class="col-md-4 text-left">
-          <p>
-            <%= render partial: 'layouts/copyright' %>
-          </p>
+      <div class="row footer-row">
+
+        <div class="col-md-4 text-center">
+          <p><%= link_to_profile_terms %></p>
+          <% if current_user&.can_discuss_here? %>
+            <p><%= link_to_forum_terms %></p>
+          <% end %>
         </div>
 
         <div class="col-md-4 text-center">
+          <a href="https://auth0.com/" target="_blank">
+            <img height="40" alt="JWT Auth for open source projects" src="//cdn.auth0.com/oss/badges/a0-badge-light.png"/>
+          </a>
           <%= login_form.footer_html %>
         </div>
 
         <div id="footer-social" class="col-md-4 text-right" lang="en">
-          <%= render partial: 'layouts/social_media' %>
+          <p><%= render partial: 'layouts/social_media' %></p>
+          <p id="footer-copyright">
+            <%= render partial: 'layouts/copyright' %>
+          </p>
         </div>
       </div>
+
     </div>
   </footer>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,36 +52,29 @@
 
 <% content_for :footer do %>
   <footer class="footer">
-    <div class="<%= exercise_container_type %>">
-      <hr>
-
-      <div class="row footer-row">
-        <div class="col-md-12">
+    <div class="mu-footer <%= exercise_container_type %>">
+      <div class="mu-footer-row">
+        <div class="mu-footer-authoring">
           <%= yield :authoring %>
         </div>
       </div>
 
-      <div class="row footer-row">
+      <div class="mu-footer-row">
+        <div class="mu-footer-copyright">
+          <%= render partial: 'layouts/copyright' %>
+        </div>
 
-        <div class="col-md-4 text-center">
-          <p><%= link_to_profile_terms %></p>
+        <div class="mu-footer-terms">
+          <div><%= link_to_profile_terms %></div>
           <% if current_user&.can_discuss_here? %>
-            <p><%= link_to_forum_terms %></p>
+            <div><%= link_to_forum_terms %></div>
           <% end %>
         </div>
 
-        <div class="col-md-4 text-center">
-          <a href="https://auth0.com/" target="_blank">
-            <img height="40" alt="JWT Auth for open source projects" src="//cdn.auth0.com/oss/badges/a0-badge-light.png"/>
-          </a>
-          <%= login_form.footer_html %>
-        </div>
+        <%= login_form.footer_html %>
 
-        <div id="footer-social" class="col-md-4 text-right" lang="en">
-          <p><%= render partial: 'layouts/social_media' %></p>
-          <p id="footer-copyright">
-            <%= render partial: 'layouts/copyright' %>
-          </p>
+        <div id="footer-social" class="mu-footer-social" lang="en">
+          <%= render partial: 'layouts/social_media' %>
         </div>
       </div>
 

--- a/app/views/layouts/embedded.html.erb
+++ b/app/views/layouts/embedded.html.erb
@@ -1,22 +1,25 @@
 <% content_for :footer do %>
   <footer class="footer">
-    <div class="<%= exercise_container_type %>">
-      <hr>
-
-      <div class="row">
-        <div class="col-md-12">
+    <div class="mu-footer <%= exercise_container_type %>">
+      <div class="mu-footer-row">
+        <div class="mu-footer-authoring">
           <%= yield :authoring %>
         </div>
       </div>
 
-      <div id="footer-copyright" class="row hidden-xs hidden-sm">
-        <div class="col-sm-8 text-left">
-          <p>
-            <%= render partial: 'layouts/copyright' %>
-          </p>
+      <div class="mu-footer-row">
+        <div class="mu-footer-copyright">
+          <%= render partial: 'layouts/copyright' %>
         </div>
 
-        <div id="footer-social" class="col-sm-4 text-right" lang="en">
+        <div class="mu-footer-terms">
+          <div><%= link_to_profile_terms %></div>
+          <% if current_user&.can_discuss_here? %>
+            <div><%= link_to_forum_terms %></div>
+          <% end %>
+        </div>
+
+        <div id="footer-social" class="mu-footer-social" lang="en">
           <%= render partial: 'layouts/social_media' %>
         </div>
       </div>

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -104,7 +104,7 @@ es-CL:
   first_name: Nombre
   forbidden_explanation: ¿Puede que hayas ingresado con una cuenta incorrecta?
   format: Dar formato
-  forum_terms_link: Si tienes alguna duda, consulta las %{terms_link}
+  forum_terms_link: Si tienes alguna duda, accede a las %{terms_link}
   fullscreen: "Pantalla completa"
   gender: Género
   get_messages: "Ver mensajes"

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -112,7 +112,7 @@ es:
   first_name: Nombre
   forbidden_explanation: ¿Puede que hayas ingresado con una cuenta incorrecta?
   format: Dar formato
-  forum_terms: Reglas del foro
+  forum_terms: Reglas del espacio de consulta
   forum_terms_link: Si tenés alguna duda, consultá las %{terms_link}
   fullscreen: "Pantalla completa"
   gender: Género

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -112,8 +112,8 @@ es:
   first_name: Nombre
   forbidden_explanation: ¿Puede que hayas ingresado con una cuenta incorrecta?
   format: Dar formato
-  forum_terms: Reglas del espacio de consulta
-  forum_terms_link: Si tenés alguna duda, consultá las %{terms_link}
+  forum_terms: Reglas del espacio de consultas
+  forum_terms_link: Si tenés alguna duda, accedé a las %{terms_link}
   fullscreen: "Pantalla completa"
   gender: Género
   get_messages: "Ver mensajes"

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -108,7 +108,7 @@ pt:
   first_name: Nome
   forbidden_explanation: Você poderia ter entrado com uma conta incorreta?
   format: Formato
-  forum_terms: Regras do fórum
+  forum_terms: Regras do espaço de consulta
   forum_terms_link: Se você tiver alguma dúvida, consulte as %{terms_link}
   fullscreen: Tela completa
   gender: Gênero

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'mumukit-auth', '~> 7.8'
   s.add_dependency 'mumukit-content-type', '~> 1.9'
 
-  s.add_dependency 'mumuki-styles', '~> 1.23'
+  s.add_dependency 'mumuki-styles', '~> 1.24'
   s.add_dependency 'muvment', '~> 1.2'
 
   s.add_dependency 'rack', '~> 2.1'


### PR DESCRIPTION
# Goal

The main goal of this PR was to add term related links to the footer.

The previous version of the footer was:

![footer-now](https://user-images.githubusercontent.com/11860076/102025193-24a20d00-3d75-11eb-8d75-e1bcbf9cb519.png)

After merging this one: 

Without forum terms:

![new-footer](https://user-images.githubusercontent.com/11860076/102025194-2bc91b00-3d75-11eb-9d92-c5ad196f6e96.png)

With forum terms: 

![with-terms](https://user-images.githubusercontent.com/11860076/102025376-4cde3b80-3d76-11eb-8341-005ca4fccb4e.png)


Notice that the word "Copyright" was removed.
This changes were discussed and approved by @flbulgarelli @fedescarpa @NadiaFinzi @aguspina & @lauramangifesta
 

## Changes and fixes after this PR

- The previous layout was responsive but it ended-up looking weird, so it was updated.

Before: 
![old-responsive](https://user-images.githubusercontent.com/11860076/102025276-967a5680-3d75-11eb-82b0-dda60b80baa7.png)

After: 
![new-responsive](https://user-images.githubusercontent.com/11860076/102025278-99754700-3d75-11eb-940f-1d779807dbd0.png)

It is now using flexbox instead of bootstrap grid system.

- Although this footer and biblio footer were quite the same, no styles were being shared. The common logic was moved to styles to avoid code repetition

- The word "foro" was replaced by "espacio de consultas"

- More semantic classes were added to the footer and some stale classes and ids were removed

