### PR TITLE
Fix restart guide link tooltip

### DIFF
--- a/app/helpers/overlapped_buttons_helper.rb
+++ b/app/helpers/overlapped_buttons_helper.rb
@@ -3,8 +3,8 @@ module OverlappedButtonsHelper
     overlapped_button_icon :fullscreen, :expand
   end
 
-  def restart_icon
-    overlapped_button_icon :restart, :undo
+  def restart_icon(data_placement='left')
+    overlapped_button_icon :restart, :undo, data_placement
   end
 
   def format_icon
@@ -12,10 +12,14 @@ module OverlappedButtonsHelper
   end
 
   def restart_guide_link(guide)
-    link_to restart_icon, guide_progress_path(guide), class: 'mu-content-toolbar-item mu-restart-guide', data: {confirm: t(:confirm_restart)}, method: :delete
+    link_to restart_icon('top'),
+            guide_progress_path(guide),
+            class: 'mu-content-toolbar-item mu-restart-guide',
+            data: {confirm: t(:confirm_restart)},
+            method: :delete
   end
 
-  def overlapped_button_icon(key, icon)
-    fa_icon(icon, title: t(key), class: 'fa-fw', role: 'button', 'aria-label': t(key), 'data-placement': 'left')
+  def overlapped_button_icon(key, icon, data_placement='left')
+    fa_icon(icon, title: t(key), class: 'fa-fw', role: 'button', 'aria-label': t(key), 'data-placement': data_placement)
   end
 end

--- a/app/helpers/overlapped_buttons_helper.rb
+++ b/app/helpers/overlapped_buttons_helper.rb
@@ -1,6 +1,6 @@
 module OverlappedButtonsHelper
   def expand_icon
-    overlapped_button_icon :fullscreen, :expand, " (F11)"
+    overlapped_button_icon :fullscreen, :expand
   end
 
   def restart_icon
@@ -15,7 +15,7 @@ module OverlappedButtonsHelper
     link_to restart_icon, guide_progress_path(guide), class: 'mu-content-toolbar-item mu-restart-guide', data: {confirm: t(:confirm_restart)}, method: :delete
   end
 
-  def overlapped_button_icon(key, icon, extra_title='')
-    fa_icon(icon, title: t(key) + extra_title, class: 'fa-fw', role: 'button', 'aria-label': t(key), 'data-placement': 'left')
+  def overlapped_button_icon(key, icon)
+    fa_icon(icon, title: t(key), class: 'fa-fw', role: 'button', 'aria-label': t(key), 'data-placement': 'left')
   end
 end

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -108,7 +108,7 @@ en:
   forum: Forum
   forum_terms: Forum rules
   forum_terms_link: If you have any questions, please check %{terms_link}
-  fullscreen: "Fullscreen"
+  fullscreen: "Fullscreen (F11)"
   gender: Gender
   get_messages: "View messages"
   go_to: 'Go to %{organization}'

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -104,7 +104,7 @@ es-CL:
   forbidden_explanation: ¿Puede que hayas ingresado con una cuenta incorrecta?
   format: Dar formato
   forum_terms_link: No olvides que al participar debes cumplir las %{terms_link}
-  fullscreen: "Pantalla completa"
+  fullscreen: "Pantalla completa (F11)"
   gender: Género
   get_messages: "Ver mensajes"
   go_to: 'Ir a %{organization}'

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -114,7 +114,7 @@ es:
   forum: Espacio de Consultas
   forum_terms: Reglas del Espacio de Consultas
   forum_terms_link: No olvides que al participar debés cumplir las %{terms_link}
-  fullscreen: "Pantalla completa"
+  fullscreen: "Pantalla completa (F11)"
   gender: Género
   get_messages: "Ver mensajes"
   go_to: 'Ir a %{organization}'

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -110,7 +110,7 @@ pt:
   forum: Espaço de Consulta
   forum_terms: Regras do Espaço de Consulta
   forum_terms_link: Se você tiver alguma dúvida, consulte as %{terms_link}
-  fullscreen: Tela completa
+  fullscreen: Tela cheia (F11)
   gender: Gênero
   get_messages: Ver mensagens
   go_to: Vá para %{organization}


### PR DESCRIPTION
## :dart: Goal

Fix tooltip facing the wrong direction on guide restart button.

### Before
![image](https://user-images.githubusercontent.com/11304439/105777487-39afb580-5f49-11eb-94de-18e30a7384cb.png)

### After
![image](https://user-images.githubusercontent.com/11304439/105777522-48966800-5f49-11eb-8c8e-aac7704af608.png)

This was an oversight from this commit https://github.com/mumuki/mumuki-laboratory/commit/e69f5b0566155fd6d1ab2cf7c09131c6ba1c1773 from a couple of weeks ago.