### PR TITLE
Remove divider if no menu_bar_links present

### DIFF
--- a/app/helpers/menu_bar_helper.rb
+++ b/app/helpers/menu_bar_helper.rb
@@ -42,4 +42,8 @@ module MenuBarHelper
   def menu_item(icon, name, url)
     link_to fixed_fa_icon(icon, text: t(name)), url, role: 'menuitem', tabindex: '-1'
   end
+
+  def any_menu_bar_links?
+    menu_bar_links.any?
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,7 +38,9 @@
             </div>
             <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="profileDropdown">
               <%= menu_bar_list_items %>
-              <li class="divider"></li>
+              <% if any_menu_bar_links? %>
+                <li class="divider"></li>
+              <% end %>
               <%= logout_link %>
             </ul>
           </div>


### PR DESCRIPTION
Suggested and implemented by @felipecalvo 

Before: 
![Screenshot from 2021-01-15 12-07-24](https://user-images.githubusercontent.com/11860076/104743327-5585b100-572a-11eb-8576-199bbab35308.png)

After:
![Screenshot from 2021-01-15 12-06-29](https://user-images.githubusercontent.com/11860076/104743344-5a4a6500-572a-11eb-9c44-cce6810e264f.png)

