### PR TITLE
Use FontAwesome5 syntax

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/button.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/button.js
@@ -106,11 +106,11 @@ mumuki.Button = class {
   }
 
   setWaitingText () {
-    this.$button.html('<i class="fa fa-refresh fa-spin"></i> ' + this.$button.attr('data-waiting'));
+    this.$button.html('<i class="fas fa-sync-alt fa-spin"></i> ' + this.$button.attr('data-waiting'));
   }
 
   setRetryText() {
-    this.$button.html('<i class="fa fa-undo"></i>');
+    this.$button.html('<i class="fas fa-undo"></i>');
   }
 
   setOriginalContent () {

--- a/app/assets/javascripts/mumuki_laboratory/application/codemirror-builder.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/codemirror-builder.js
@@ -1,7 +1,7 @@
 (() => {
   function submit() {
     $('body').removeClass('fullscreen');
-    $('.editor-resize .fa-stack-1x').removeClass('fa-compress').addClass('fa-expand');
+    $('.editor-resize .fas').toggleClass('fa-expand fa-compress');
     $('.btn-submit').click();
   }
 

--- a/app/assets/javascripts/mumuki_laboratory/application/codemirror.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/codemirror.js
@@ -36,7 +36,7 @@ mumuki.page.editors = [];
 
   function toggleFullscreen() {
     $('body').toggleClass('fullscreen');
-    $('.editor-resize .fa-stack-1x').toggleClass('fa-expand').toggleClass('fa-compress');
+    $('.editor-resize .fas').toggleClass('fa-expand fa-compress');
   }
 
   function indentWithSpaces(cm) {

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_overlap.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_overlap.scss
@@ -18,10 +18,6 @@
   }
 }
 
-.editor-resize {
-  font-size: 0.5em;
-}
-
 body.fullscreen {
   .mu-overlapped a {
     margin-right: 15px;

--- a/app/helpers/assignment_result_helper.rb
+++ b/app/helpers/assignment_result_helper.rb
@@ -15,7 +15,7 @@ module AssignmentResultHelper
 
   def render_community_link
     if community_link?
-      link_to fa_icon(:facebook, text: I18n.t(:ask_community), class: 'fa-fw'), community_link, target: '_blank'
+      link_to fa_icon('facebook-f', type: :brand, text: I18n.t(:ask_community), class: 'fa-fw'), community_link, target: '_blank'
     end
   end
 

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -67,8 +67,8 @@ module DiscussionsHelper
   def discussion_messages_icon(discussion)
     %Q{
       <span class="discussion-icon fa-stack fa-xs">
-        <i class="fa fa-comment-o fa-stack-2x"></i>
-        <i class="fa fa-stack-1x">#{discussion.validated_messages_count}</i>
+        <i class="far fa-comment fa-stack-2x"></i>
+        <i class="fas fa-stack-1x">#{discussion.validated_messages_count}</i>
       </span>
     }.html_safe
   end
@@ -77,8 +77,8 @@ module DiscussionsHelper
     if discussion.upvotes_count > 0
       %Q{
         <span class="discussion-icon fa-stack fa-xs">
-          <i class="fa fa-star-o fa-stack-2x"></i>
-          <i class="fa fa-stack-1x">#{discussion.upvotes_count}</i>
+          <i class="far fa-star fa-stack-2x"></i>
+          <i class="fas fa-stack-1x">#{discussion.upvotes_count}</i>
         </span>
       }.html_safe
     end

--- a/app/helpers/editor_tabs_helper.rb
+++ b/app/helpers/editor_tabs_helper.rb
@@ -14,7 +14,7 @@ module EditorTabsHelper
   def messages_tab(exercise, organization = Organization.current)
     "<li id='messages-tab' role='presentation'>
         <a data-target='#messages' tabindex='0' aria-controls='console' role='tab' data-toggle='tab' class='editor-tab'>
-          #{fa_icon 'comments-o'} #{t :messages }
+          #{fa_icon 'comments', type: :regular} #{t :messages }
         </a>
      </li>".html_safe if organization.raise_hand_enabled? && exercise.has_messages_for?(current_user)
   end

--- a/app/helpers/icons_helper.rb
+++ b/app/helpers/icons_helper.rb
@@ -58,6 +58,6 @@ module IconsHelper
   end
 
   def icon_for_read(read)
-    tag('i', class: "fa fa-envelope#{read ? '-o' : ''}")
+    tag('i', class: "fa#{read ? 'r' : 's'} fa-envelope")
   end
 end

--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -80,7 +80,7 @@ module LinksHelper
     return unless current_user&.writer?
 
     url = yield
-    link_to fixed_fa_icon(:pencil), url, class: "mu-content-toolbar-item", target: "_blank", title: t(:edit)
+    link_to fixed_fa_icon('pencil-alt'), url, class: "mu-content-toolbar-item", target: "_blank", title: t(:edit)
   end
 
   def url_for_bibliotheca_guide(guide)

--- a/app/helpers/menu_bar_helper.rb
+++ b/app/helpers/menu_bar_helper.rb
@@ -35,6 +35,10 @@ module MenuBarHelper
     menu_item icon, app_name, url
   end
 
+  def logout_link
+    li_tag menu_item('sign-out-alt', :sign_out, logout_path(origin: url_for))
+  end
+
   def menu_item(icon, name, url)
     link_to fixed_fa_icon(icon, text: t(name)), url, role: 'menuitem', tabindex: '-1'
   end

--- a/app/helpers/menu_bar_helper.rb
+++ b/app/helpers/menu_bar_helper.rb
@@ -18,7 +18,7 @@ module MenuBarHelper
   end
 
   def link_to_profile
-    li_tag menu_item('user', :profile, user_path)
+    menu_item('user', :profile, user_path)
   end
 
   def link_to_classroom

--- a/app/helpers/menu_bar_helper.rb
+++ b/app/helpers/menu_bar_helper.rb
@@ -18,7 +18,7 @@ module MenuBarHelper
   end
 
   def link_to_profile
-    li_tag menu_item('user-o', :profile, user_path)
+    li_tag menu_item('user', :profile, user_path)
   end
 
   def link_to_classroom

--- a/app/helpers/overlapped_buttons_helper.rb
+++ b/app/helpers/overlapped_buttons_helper.rb
@@ -1,4 +1,8 @@
 module OverlappedButtonsHelper
+  def expand_icon
+    overlapped_button_icon :fullscreen, :expand, " (F11)"
+  end
+
   def restart_icon
     overlapped_button_icon :restart, :undo
   end
@@ -11,7 +15,7 @@ module OverlappedButtonsHelper
     link_to restart_icon, guide_progress_path(guide), class: 'mu-content-toolbar-item mu-restart-guide', data: {confirm: t(:confirm_restart)}, method: :delete
   end
 
-  def overlapped_button_icon(key, icon)
-    fa_icon(icon, title: t(key), class: 'fa-fw', role: 'button', 'aria-label': t(key))
+  def overlapped_button_icon(key, icon, extra_title='')
+    fa_icon(icon, title: t(key) + extra_title, class: 'fa-fw', role: 'button', 'aria-label': t(key))
   end
 end

--- a/app/helpers/overlapped_buttons_helper.rb
+++ b/app/helpers/overlapped_buttons_helper.rb
@@ -16,6 +16,6 @@ module OverlappedButtonsHelper
   end
 
   def overlapped_button_icon(key, icon, extra_title='')
-    fa_icon(icon, title: t(key) + extra_title, class: 'fa-fw', role: 'button', 'aria-label': t(key))
+    fa_icon(icon, title: t(key) + extra_title, class: 'fa-fw', role: 'button', 'aria-label': t(key), 'data-placement': 'left')
   end
 end

--- a/app/views/book/show.html.erb
+++ b/app/views/book/show.html.erb
@@ -26,7 +26,7 @@
 
       <% unless enabled  %>
         <div class="text-center mu-lock">
-          <i class="fa fa-lock fa-5x"></i>
+          <i class="fas fa-lock fa-5x"></i>
           <p><%= t :locked_content %></p>
         </div>
       <% end %>

--- a/app/views/discussions/_message.html.erb
+++ b/app/views/discussions/_message.html.erb
@@ -17,11 +17,11 @@
               </a>
               <% if message.from_initiator? %>
                 <a class="discussion-message-not-actually-a-question <%= 'selected' if message.not_actually_a_question? %>" onclick="mumuki.Forum.discussionMessageToggleNotActuallyAQuestion('<%= question_discussion_message_url(@discussion, message) %>', $(this))">
-                  <%= fa_icon('question-circle-o', class: 'fa-xs') %>
+                  <%= fa_icon('question-circle', type: 'regular', class: 'fa-xs') %>
                 </a>
               <% end %>
             <% end %>
-            <%= link_to fa_icon('trash-o'), discussion_message_path(@discussion, message), method: :delete, data: { confirm: t(:are_you_sure, action: t(:destroy_message)) } %>
+            <%= link_to fa_icon('trash-alt', type: :regular), discussion_message_path(@discussion, message), method: :delete, data: { confirm: t(:are_you_sure, action: t(:destroy_message)) } %>
           <% end %>
           <% if should_show_approved_for?(current_user, message) %>
             <span class="discussion-message-approved selected">

--- a/app/views/exercise_solutions/_kids_level_up.html.erb
+++ b/app/views/exercise_solutions/_kids_level_up.html.erb
@@ -3,7 +3,7 @@
     <%= t :level_up %>
   </h3>
   <div class="text-center mu-level">
-    <i class="fa fa-star fa-fw fa-4x"></i>
+    <i class="fas fa-star fa-fw fa-4x"></i>
     <span class="mu-level-number"></span>
     <p></p>
     <p id="mu-solve-more-exercises"> <%= (t :solve_more_exercises_to_level_up).html_safe %></p>

--- a/app/views/exercises/_exercise_assignment.html.erb
+++ b/app/views/exercises/_exercise_assignment.html.erb
@@ -6,7 +6,7 @@
     <div class="hint-box <%= 'hidden' if exercise.hint.blank? %>">
       <% if exercise.hint.present? %>
         <a data-toggle="collapse" href="#hint-section" class="text-info">
-          <%= fa_icon 'lightbulb-o' %> <%= t :need_a_hint %>
+          <%= fa_icon 'lightbulb', type: :regular %> <%= t :need_a_hint %>
         </a>
 
         <div id="hint-section" class="collapse">

--- a/app/views/exercises/_read_only.html.erb
+++ b/app/views/exercises/_read_only.html.erb
@@ -36,7 +36,7 @@
           <% end %>
           <% if @discussion.solved? %>
             <a class="discussion-upvote" onclick="mumuki.Forum.discussionUpvote('<%= upvote_discussion_url(@discussion) %>')">
-              <%= fa_icon('thumbs-o-up', class: 'fa-xs') %>
+              <%= fa_icon('thumbs-up', type: :regular, class: 'fa-xs') %>
               <%= span_toggle t(:upvote), t(:undo_upvote), current_user.upvoted?(@discussion), class: 'hidden-sm hidden-xs' %>
             </a>
           <% end %>

--- a/app/views/exercises/show.html.erb
+++ b/app/views/exercises/show.html.erb
@@ -51,7 +51,7 @@
 
 <div style="display: none" id="processing-template">
   <div class="bs-callout bs-callout-info">
-    <h4><i class="fa fa-refresh fa-spin"></i> <strong><%= t :processing_your_solution %></strong></h4>
+    <h4><i class="fas fa-sync-alt fa-spin"></i> <strong><%= t :processing_your_solution %></strong></h4>
     <%= t :refresh_or_wait %>
   </div>
 </div>

--- a/app/views/layouts/_kids.html.erb
+++ b/app/views/layouts/_kids.html.erb
@@ -3,17 +3,17 @@
   <% if exercise.hint? %>
       <ul class="mu-kids-character-speech-bubble-tabs">
         <li class="mu-kids-description active" data-target="description" title="<%= t :task %>">
-          <i class="fa fa-fw fa-file-text-o"></i>
+          <i class="far fa-fw fa-file-alt"></i>
         </li>
         <li class="separator"></li>
         <li class="mu-kids-hint blink" data-target="hint" title="<%= t :need_a_hint %>">
-          <i class="fa fa-fw fa-lightbulb-o"></i>
+          <i class="far fa-fw fa-lightbulb"></i>
         </li>
       </ul>
   <% end %>
   <div class="mu-kids-character-speech-bubble-normal">
-    <i class="mu-kids-prev-speech fa fa-fw fa-caret-up"></i>
-    <i class="mu-kids-next-speech fa fa-fw fa-caret-down"></i>
+    <i class="mu-kids-prev-speech fas fa-fw fa-caret-up"></i>
+    <i class="mu-kids-next-speech fas fa-fw fa-caret-down"></i>
     <div class="description"><%= exercise.description_task %></div>
     <div class="hint" style="display: none"><%= exercise.hint_html %></div>
   </div>

--- a/app/views/layouts/_kindergarten.html.erb
+++ b/app/views/layouts/_kindergarten.html.erb
@@ -24,7 +24,7 @@
           <%= exercise.hint.markdownified %>
         </span>
         <button class="expand-or-collapse-hint-media" onclick="mumuki.kids.hint.toggleMedia()">
-          <i class="fa fa-fw fa-2x fa-caret-up"></i>
+          <i class="fas fa-fw fa-2x fa-caret-up"></i>
         </button>
       </div>
     <% else %>

--- a/app/views/layouts/_social_media.html.erb
+++ b/app/views/layouts/_social_media.html.erb
@@ -1,4 +1,4 @@
-<a class="fa fa-facebook social-icon" aria-label="Facebook" href="https://www.facebook.com/MumukiOrg" target="_blank"></a>
-<a class="fa fa-twitter social-icon" aria-label="Twitter" href="https://twitter.com/MumukiOrg" target="_blank"></a>
-<a class="fa fa-github social-icon" aria-label="Github" href="https://github.com/mumuki" target="_blank"></a>
-<a class="fa fa-linkedin social-icon" aria-label="LinkedIn" href="https://www.linkedin.com/company/mumukiorg" target="_blank"></a>
+<a class="fab fa-facebook-f social-icon" aria-label="Facebook" href="https://www.facebook.com/MumukiOrg" target="_blank"></a>
+<a class="fab fa-twitter social-icon" aria-label="Twitter" href="https://twitter.com/MumukiOrg" target="_blank"></a>
+<a class="fab fa-github social-icon" aria-label="Github" href="https://github.com/mumuki" target="_blank"></a>
+<a class="fab fa-linkedin-in social-icon" aria-label="LinkedIn" href="https://www.linkedin.com/company/mumukiorg" target="_blank"></a>

--- a/app/views/layouts/_timer.html.erb
+++ b/app/views/layouts/_timer.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-md-3 col-md-offset-5">
-    <i class="timer text-center fa fa-clock-o"></i>
+    <i class="timer text-center far fa-clock"></i>
     <i class="timer timer-text text-center"><%= t :time_left %></i>
     <i id="timer" class="timer timer-text text-center"></i>
     <script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
       <div class="dropdown hamburguer-breadcrumb hidden-sm hidden-md hidden-lg">
         <% if content_for? :breadcrumbs %>
         <span class="hamburguer" id="profileDropdown" data-toggle="dropdown">
-          <i class="fa fa-bars"></i>
+          <i class="fas fa-bars"></i>
         </span>
           <ul class="dropdown-menu dropdown-menu-left" aria-labelledby="profileDropdown">
             <%= yield :breadcrumbs %>
@@ -21,13 +21,13 @@
         <% if current_logged_user? %>
           <% if in_gamified_context? %>
             <div class="mu-navbar-element">
-              <i class="fa fa-star fa-fw fa-2x mu-navbar-icon mu-level-tooltip" data-toggle="tooltip" data-placement="bottom" level="<%= t(:level) %>"></i>
+              <i class="fas fa-star fa-fw fa-2x mu-navbar-icon mu-level-tooltip" data-toggle="tooltip" data-placement="bottom" level="<%= t(:level) %>"></i>
               <span class="mu-level-number"></span>
             </div>
           <% end %>
           <div class="dropdown mu-navbar-element notifications-box <%= 'notifications-box-empty' unless has_notifications? %>">
             <a href=<%= "#{user_notifications_path}" %>>
-              <i class="fa fa-bell fa-fw fa-2x mu-navbar-icon"></i>
+              <i class="fas fa-bell fa-fw fa-2x mu-navbar-icon"></i>
                 <span class="badge badge-notifications"><%= notifications_count %></span>
             </a>
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,7 +39,7 @@
             <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="profileDropdown">
               <%= menu_bar_list_items %>
               <li class="divider"></li>
-              <li><%= link_to(t(:sign_out), logout_path(origin: url_for), role: 'menuitem') %></li>
+              <%= logout_link %>
             </ul>
           </div>
         <% else %>

--- a/app/views/layouts/exercise_inputs/editors/_code.html.erb
+++ b/app/views/layouts/exercise_inputs/editors/_code.html.erb
@@ -5,12 +5,7 @@
                   value: @current_content,
                   data: {lines: 17} %>
   <div class="mu-overlapped">
-    <a class="editor-resize" title="<%= t(:fullscreen) %> (F11)">
-      <span class="fa-stack fa-lg">
-        <i class="fa fa-square-o fa-stack-2x"></i>
-        <i class="fa fa-expand fa-stack-1x"></i>
-      </span>
-    </a>
+    <a class="editor-resize"> <%= expand_icon %></a>
     <a class="editor-format"><%= format_icon %></a>
     <a class="editor-reset submission-reset" data-confirm="<%= t(:confirm_reset) %>"><%= restart_icon %></a>
   </div>

--- a/app/views/layouts/exercise_inputs/editors/_multiple_files.html.erb
+++ b/app/views/layouts/exercise_inputs/editors/_multiple_files.html.erb
@@ -28,6 +28,7 @@
 
     <div class="mu-overlapped multiple-files">
       <a class="editor-resize"> <%= expand_icon %></a>
+      <a class="editor-format"><%= format_icon %></a>
       <!--<a class="editor-reset submission-reset" data-confirm="<%= t(:confirm_reset) %>"><%= restart_icon %></a> -->
     </div>
   </div>

--- a/app/views/layouts/exercise_inputs/editors/_multiple_files.html.erb
+++ b/app/views/layouts/exercise_inputs/editors/_multiple_files.html.erb
@@ -27,14 +27,8 @@
     </div>
 
     <div class="mu-overlapped multiple-files">
-      <a class="editor-resize" title="<%= t(:fullscreen) %> (F11)">
-        <span class="fa-stack fa-lg">
-          <i class="fa fa-square-o fa-stack-2x"></i>
-          <i class="fa fa-expand fa-stack-1x"></i>
-        </span>
-      </a>
+      <a class="editor-resize"> <%= expand_icon %></a>
       <!--<a class="editor-reset submission-reset" data-confirm="<%= t(:confirm_reset) %>"><%= restart_icon %></a> -->
     </div>
-
   </div>
 </div>

--- a/app/views/layouts/exercise_inputs/editors/_multiple_files.html.erb
+++ b/app/views/layouts/exercise_inputs/editors/_multiple_files.html.erb
@@ -5,11 +5,11 @@
       <ul class="nav nav-tabs">
         <% @files.each_with_index do |file, index| %>
           <li role="presentation" class="file-tab <%= 'active' if index == 0 %>" data-target="#editor-file-<%= index %>" tabindex='0' data-toggle='tab'>
-            <a class="file-name" href="#"><%= file.name %></a> <i class="delete-file-button fa fa-times"></i>
+            <a class="file-name" href="#"><%= file.name %></a> <i class="delete-file-button fas fa-times"></i>
           </li>
         <% end %>
       </ul>
-      <i class="add-file-button fa fa-plus"></i>
+      <i class="add-file-button fas fa-plus"></i>
     </span>
 
     <%= multifile_hidden_inputs %>

--- a/app/views/layouts/exercise_inputs/forms/_problem_form.html.erb
+++ b/app/views/layouts/exercise_inputs/forms/_problem_form.html.erb
@@ -4,7 +4,7 @@
 <% if should_render_problem_tabs? exercise, current_user %>
   <ul class="nav nav-tabs" role="tablist">
     <li role="presentation" class="active">
-      <a data-target="#editor" aria-controls="editor" tabindex="0" role="tab" data-toggle="tab" class="editor-tab"><%= fa_icon 'pencil-square' %> <%= t :solution %></a>
+      <a data-target="#editor" aria-controls="editor" tabindex="0" role="tab" data-toggle="tab" class="editor-tab"><%= fa_icon 'pen-square' %> <%= t :solution %></a>
     </li>
     <% if exercise.extra_visible? %>
       <%= extra_code_tab %>

--- a/app/views/layouts/modals/_guide_corollary.html.erb
+++ b/app/views/layouts/modals/_guide_corollary.html.erb
@@ -4,7 +4,7 @@
       <% if Organization.current.kids? %>
         <button type="button" class="mu-kids-modal-button mu-close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">
-            <i class="fa fa-fw fa-times fa-3x"></i>
+            <i class="fas fa-fw fa-times fa-3x"></i>
           </span>
         </button>
       <% end %>

--- a/app/views/layouts/modals/_kids_results.html.erb
+++ b/app/views/layouts/modals/_kids_results.html.erb
@@ -3,12 +3,12 @@
     <div class="modal-content success">
       <button type="button" class="mu-kids-modal-button mu-previous hidden" onclick="mumuki.kids.resultsCarrousel.prevSlide()" aria-label="Previous">
         <span aria-hidden="true">
-          <i class="fa fa-fw fa-arrow-left fa-3x"></i>
+          <i class="fas fa-fw fa-arrow-left fa-3x"></i>
         </span>
       </button>
       <button type="button" class="mu-kids-modal-button mu-next" onclick="mumuki.kids.resultsCarrousel.nextSlide()" aria-label="Next">
         <span aria-hidden="true">
-          <i class="fa fa-fw fa-arrow-right fa-3x"></i>
+          <i class="fas fa-fw fa-arrow-right fa-3x"></i>
         </span>
       </button>
       <div class="modal-header text-center">

--- a/app/views/layouts/modals/_kindergarten_context.html.erb
+++ b/app/views/layouts/modals/_kindergarten_context.html.erb
@@ -3,17 +3,17 @@
     <div class="modal-content kindergarten">
       <button type="button" class="mu-kids-modal-button mu-close" data-waiting="" data-dismiss="modal" aria-label="Close">
         <span aria-hidden="true">
-          <i class="fa fa-fw fa-times fa-3x"></i>
+          <i class="fas fa-fw fa-times fa-3x"></i>
         </span>
       </button>
       <button type="button" class="mu-kids-modal-button mu-previous hidden" onclick="mumuki.kids.context.prevSlide()" aria-label="Previous">
         <span aria-hidden="true">
-          <i class="fa fa-fw fa-arrow-left fa-3x"></i>
+          <i class="fas fa-fw fa-arrow-left fa-3x"></i>
         </span>
       </button>
       <button type="button" class="mu-kids-modal-button mu-next" onclick="mumuki.kids.context.nextSlide()" aria-label="Next">
         <span aria-hidden="true">
-          <i class="fa fa-fw fa-arrow-right fa-3x"></i>
+          <i class="fas fa-fw fa-arrow-right fa-3x"></i>
         </span>
       </button>
       <div class="modal-body mu-kids-context-body">

--- a/app/views/layouts/modals/_kindergarten_results.html.erb
+++ b/app/views/layouts/modals/_kindergarten_results.html.erb
@@ -3,17 +3,17 @@
     <div class="modal-content kindergarten">
       <button type="button" class="mu-kids-modal-button mu-close" data-waiting="" data-dismiss="modal" aria-label="Close">
         <span aria-hidden="true">
-          <i class="fa fa-fw fa-times fa-3x"></i>
+          <i class="fas fa-fw fa-times fa-3x"></i>
         </span>
       </button>
       <button type="button" class="mu-kids-modal-button mu-previous hidden" onclick="mumuki.kids.resultsCarrousel.prevSlide()" aria-label="Previous">
         <span aria-hidden="true">
-          <i class="fa fa-fw fa-arrow-left fa-3x"></i>
+          <i class="fas fa-fw fa-arrow-left fa-3x"></i>
         </span>
       </button>
       <button type="button" class="mu-kids-modal-button mu-next" onclick="mumuki.kids.resultsCarrousel.nextSlide()" aria-label="Next">
         <span aria-hidden="true">
-          <i class="fa fa-fw fa-arrow-right fa-3x"></i>
+          <i class="fas fa-fw fa-arrow-right fa-3x"></i>
         </span>
       </button>
       <div class="modal-header">

--- a/app/views/layouts/modals/_kindergarten_results_aborted.html.erb
+++ b/app/views/layouts/modals/_kindergarten_results_aborted.html.erb
@@ -3,7 +3,7 @@
     <div class="modal-content broken kindergarten">
       <button type="button" class="mu-kids-modal-button mu-close" data-dismiss="modal" aria-label="Close" data-waiting="">
             <span aria-hidden="true">
-              <i class="fa fa-fw fa-times fa-3x"></i>
+              <i class="fas fa-fw fa-times fa-3x"></i>
             </span>
       </button>
       <div class="modal-header">

--- a/app/views/layouts/modals/_level_up.html.erb
+++ b/app/views/layouts/modals/_level_up.html.erb
@@ -13,7 +13,7 @@
           <div class="row">
             <div class="col-md-12">
               <div class="text-center mu-level">
-                <i class="fa fa-star fa-fw fa-4x"></i>
+                <i class="fas fa-star fa-fw fa-4x"></i>
                 <span class="mu-level-number"></span>
                 <p></p>
                 <p id="mu-solve-more-exercises"> <%= (t :solve_more_exercises_to_level_up).html_safe %></p>

--- a/app/views/users/_edit_user_form.html.erb
+++ b/app/views/users/_edit_user_form.html.erb
@@ -9,7 +9,7 @@
   <div class="row mu-tab-body">
     <div class="col-md-4 text-center">
       <%= profile_picture_for(@user, id: 'mu-user-avatar', class: 'mu-user-avatar') %>
-      <i class="fa fa-pencil fa-2x pointer mu-edit-avatar" id="mu-edit-avatar-icon" tabindex="0"></i>
+      <i class="fas fa-pencil-alt fa-2x pointer mu-edit-avatar" id="mu-edit-avatar-icon" tabindex="0"></i>
     </div>
     <div class="col-md-8">
       <%= render partial: 'profile_fields', locals: {form: f} %>

--- a/app/views/users/_user_form.html.erb
+++ b/app/views/users/_user_form.html.erb
@@ -12,7 +12,7 @@
         <path id="mu-level-progress" stroke-linecap="round" stroke="#24b8aa" stroke-width="4" stroke-dasharray="0, 999" fill="none" d="M50 10 a 40 40 0 0 1 0 80 a 40 40 0 0 1 0 -80"></path>
       </svg>
       <div class="mu-level">
-        <i class="fa fa-star fa-fw fa-4x"></i>
+        <i class="fas fa-star fa-fw fa-4x"></i>
         <span class="mu-level-number"></span>
         <p><%= t :level %></p>
       </div>

--- a/lib/mumuki/laboratory/engine.rb
+++ b/lib/mumuki/laboratory/engine.rb
@@ -1,5 +1,5 @@
 require 'turbolinks'
-require 'font-awesome-rails'
+require 'font_awesome5_rails'
 require 'momentjs-rails'
 require 'nprogress-rails'
 require 'rails-i18n'

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'mumukit-auth', '~> 7.8'
   s.add_dependency 'mumukit-content-type', '~> 1.9'
 
-  s.add_dependency 'mumuki-styles', '~> 1.24'
+  s.add_dependency 'mumuki-styles', '~> 2.0'
   s.add_dependency 'muvment', '~> 1.2'
 
   s.add_dependency 'rack', '~> 2.1'

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'kaminari', '~> 0.16'
   s.add_dependency 'bootstrap-kaminari-views'
 
-  s.add_dependency 'font-awesome-rails', '~> 4.7'
+  s.add_dependency 'font_awesome5_rails', '~> 1.3'
   s.add_dependency 'momentjs-rails', '~> 2.10'
   s.add_dependency 'nprogress-rails', '~> 0.2'
   s.add_dependency 'rails-i18n', '~> 4.0.0'

--- a/spec/helpers/icons_helper_spec.rb
+++ b/spec/helpers/icons_helper_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe IconsHelper, organization_workspace: :test do
   helper IconsHelper
-  helper FontAwesome::Rails::IconHelper
+  helper FontAwesome5::Rails::IconHelper
 
   describe '#language_icon' do
     let(:haskell) { create(:language, name: 'Haskell') }

--- a/spec/helpers/icons_helper_spec.rb
+++ b/spec/helpers/icons_helper_spec.rb
@@ -16,7 +16,7 @@ describe IconsHelper, organization_workspace: :test do
     }
     let(:failed_submission) { create(:assignment, status: :failed) }
 
-    it { expect(status_icon(passed_submission)).to eq '<i class="fa fa-check-circle text-success status-icon"></i>' }
-    it { expect(status_icon(failed_submission)).to eq '<i class="fa fa-times-circle text-danger status-icon"></i>' }
+    it { expect(status_icon(passed_submission)).to eq '<i class="fas fa-check-circle text-success status-icon"></i>' }
+    it { expect(status_icon(failed_submission)).to eq '<i class="fas fa-times-circle text-danger status-icon"></i>' }
   end
 end

--- a/spec/helpers/test_results_rendering_spec.rb
+++ b/spec/helpers/test_results_rendering_spec.rb
@@ -13,13 +13,13 @@ describe ContextualizationResultHelper do
     context 'plain explanation' do
       let(:expectation_result) { {result: :failed, explanation: 'you must delegate'} }
 
-      it { expect(html).to eq '<i class="fa fa-times-circle text-danger status-icon"></i> you must delegate' }
+      it { expect(html).to eq '<i class="fas fa-times-circle text-danger status-icon"></i> you must delegate' }
     end
 
     context 'html explanation' do
       let(:expectation_result) { {result: :failed, explanation: 'you must use <strong>if</strong>'} }
 
-      it { expect(html).to eq '<i class="fa fa-times-circle text-danger status-icon"></i> you must use <strong>if</strong>' }
+      it { expect(html).to eq '<i class="fas fa-times-circle text-danger status-icon"></i> you must use <strong>if</strong>' }
     end
   end
 
@@ -35,7 +35,7 @@ describe ContextualizationResultHelper do
           test_results: [{title: '2 is 2', status: :passed, result: ''}]) }
 
         it { expect(html).to be_html_safe }
-        it { expect(html).to include "<i class=\"fa fa-check-circle text-success status-icon\"></i>" }
+        it { expect(html).to include "<i class=\"fas fa-check-circle text-success status-icon\"></i>" }
         it { expect(html).to include "2 is 2" }
       end
 
@@ -47,7 +47,7 @@ describe ContextualizationResultHelper do
             exercise: problem,
             test_results: [{title: '2 is 2', status: :failed, result: 'something _went_ wrong'}]) }
 
-          it { expect(html).to include "<i class=\"fa fa-times-circle text-danger status-icon\"></i>" }
+          it { expect(html).to include "<i class=\"fas fa-times-circle text-danger status-icon\"></i>" }
           it { expect(html).to include "2 is 2" }
           it { expect(html).to include "<pre>something _went_ wrong</pre>" }
         end
@@ -59,7 +59,7 @@ describe ContextualizationResultHelper do
             exercise: problem,
             test_results: [{title: '2 is 2', status: :failed, result: 'something went _really_ wrong'}]) }
 
-          it { expect(html).to include "<i class=\"fa fa-times-circle text-danger status-icon\"></i>" }
+          it { expect(html).to include "<i class=\"fas fa-times-circle text-danger status-icon\"></i>" }
           it { expect(html).to include "2 is 2" }
           it { expect(html).to include "<p>something went <em>really</em> wrong</p>" }
         end
@@ -72,7 +72,7 @@ describe ContextualizationResultHelper do
             test_results: [{title: 'foo is 2', status: :failed, result: 'foo is undefined', summary: {type: 'undefined_variable', message: 'you are using things that are _not defined_'}}]) }
 
           it { expect(html).to include 'foo is 2: you are using things that are <em>not defined</em>' }
-          it { expect(html).to include "<i class=\"fa fa-times-circle text-danger status-icon\"></i>" }
+          it { expect(html).to include "<i class=\"fas fa-times-circle text-danger status-icon\"></i>" }
           it { expect(html).to include '<p>foo is undefined</p>' }
         end
 
@@ -84,7 +84,7 @@ describe ContextualizationResultHelper do
             test_results: [{title: '', status: :failed, result: 'foo is undefined', summary: {type: 'undefined_variable', message: 'you are using things that are _not defined_'}}]) }
 
           it { expect(html).to include 'you are using things that are <em>not defined</em>' }
-          it { expect(html).to include "<i class=\"fa fa-times-circle text-danger status-icon\"></i>" }
+          it { expect(html).to include "<i class=\"fas fa-times-circle text-danger status-icon\"></i>" }
           it { expect(html).to include '<p>foo is undefined</p>' }
         end
       end

--- a/spec/helpers/test_results_rendering_spec.rb
+++ b/spec/helpers/test_results_rendering_spec.rb
@@ -3,7 +3,7 @@ require 'ostruct'
 
 describe ContextualizationResultHelper do
   helper IconsHelper
-  helper FontAwesome::Rails::IconHelper
+  helper FontAwesome5::Rails::IconHelper
   helper ContextualizationResultHelper
 
 

--- a/spec/helpers/with_navigation_spec.rb
+++ b/spec/helpers/with_navigation_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe WithStudentPathNavigation, organization_workspace: :test do
   helper WithStudentPathNavigation
-  helper FontAwesome::Rails::IconHelper
+  helper FontAwesome5::Rails::IconHelper
 
   describe '#next_button' do
     let(:current_user) { create(:user) }

--- a/spec/helpers/with_navigation_spec.rb
+++ b/spec/helpers/with_navigation_spec.rb
@@ -14,9 +14,9 @@ describe WithStudentPathNavigation, organization_workspace: :test do
       let!(:exercise_3) { create(:exercise, id: 13, name: 'exercise 3', guide: guide) }
 
       context 'when user did not submit any solution' do
-        it { expect(next_button(exercise_1)).to eq "<a class=\"btn btn-success btn-block\" role=\"button\" href=\"/exercises/#{exercise_2.friendly_name}\">Next: exercise 2 <i class=\"fa fa-chevron-right\"></i></a>" }
-        it { expect(next_button(exercise_2)).to eq "<a class=\"btn btn-success btn-block\" role=\"button\" href=\"/exercises/#{exercise_3.friendly_name}\">Next: exercise 3 <i class=\"fa fa-chevron-right\"></i></a>" }
-        it { expect(next_button(exercise_3)).to eq "<a class=\"btn btn-warning btn-block\" role=\"button\" href=\"/exercises/#{exercise_1.friendly_name}\">Next pending: exercise 1 <i class=\"fa fa-chevron-right\"></i></a>" }
+        it { expect(next_button(exercise_1)).to eq "<a class=\"btn btn-success btn-block\" role=\"button\" href=\"/exercises/#{exercise_2.friendly_name}\"><span class=\"fa5-text-r\">Next: exercise 2</span><i class=\"fas fa-chevron-right\"></i></a>" }
+        it { expect(next_button(exercise_2)).to eq "<a class=\"btn btn-success btn-block\" role=\"button\" href=\"/exercises/#{exercise_3.friendly_name}\"><span class=\"fa5-text-r\">Next: exercise 3</span><i class=\"fas fa-chevron-right\"></i></a>" }
+        it { expect(next_button(exercise_3)).to eq "<a class=\"btn btn-warning btn-block\" role=\"button\" href=\"/exercises/#{exercise_1.friendly_name}\"><span class=\"fa5-text-r\">Next pending: exercise 1</span><i class=\"fas fa-chevron-right\"></i></a>" }
       end
 
       context 'when on last unresolved exercise' do
@@ -25,9 +25,9 @@ describe WithStudentPathNavigation, organization_workspace: :test do
           exercise_3.submit_solution!(current_user).passed!
         end
 
-        it { expect(next_button(exercise_1)).to eq "<a class=\"btn btn-success btn-block\" role=\"button\" href=\"/exercises/#{exercise_2.friendly_name}\">Next: exercise 2 <i class=\"fa fa-chevron-right\"></i></a>" }
+        it { expect(next_button(exercise_1)).to eq "<a class=\"btn btn-success btn-block\" role=\"button\" href=\"/exercises/#{exercise_2.friendly_name}\"><span class=\"fa5-text-r\">Next: exercise 2</span><i class=\"fas fa-chevron-right\"></i></a>" }
         it { expect(next_button(exercise_2)).to be nil }
-        it { expect(next_button(exercise_3)).to eq "<a class=\"btn btn-warning btn-block\" role=\"button\" href=\"/exercises/#{exercise_2.friendly_name}\">Next pending: exercise 2 <i class=\"fa fa-chevron-right\"></i></a>" }
+        it { expect(next_button(exercise_3)).to eq "<a class=\"btn btn-warning btn-block\" role=\"button\" href=\"/exercises/#{exercise_2.friendly_name}\"><span class=\"fa5-text-r\">Next pending: exercise 2</span><i class=\"fas fa-chevron-right\"></i></a>" }
       end
 
       context 'when user did submit a solution' do
@@ -35,9 +35,9 @@ describe WithStudentPathNavigation, organization_workspace: :test do
           exercise_1.submit_solution!(current_user).passed!
         end
 
-        it { expect(next_button(exercise_1)).to eq "<a class=\"btn btn-success btn-block\" role=\"button\" href=\"/exercises/#{exercise_2.friendly_name}\">Next: exercise 2 <i class=\"fa fa-chevron-right\"></i></a>" }
-        it { expect(next_button(exercise_2)).to eq "<a class=\"btn btn-success btn-block\" role=\"button\" href=\"/exercises/#{exercise_3.friendly_name}\">Next: exercise 3 <i class=\"fa fa-chevron-right\"></i></a>" }
-        it { expect(next_button(exercise_3)).to eq "<a class=\"btn btn-warning btn-block\" role=\"button\" href=\"/exercises/#{exercise_2.friendly_name}\">Next pending: exercise 2 <i class=\"fa fa-chevron-right\"></i></a>" }
+        it { expect(next_button(exercise_1)).to eq "<a class=\"btn btn-success btn-block\" role=\"button\" href=\"/exercises/#{exercise_2.friendly_name}\"><span class=\"fa5-text-r\">Next: exercise 2</span><i class=\"fas fa-chevron-right\"></i></a>" }
+        it { expect(next_button(exercise_2)).to eq "<a class=\"btn btn-success btn-block\" role=\"button\" href=\"/exercises/#{exercise_3.friendly_name}\"><span class=\"fa5-text-r\">Next: exercise 3</span><i class=\"fas fa-chevron-right\"></i></a>" }
+        it { expect(next_button(exercise_3)).to eq "<a class=\"btn btn-warning btn-block\" role=\"button\" href=\"/exercises/#{exercise_2.friendly_name}\"><span class=\"fa5-text-r\">Next pending: exercise 2</span><i class=\"fas fa-chevron-right\"></i></a>" }
       end
     end
 
@@ -46,8 +46,8 @@ describe WithStudentPathNavigation, organization_workspace: :test do
       let!(:exercise) { create(:exercise, id: 12, name: 'exercise 2', guide: guide) }
 
       context 'when user did not submit any exercise' do
-        it { expect(next_button(reading)).to eq "<a class=\"btn-confirmation btn btn-success btn-block\" data-confirmation-url=\"/exercises/#{reading.friendly_name}/confirmations\" role=\"button\" href=\"/exercises/#{exercise.friendly_name}\">Next: exercise 2 <i class=\"fa fa-chevron-right\"></i></a>" }
-        it { expect(next_button(exercise)).to eq "<a class=\"btn btn-warning btn-block\" role=\"button\" href=\"/exercises/#{reading.friendly_name}\">Next pending: exercise 1 <i class=\"fa fa-chevron-right\"></i></a>" }
+        it { expect(next_button(reading)).to eq "<a class=\"btn-confirmation btn btn-success btn-block\" data-confirmation-url=\"/exercises/#{reading.friendly_name}/confirmations\" role=\"button\" href=\"/exercises/#{exercise.friendly_name}\"><span class=\"fa5-text-r\">Next: exercise 2</span><i class=\"fas fa-chevron-right\"></i></a>" }
+        it { expect(next_button(exercise)).to eq "<a class=\"btn btn-warning btn-block\" role=\"button\" href=\"/exercises/#{reading.friendly_name}\"><span class=\"fa5-text-r\">Next pending: exercise 1</span><i class=\"fas fa-chevron-right\"></i></a>" }
       end
 
       context 'when user finished just reading' do
@@ -55,7 +55,7 @@ describe WithStudentPathNavigation, organization_workspace: :test do
           reading.submit_confirmation!(current_user)
         end
 
-        it { expect(next_button(reading)).to eq "<a class=\"btn-confirmation btn btn-success btn-block\" data-confirmation-url=\"/exercises/#{reading.friendly_name}/confirmations\" role=\"button\" href=\"/exercises/#{exercise.friendly_name}\">Next: exercise 2 <i class=\"fa fa-chevron-right\"></i></a>" }
+        it { expect(next_button(reading)).to eq "<a class=\"btn-confirmation btn btn-success btn-block\" data-confirmation-url=\"/exercises/#{reading.friendly_name}/confirmations\" role=\"button\" href=\"/exercises/#{exercise.friendly_name}\"><span class=\"fa5-text-r\">Next: exercise 2</span><i class=\"fas fa-chevron-right\"></i></a>" }
         it { expect(next_button(exercise)).to eq nil }
       end
     end
@@ -83,12 +83,12 @@ describe WithStudentPathNavigation, organization_workspace: :test do
         let(:lessons) { [lesson_1, lesson_2, lesson_3] }
 
         context 'one suggestion' do
-          it { expect(next_button(lesson_2)).to include "<a class=\"btn btn-success btn-block\" role=\"button\" href=\"/lessons/#{lesson_3.friendly_name}\">Next: #{lesson_3.name} <i class=\"fa fa-chevron-right\"></i></a>" }
+          it { expect(next_button(lesson_2)).to include "<a class=\"btn btn-success btn-block\" role=\"button\" href=\"/lessons/#{lesson_3.friendly_name}\"><span class=\"fa5-text-r\">Next: #{lesson_3.name}</span><i class=\"fas fa-chevron-right\"></i></a>" }
           it { expect(next_button(lesson_1)).to be_html_safe }
         end
 
         context 'many suggestions' do
-          it { expect(next_button(lesson_1)).to include "<a class=\"btn btn-success btn-block\" role=\"button\" href=\"/lessons/#{lesson_2.friendly_name}\">Next: #{lesson_2.name} <i class=\"fa fa-chevron-right\"></i></a>" }
+          it { expect(next_button(lesson_1)).to include "<a class=\"btn btn-success btn-block\" role=\"button\" href=\"/lessons/#{lesson_2.friendly_name}\"><span class=\"fa5-text-r\">Next: #{lesson_2.name}</span><i class=\"fas fa-chevron-right\"></i></a>" }
           it { expect(next_button(lesson_1)).to be_html_safe }
         end
       end


### PR DESCRIPTION
## :dart: Goal

Use FontAwesome5 syntax as well as change some icons.

## :spiral_notepad: Notes

The biggest change on FA5 is that instead of having solid and outlined icons with different `fa-` prefixes (such as `fa-user` and `fa-user-o`), the style is now dictated by `fas` (s for solid), `far` (r for regular) and `fab` (b for brand). Therefore, `fas fa-user` shows a solid user icon, `far fa-user` shows the outlined style, and `fab fa-twitter` is the style for brand icons.

Minor changes in this PR include updating the names to match their new FA5 styles. For example, FA4's `fa-facebook` was moved to `fa-facebook-f` on FA5, while the new `fa-facebook` is a different icon altogether.

Every major change is up for discussion on the following comments. :+1: if they're okay.