### PR TITLE
Chore fix exam numbering

### DIFF
--- a/app/views/book/show.html.erb
+++ b/app/views/book/show.html.erb
@@ -36,7 +36,7 @@
     <h2><%= t(:exams) %></h2>
     <% @exams.each_with_index do |it, index| %>
       <div class="chapter">
-        <h3> <%= t(:exam_number, number: index) %> <%= link_to_path_element it, mode: :plain %></h3>
+        <h3> <%= index + 1 %>. <%= link_to_path_element it, mode: :plain %></h3>
 
         <div class="text-box">
           <%= it.guide.description_teaser_html %>

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -86,7 +86,6 @@ en:
       gone: Oops! Content has expired
       internal_server_error: Oops! Something went wrong
       not_found: Oops! Page was not found
-  exam_number: 'Exam %{number}:'
   exams: Exams
   exercise: Exercise
   exercises: Exercises

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -85,7 +85,6 @@ es-CL:
       gone: ¡Ups! El contenido expiró
       internal_server_error: ¡Ups! Algo no anduvo bien
       not_found: ¡Ups!  La página no existe
-  exam_number: 'Examen %{number}:'
   exams: Exámenes
   exercise: Ejercicio
   exercise_count: ejercicios

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -93,7 +93,6 @@ es:
       gone: ¡Ups! El contenido expiró
       internal_server_error: ¡Ups! Algo no anduvo bien
       not_found: ¡Ups!  La página no existe
-  exam_number: 'Examen %{number}:'
   exams: Exámenes
   exercise: Ejercicio
   exercise_count: ejercicios

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -89,7 +89,6 @@ pt:
       gone: Opa! O conteúdo expirou
       internal_server_error: Opa! Algo não estava certo
       not_found: Opa! A página que você pesquisou não existe
-  exam_number: 'Revise %{number}:'
   exams: Examesca
   exercise: Exercício
   exercise_count: exercícios


### PR DESCRIPTION
@Gustrucco reported a visual inconsistency between exam list and chapter list in book page.

Before 

![Screen Shot 2020-12-15 at 17 56 26](https://user-images.githubusercontent.com/11860076/102363864-9dcb7b00-3f94-11eb-85e8-c6bb5b035d6c.png)

After

![Screenshot_2020-12-16 Aprendé a programar](https://user-images.githubusercontent.com/11860076/102363878-a2902f00-3f94-11eb-89fb-fbed401007c6.png)


Also numbering is starting from 1 one which I think it's more human like :smile: 