### PR TITLE
Chore improve terms styles

### DIFF
--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_terms.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_terms.scss
@@ -15,11 +15,15 @@
   }
   .terms-card-header {
     cursor: pointer;
+    outline: 0;
     font-weight: bold;
     padding: .75rem 1.25rem;
     margin-bottom: 0;
     background-color: rgba(0,0,0,.03);
     border-bottom: 1px solid rgba(0,0,0,.125);
+    &::-webkit-details-marker {
+      display:none;
+    }
   }
   &:first-child .terms-card-header{
     border-radius: calc(.25rem - 1px) calc(.25rem - 1px) 0 0;

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -52,6 +52,14 @@ module DiscussionsHelper
     profile_picture_for(user, class: image_class)
   end
 
+  def forum_terms_link
+    %Q{
+      <span>
+        #{ t(:forum_terms_link, terms_link: link_to_forum_terms).html_safe }
+      </span>
+    }.html_safe
+  end
+
   def discussions_link_with_teaser(item)
     %Q{
       <div>

--- a/app/views/book_discussions/index.html.erb
+++ b/app/views/book_discussions/index.html.erb
@@ -21,3 +21,5 @@
     <%= render partial: 'layouts/discussions' %>
   <% end %>
 </div>
+
+<%= forum_terms_link %>

--- a/app/views/book_discussions/index.html.erb
+++ b/app/views/book_discussions/index.html.erb
@@ -10,7 +10,7 @@
 
 <div class="row">
   <div class="mu-inline-block-left">
-    <h1><%= @debatable.name %></h1>
+    <h1><%= t :forum %></h1>
   </div>
 </div>
 

--- a/app/views/discussions/index.html.erb
+++ b/app/views/discussions/index.html.erb
@@ -3,16 +3,21 @@
 <% end %>
 
 <div class="row">
+  <div class="mu-inline-block-left">
+    <h1><%= t :forum %></h1>
+  </div>
+</div>
+<div class="row">
   <% if @debatable.respond_to? :language %>
     <div class="mu-inline-block-right hidden-xs">
-      <h1><%= language_icon @debatable.language %></h1>
+      <h3><%= language_icon @debatable.language %></h3>
     </div>
   <% end %>
   <div class="mu-inline-block-left">
-    <h1>
+    <h3>
       <span class="hidden-xs"><%= t("#{@debatable_class.downcase}_number", number: @debatable.number) %>:&nbsp;</span>
       <span><%= @debatable.name %></span>
-    </h1>
+    </h3>
   </div>
 </div>
 
@@ -23,7 +28,9 @@
   <%= new_discussion_link(:no_useful_result, :ask_a_question) %>
 <% end %>
 
-  <%= content_for :no_container do %>
+<%= content_for :no_container do %>
 <% end if current_user? %>
+
+<%= forum_terms_link %>
 
 

--- a/app/views/layouts/_discussions.html.erb
+++ b/app/views/layouts/_discussions.html.erb
@@ -84,7 +84,3 @@
 
   <% end %>
 </div>
-
-<span>
-  <%= t(:forum_terms_link, terms_link: link_to_forum_terms).html_safe %>
-</span>

--- a/app/views/users/_term.html.erb
+++ b/app/views/users/_term.html.erb
@@ -1,7 +1,7 @@
 <div class="terms-card">
   <details <%= 'open' unless collapsed %>>
     <summary class="terms-card-header">
-      <h4><%= term.header %></h4>
+      <h4 class="terms-card-title"><%= term.header %></h4>
     </summary>
     <div class="terms-card-body">
       <%= term.content_html %>

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -105,6 +105,7 @@ en:
   first_name: First Name
   forbidden_explanation: Please verify you have logged in with the right account
   format: Format
+  forum: Forum
   forum_terms: Forum rules
   forum_terms_link: If you have any questions, please check %{terms_link}
   fullscreen: "Fullscreen"

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -255,7 +255,7 @@ en:
   tell_us_how: Please tell us how this happened!
   tell_us_if_our_error: If you think this is our fault, %{issues}
   terms_accepted: The terms and conditions were accepted
-  terms_and_conditions: Terms and conditions
+  terms_and_conditions: Terms and Conditions
   terms_and_conditions_continue_disclaimer: By continuing you agree to %{terms_link}
   terms_and_conditions_must_be_accepted: You must accept the terms and conditions
   test_results: Test results

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -103,7 +103,7 @@ es-CL:
   first_name: Nombre
   forbidden_explanation: ¿Puede que hayas ingresado con una cuenta incorrecta?
   format: Dar formato
-  forum_terms_link: Si tienes alguna duda, accede a las %{terms_link}
+  forum_terms_link: No olvides que al participar debes cumplir las %{terms_link}
   fullscreen: "Pantalla completa"
   gender: Género
   get_messages: "Ver mensajes"

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -263,7 +263,7 @@ es-CL:
   teacher_info: Información para docentes
   tell_us_how: ¡Cuéntanos cómo te pasó esto!
   tell_us_if_our_error: Si piensas que es un error nuestro, %{issues}
-  terms_and_conditions: Términos y condiciones
+  terms_and_conditions: Términos y Condiciones
   terms_and_conditions_continue_disclaimer: Al continuar aceptas los %{terms_link}
   terms_and_conditions_must_be_accepted: Tienes que aceptar los términos y condiciones
   test_results: Resultados de las pruebas

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -111,6 +111,7 @@ es:
   first_name: Nombre
   forbidden_explanation: ¿Puede que hayas ingresado con una cuenta incorrecta?
   format: Dar formato
+  forum: Espacio de Consultas
   forum_terms: Reglas del Espacio de Consultas
   forum_terms_link: No olvides que al participar debés cumplir las %{terms_link}
   fullscreen: "Pantalla completa"

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -111,7 +111,7 @@ es:
   first_name: Nombre
   forbidden_explanation: ¿Puede que hayas ingresado con una cuenta incorrecta?
   format: Dar formato
-  forum_terms: Reglas del espacio de consultas
+  forum_terms: Reglas del Espacio de Consultas
   forum_terms_link: Si tenés alguna duda, accedé a las %{terms_link}
   fullscreen: "Pantalla completa"
   gender: Género
@@ -278,7 +278,7 @@ es:
   tell_us_how: ¡Contanos cómo te pasó esto!
   tell_us_if_our_error: Si pensás que es un error nuestro, %{issues}
   terms_accepted: Los términos y condiciones fueron aceptados
-  terms_and_conditions: Términos y condiciones
+  terms_and_conditions: Términos y Condiciones
   terms_and_conditions_continue_disclaimer: Al continuar estás aceptando los %{terms_link}
   terms_and_conditions_must_be_accepted: Tenés que aceptar los términos y condiciones
   test_results: Resultados de las pruebas

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -112,7 +112,7 @@ es:
   forbidden_explanation: ¿Puede que hayas ingresado con una cuenta incorrecta?
   format: Dar formato
   forum_terms: Reglas del Espacio de Consultas
-  forum_terms_link: Si tenés alguna duda, accedé a las %{terms_link}
+  forum_terms_link: No olvides que al participar debés cumplir las %{terms_link}
   fullscreen: "Pantalla completa"
   gender: Género
   get_messages: "Ver mensajes"

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -107,6 +107,7 @@ pt:
   first_name: Nome
   forbidden_explanation: Você poderia ter entrado com uma conta incorreta?
   format: Formato
+  forum: Espaço de Consulta
   forum_terms: Regras do Espaço de Consulta
   forum_terms_link: Se você tiver alguma dúvida, consulte as %{terms_link}
   fullscreen: Tela completa

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -107,7 +107,7 @@ pt:
   first_name: Nome
   forbidden_explanation: Você poderia ter entrado com uma conta incorreta?
   format: Formato
-  forum_terms: Regras do espaço de consulta
+  forum_terms: Regras do Espaço de Consulta
   forum_terms_link: Se você tiver alguma dúvida, consulte as %{terms_link}
   fullscreen: Tela completa
   gender: Gênero


### PR DESCRIPTION
This one fixes several UI related stuff of terms feature.

- Terms and Conditions and Forum Terms is capitalized consistently across the application
- Forum Terms link is relocated at the bottom at the bottom of the layout
- Summary marker is hidden in Chrome as it didn't look good
- Forum title is added in forum related views