### PR TITLE
Update social media icons

### DIFF
--- a/app/views/layouts/_social_media.html.erb
+++ b/app/views/layouts/_social_media.html.erb
@@ -1,4 +1,4 @@
-<a class="fab fa-facebook-f social-icon" aria-label="Facebook" href="https://www.facebook.com/MumukiOrg" target="_blank"></a>
+<a class="fab fa-instagram social-icon" aria-label="Instagram" href="https://www.instagram.com/mumukiorg" target="_blank"></a>
 <a class="fab fa-twitter social-icon" aria-label="Twitter" href="https://twitter.com/MumukiOrg" target="_blank"></a>
+<a class="fab fa-youtube social-icon" aria-label="Youtube" href="https://www.youtube.com/c/MumukiOrg" target="_blank"></a>
 <a class="fab fa-github social-icon" aria-label="Github" href="https://github.com/mumuki" target="_blank"></a>
-<a class="fab fa-linkedin-in social-icon" aria-label="LinkedIn" href="https://www.linkedin.com/company/mumukiorg" target="_blank"></a>


### PR DESCRIPTION
We are removing facebook and linkedin and adding youtube and instagram.

The decision was taken mainly by @lauramangifesta who considers that this social media are the most used ones and are the ones who makes more sense for the audience that access the platform