### PR TITLE
Feature add uppercase mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem 'execjs'
 gem 'therubyracer', platforms: :ruby
 gem 'uglifier', '~> 2.7'
 
+gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'feature-add-uppercase-mode'
+
 group :test do
   gem 'rspec-rails', '~> 3.6'
   gem 'factory_bot_rails', '~> 5.0'

--- a/app/assets/javascripts/mumuki_laboratory/application/uppercase-mode.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/uppercase-mode.js
@@ -1,0 +1,5 @@
+mumuki.load(() => {
+  if (JSON.parse($('#mu-uppercase-mode-enabled').val())) {
+    $('body').addClass('mu-uppercase');
+  }
+});

--- a/app/assets/stylesheets/mumuki_laboratory/application/_modules.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/_modules.scss
@@ -15,8 +15,9 @@
 @import "modules/guide_corollary";
 @import "modules/highlight";
 @import "modules/kids";
-@import "modules/kindergarten";
 @import "modules/kids_results";
+@import "modules/kindergarten";
+@import "modules/main";
 @import "modules/medal";
 @import "modules/modal";
 @import "modules/organization_chooser";

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_main.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_main.scss
@@ -1,0 +1,7 @@
+.mu-uppercase {
+  text-transform: uppercase;
+
+  code, .editor-code {
+    text-transform: initial;
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,6 @@
 <%= content_for :navbar do %>
   <%= hidden_field_tag("mu-current-exp", UserStats.exp_for(@current_user)) if in_gamified_context? %>
+  <%= hidden_field_tag("mu-uppercase-mode-enabled", @current_user.uppercase_mode_enabled) %>
   <div class="<%= exercise_container_type %>">
     <nav class="mu-navbar">
       <div class="mu-navbar-breadcrumb hidden-xs">


### PR DESCRIPTION
## :dart: Goal

Add an all-caps user configuration.

## :warning: Missing

This points to a placeholder Domain branch, which should add the field to User. I'll do it if we decide to go forward with this idea.

Also, we could extend this to auto-uppercase kindergarten organizations as well.

Finally, we should discuss where to add this setting, if we go ahead with it. Take this other setting https://github.com/mumuki/mumuki-laboratory/pull/1531 into account.

## :camera_flash: Screenshots

![image](https://user-images.githubusercontent.com/11304439/102911288-96a3e180-445a-11eb-91ee-91deda22199d.png)

_______

![image](https://user-images.githubusercontent.com/11304439/102911415-c357f900-445a-11eb-956f-47f6023a181e.png)


_______

![image](https://user-images.githubusercontent.com/11304439/102911467-da96e680-445a-11eb-8e18-b68fc7f0ddb3.png)

I kept the blocks in `kids` exercises in uppercase because I thought it didn't matter much, plus the all-caps setting will probably aid kids the most. There's not much point in setting it on if it's not enabled on the editor, where users spent the most time on and where it'll be most required.