### PR TITLE
Fix editor buttons overlap

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/codemirror.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/codemirror.js
@@ -62,7 +62,7 @@ mumuki.page.editors = [];
 
   function setEditorLanguage(editor, language) {
     editor.setOption("mode", language);
-    editor.setOption('theme', 'default ' + language);
+    editor.setOption('theme', 'mu-light ' + language);
   }
 
   function syncContent(){

--- a/app/assets/stylesheets/mumuki_laboratory/application.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application.scss
@@ -15,3 +15,4 @@ $da-font-path: asset-path('assets');
 @import "application/modules";
 @import "application/errors";
 @import "application/alerts";
+@import "application/codemirror-themes";

--- a/app/assets/stylesheets/mumuki_laboratory/application/_codemirror-themes.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/_codemirror-themes.scss
@@ -1,0 +1,1 @@
+@import "codemirror-themes/mu-light";

--- a/app/assets/stylesheets/mumuki_laboratory/application/codemirror-themes/_mu-light.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/codemirror-themes/_mu-light.scss
@@ -1,0 +1,3 @@
+.cm-s-mu-light .CodeMirror-code {
+  padding-right: 25px;
+}


### PR DESCRIPTION
## :dart: Goal

Avoid text overlapping with buttons in the code editor.

### Before

![image](https://user-images.githubusercontent.com/11304439/105733427-4fed4f80-5f10-11eb-9687-4080febc58b8.png)

### After
![image](https://user-images.githubusercontent.com/11304439/105745929-91d0c280-5f1d-11eb-83ee-3eb29b756c52.png)

## :spiral_notepad: Notes

While CodeMirrors supports custom themes ([see examples](https://codemirror.net/demo/theme.html#default)) we've been using the default theme all along. The new `mu-light` theme sets only one property - some padding to the text so our icons don't overlap - and falls back to the default theme for everything else. 

The name `mu-light` is chosen in hopes we can write our own `mu-dark` in the not so distant future :smile: 

Closes #827.