### PR TITLE
Fix upload exercises

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/upload.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/upload.js
@@ -1,44 +1,56 @@
-mumuki.load(() => {
-  let $uploadInput = $('#mu-upload-input');
-  let maxFileSize = $uploadInput.attr("mu-upload-file-limit");
-  let $uploadFileLimitExceeded = $('#mu-upload-file-limit-exceeded');
-  let $uploadLabel = $('#mu-upload-label span');
-  let $uploadLabelText = $uploadLabel.text();
-  let $uploadIcon = $('#mu-upload-icon');
-  let $btnSubmit = $('.btn-submit');
+mumuki.upload = (() => {
+  class FileUploader {
+    constructor(file) {
+      this.file = file;
 
-  $uploadInput.change(function (evt) {
-    var file = evt.target.files[0];
-    if (!file) return;
-
-    if (file.size > maxFileSize) {
-      showFileExceedsMaxSize();
-      return;
+      this.$uploadFileLimitExceeded = $('#mu-upload-file-limit-exceeded');
+      this.$uploadLabel = $('#mu-upload-label span');
+      this.$uploadLabelText = this.$uploadLabel.text();
+      this.$uploadIcon = $('#mu-upload-icon');
+      this.$btnSubmit = $('.btn-submit');
     }
 
-    allowSubmissionFor(file.name);
+    uploadFileIfValid() {
+      if (!this.file) return;
 
-    var reader = new FileReader();
-    reader.onload = function (e) {
-      var contents = e.target.result;
-      $('#solution_content').html(contents);
-      $(evt.target).val("");
-    };
-    reader.readAsText(file);
+      let maxFileSize = $('#mu-upload-input').attr("mu-upload-file-limit");
+      if (this.file.size > maxFileSize) {
+        return this.showFileExceedsMaxSize();
+      }
+
+      this.allowSubmissionFor(this.file.name);
+
+      var reader = new FileReader();
+      reader.onload = function (e) {
+        var contents = e.target.result;
+        $('#solution_content').html(contents);
+      };
+      reader.readAsText(this.file);
+    }
+
+    showFileExceedsMaxSize() {
+      this.$uploadFileLimitExceeded.removeClass('hidden');
+      this.$uploadLabel.text(this.$uploadLabelText);
+      this.$uploadIcon.addClass('fa-upload').removeClass('fa-file-alt');
+      this.$btnSubmit.addClass('disabled');
+    }
+
+    allowSubmissionFor(filename) {
+      this.$uploadFileLimitExceeded.addClass('hidden');
+      this.$uploadLabel.text(filename);
+      this.$uploadIcon.removeClass('fa-upload').addClass('fa-file-alt');
+      this.$btnSubmit.removeClass('disabled');
+    }
+  }
+
+  return {
+    FileUploader
+  };
+})();
+
+mumuki.load(() => {
+  $('#mu-upload-input').change(function (evt) {
+    return new mumuki.upload.FileUploader(evt.target.files[0]).uploadFileIfValid();
   });
-
-  function showFileExceedsMaxSize() {
-    $uploadFileLimitExceeded.removeClass('hidden');
-    $uploadLabel.text($uploadLabelText);
-    $uploadIcon.addClass('fa-upload').removeClass('fa-file-alt');
-    $btnSubmit.addClass('disabled');
-  }
-
-  function allowSubmissionFor(filename) {
-    $uploadFileLimitExceeded.addClass('hidden');
-    $uploadLabel.text(filename);
-    $uploadIcon.removeClass('fa-upload').addClass('fa-file-alt');
-    $btnSubmit.removeClass('disabled');
-  }
 });
 

--- a/app/assets/javascripts/mumuki_laboratory/application/upload.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/upload.js
@@ -4,6 +4,8 @@ mumuki.load(() => {
     if (!file) return;
 
     $('.btn-submit').removeClass('disabled');
+    $('#mu-upload-text').removeClass('fa-upload').addClass('fa-file-alt');
+    $('#mu-upload-label span').text(file.name);
 
     var reader = new FileReader();
     reader.onload = function (e) {

--- a/app/assets/javascripts/mumuki_laboratory/application/upload.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/upload.js
@@ -12,17 +12,11 @@ mumuki.load(() => {
     if (!file) return;
 
     if (file.size > maxFileSize) {
-      $uploadFileLimitExceeded.removeClass('hidden');
-      $uploadLabel.text($uploadLabelText);
-      $uploadIcon.addClass('fa-upload').removeClass('fa-file-alt');
-      $btnSubmit.addClass('disabled');
+      showFileExceedsMaxSize();
       return;
     }
 
-    $uploadFileLimitExceeded.addClass('hidden');
-    $uploadLabel.text(file.name);
-    $uploadIcon.removeClass('fa-upload').addClass('fa-file-alt');
-    $btnSubmit.removeClass('disabled');
+    allowSubmissionFor(file.name);
 
     var reader = new FileReader();
     reader.onload = function (e) {
@@ -32,5 +26,19 @@ mumuki.load(() => {
     };
     reader.readAsText(file);
   });
+
+  function showFileExceedsMaxSize() {
+    $uploadFileLimitExceeded.removeClass('hidden');
+    $uploadLabel.text($uploadLabelText);
+    $uploadIcon.addClass('fa-upload').removeClass('fa-file-alt');
+    $btnSubmit.addClass('disabled');
+  }
+
+  function allowSubmissionFor(filename) {
+    $uploadFileLimitExceeded.addClass('hidden');
+    $uploadLabel.text(filename);
+    $uploadIcon.removeClass('fa-upload').addClass('fa-file-alt');
+    $btnSubmit.removeClass('disabled');
+  }
 });
 

--- a/app/assets/javascripts/mumuki_laboratory/application/upload.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/upload.js
@@ -14,12 +14,14 @@ mumuki.upload = (() => {
 
       mumuki.upload.ui.allowSubmissionFor(this.file.name);
 
-      var reader = new FileReader();
+      const reader = new FileReader();
       reader.onload = function (e) {
-        var contents = e.target.result;
+        const contents = e.target.result;
         $('#solution_content').html(contents);
       };
       reader.readAsText(this.file);
+
+      return reader;
     }
   }
 

--- a/app/assets/javascripts/mumuki_laboratory/application/upload.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/upload.js
@@ -8,10 +8,8 @@ mumuki.load(() => {
       var contents = e.target.result;
       $('#solution_content').html(contents);
       $(evt.target).val("");
-      $('form.new_solution').submit();
     };
     reader.readAsText(file);
-    return false;
   });
 });
 

--- a/app/assets/javascripts/mumuki_laboratory/application/upload.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/upload.js
@@ -3,6 +3,8 @@ mumuki.load(() => {
     var file = evt.target.files[0];
     if (!file) return;
 
+    $('.btn-submit').removeClass('disabled');
+
     var reader = new FileReader();
     reader.onload = function (e) {
       var contents = e.target.result;

--- a/app/assets/javascripts/mumuki_laboratory/application/upload.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/upload.js
@@ -1,5 +1,5 @@
 mumuki.load(() => {
-  let $uploadInput = $('#upload-input');
+  let $uploadInput = $('#mu-upload-input');
   let maxFileSize = $uploadInput.attr("mu-upload-file-limit");
   let $uploadFileLimitExceeded = $('#mu-upload-file-limit-exceeded');
   let $uploadLabel = $('#mu-upload-label span');

--- a/app/assets/javascripts/mumuki_laboratory/application/upload.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/upload.js
@@ -2,12 +2,6 @@ mumuki.upload = (() => {
   class FileUploader {
     constructor(file) {
       this.file = file;
-
-      this.$uploadFileLimitExceeded = $('#mu-upload-file-limit-exceeded');
-      this.$uploadLabel = $('#mu-upload-label span');
-      this.$uploadLabelText = this.$uploadLabel.text();
-      this.$uploadIcon = $('#mu-upload-icon');
-      this.$btnSubmit = $('.btn-submit');
     }
 
     uploadFileIfValid() {
@@ -15,10 +9,10 @@ mumuki.upload = (() => {
 
       let maxFileSize = $('#mu-upload-input').attr("mu-upload-file-limit");
       if (this.file.size > maxFileSize) {
-        return this.showFileExceedsMaxSize();
+        return mumuki.upload.ui.showFileExceedsMaxSize();
       }
 
-      this.allowSubmissionFor(this.file.name);
+      mumuki.upload.ui.allowSubmissionFor(this.file.name);
 
       var reader = new FileReader();
       reader.onload = function (e) {
@@ -26,6 +20,16 @@ mumuki.upload = (() => {
         $('#solution_content').html(contents);
       };
       reader.readAsText(this.file);
+    }
+  }
+
+  class UI {
+    constructor() {
+      this.$uploadFileLimitExceeded = $('#mu-upload-file-limit-exceeded');
+      this.$uploadLabel = $('#mu-upload-label span');
+      this.$uploadLabelText = this.$uploadLabel.text();
+      this.$uploadIcon = $('#mu-upload-icon');
+      this.$btnSubmit = $('.btn-submit');
     }
 
     showFileExceedsMaxSize() {
@@ -43,14 +47,24 @@ mumuki.upload = (() => {
     }
   }
 
+  function _setUI() {
+    mumuki.upload.ui = new UI();
+  }
+
   return {
-    FileUploader
+    FileUploader,
+    UI,
+
+    _setUI,
+
+    /** @type {UI} */
+    ui: null
   };
 })();
 
 mumuki.load(() => {
   $('#mu-upload-input').change(function (evt) {
+    if (!mumuki.upload.ui) mumuki.upload._setUI();
     return new mumuki.upload.FileUploader(evt.target.files[0]).uploadFileIfValid();
   });
 });
-

--- a/app/assets/javascripts/mumuki_laboratory/application/upload.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/upload.js
@@ -1,11 +1,28 @@
 mumuki.load(() => {
-  $('#upload-input').change(function (evt) {
+  let $uploadInput = $('#upload-input');
+  let maxFileSize = $uploadInput.attr("mu-upload-file-limit");
+  let $uploadFileLimitExceeded = $('#mu-upload-file-limit-exceeded');
+  let $uploadLabel = $('#mu-upload-label span');
+  let $uploadLabelText = $uploadLabel.text();
+  let $uploadIcon = $('#mu-upload-icon');
+  let $btnSubmit = $('.btn-submit');
+
+  $uploadInput.change(function (evt) {
     var file = evt.target.files[0];
     if (!file) return;
 
-    $('.btn-submit').removeClass('disabled');
-    $('#mu-upload-text').removeClass('fa-upload').addClass('fa-file-alt');
-    $('#mu-upload-label span').text(file.name);
+    if (file.size > maxFileSize) {
+      $uploadFileLimitExceeded.removeClass('hidden');
+      $uploadLabel.text($uploadLabelText);
+      $uploadIcon.addClass('fa-upload').removeClass('fa-file-alt');
+      $btnSubmit.addClass('disabled');
+      return;
+    }
+
+    $uploadFileLimitExceeded.addClass('hidden');
+    $uploadLabel.text(file.name);
+    $uploadIcon.removeClass('fa-upload').addClass('fa-file-alt');
+    $btnSubmit.removeClass('disabled');
 
     var reader = new FileReader();
     reader.onload = function (e) {

--- a/app/helpers/exercise_input_helper.rb
+++ b/app/helpers/exercise_input_helper.rb
@@ -53,12 +53,11 @@ module ExerciseInputHelper
     waiting_text = t(options.waiting_t) if options.waiting_t.present?
     %Q{
       <div class="btn-submit-container">
-        <#{options.tag} for="#{options.for}"
-                       class="btn btn-success btn-block btn-submit #{options.classes}"
+        <button class="btn btn-success btn-block btn-submit #{options.classes}"
                        data-waiting="#{waiting_text}">
-          #{fa_icon options.fa_icon}
+          #{fa_icon 'play'}
           #{text} #{remaining_attempts_text(assignment)}
-       </#{options.tag}>
+       </button>
       </div>
     }.html_safe
   end
@@ -92,26 +91,18 @@ module ExerciseInputHelper
 
   def submit_button_options(exercise)
     if exercise.upload?
-      struct tag: :button,
-             classes: 'disabled',
-             fa_icon: :play,
+      struct classes: 'disabled',
              waiting_t: :uploading_solution,
              t: :create_submission
     elsif exercise.hidden?
-      struct tag: :button,
-             classes: 'submission_control',
+      struct classes: 'submission_control',
              waiting_t: :working,
-             fa_icon: :play,
              t: :continue_exercise
     elsif exercise.input_kids?
-      struct tag: :button,
-             classes: 'submission_control',
-             fa_icon: :play
+      struct classes: 'submission_control'
     else
-      struct tag: :button,
-             classes: 'submission_control',
+      struct classes: 'submission_control',
              waiting_t: :sending_solution,
-             fa_icon: :play,
              t: :create_submission
     end
   end

--- a/app/helpers/exercise_input_helper.rb
+++ b/app/helpers/exercise_input_helper.rb
@@ -93,6 +93,7 @@ module ExerciseInputHelper
   def submit_button_options(exercise)
     if exercise.upload?
       struct tag: :button,
+             classes: 'disabled',
              fa_icon: :play,
              waiting_t: :uploading_solution,
              t: :create_submission

--- a/app/helpers/exercise_input_helper.rb
+++ b/app/helpers/exercise_input_helper.rb
@@ -92,11 +92,10 @@ module ExerciseInputHelper
 
   def submit_button_options(exercise)
     if exercise.upload?
-      struct for: 'upload-input',
-             tag: :label,
+      struct tag: :button,
+             fa_icon: :play,
              waiting_t: :uploading_solution,
-             fa_icon: :upload,
-             t: :upload_solution
+             t: :create_submission
     elsif exercise.hidden?
       struct tag: :button,
              classes: 'submission_control',

--- a/app/views/layouts/exercise_inputs/editors/_upload.html.erb
+++ b/app/views/layouts/exercise_inputs/editors/_upload.html.erb
@@ -1,7 +1,13 @@
 <div class="form-group">
-  <textarea id="solution_content" type="text" name="solution[content]" style="display: none"></textarea>
-  <input id="upload-input" type="file" class="upload submission-control" accept=".<%= @exercise.language.extension %>" />
-  <label id="mu-upload-label" for="upload-input" class="btn btn-success">
-    <%= fa_icon(:upload, text: t(:select_file), id: "mu-upload-text") %>
-  </label>
+  <% @max_file_size = 256000 %>
+
+  <textarea id="solution_content" type="text" name="solution[content]" class="hidden"></textarea>
+  <input id="upload-input" type="file" class="upload submission-control hidden" mu-upload-file-limit=<%= @max_file_size %> accept=".<%= @exercise.language.extension %>" />
+  <div>
+    <label id="mu-upload-label" for="upload-input" class="btn btn-success">
+      <%= fa_icon(:upload, text: t(:select_file), id: "mu-upload-text") %>
+    </label>
+    <div id="mu-upload-file-limit-exceeded" class="hidden">
+      <%= fa_icon("exclamation-triangle", text: t(:file_exceeds_max_size, size_kb: (@max_file_size / 1000))) %></div>
+  </div>
 </div>

--- a/app/views/layouts/exercise_inputs/editors/_upload.html.erb
+++ b/app/views/layouts/exercise_inputs/editors/_upload.html.erb
@@ -1,4 +1,7 @@
 <div class="form-group">
   <textarea id="solution_content" type="text" name="solution[content]" style="display: none"></textarea>
   <input id="upload-input" type="file" class="upload submission-control" size="5120" accept=".<%= @exercise.language.extension %>" />
+  <label id="mu-upload-label" for="upload-input" class="btn btn-success">
+    <%= fa_icon(:upload, text: t(:upload_solution), id: "mu-upload-text") %>
+  </label>
 </div>

--- a/app/views/layouts/exercise_inputs/editors/_upload.html.erb
+++ b/app/views/layouts/exercise_inputs/editors/_upload.html.erb
@@ -1,6 +1,6 @@
 <div class="form-group">
   <textarea id="solution_content" type="text" name="solution[content]" style="display: none"></textarea>
-  <input id="upload-input" type="file" class="upload submission-control" size="5120" accept=".<%= @exercise.language.extension %>" />
+  <input id="upload-input" type="file" class="upload submission-control" accept=".<%= @exercise.language.extension %>" />
   <label id="mu-upload-label" for="upload-input" class="btn btn-success">
     <%= fa_icon(:upload, text: t(:upload_solution), id: "mu-upload-text") %>
   </label>

--- a/app/views/layouts/exercise_inputs/editors/_upload.html.erb
+++ b/app/views/layouts/exercise_inputs/editors/_upload.html.erb
@@ -2,6 +2,6 @@
   <textarea id="solution_content" type="text" name="solution[content]" style="display: none"></textarea>
   <input id="upload-input" type="file" class="upload submission-control" accept=".<%= @exercise.language.extension %>" />
   <label id="mu-upload-label" for="upload-input" class="btn btn-success">
-    <%= fa_icon(:upload, text: t(:upload_solution), id: "mu-upload-text") %>
+    <%= fa_icon(:upload, text: t(:select_file), id: "mu-upload-text") %>
   </label>
 </div>

--- a/app/views/layouts/exercise_inputs/editors/_upload.html.erb
+++ b/app/views/layouts/exercise_inputs/editors/_upload.html.erb
@@ -5,7 +5,7 @@
   <input id="upload-input" type="file" class="upload submission-control hidden" mu-upload-file-limit=<%= @max_file_size %> accept=".<%= @exercise.language.extension %>" />
   <div>
     <label id="mu-upload-label" for="upload-input" class="btn btn-success">
-      <%= fa_icon(:upload, text: t(:select_file), id: "mu-upload-text") %>
+      <%= fa_icon(:upload, text: t(:select_file), id: "mu-upload-icon") %>
     </label>
     <div id="mu-upload-file-limit-exceeded" class="hidden">
       <%= fa_icon("exclamation-triangle", text: t(:file_exceeds_max_size, size_kb: (@max_file_size / 1000))) %></div>

--- a/app/views/layouts/exercise_inputs/editors/_upload.html.erb
+++ b/app/views/layouts/exercise_inputs/editors/_upload.html.erb
@@ -2,9 +2,9 @@
   <% @max_file_size = 256000 %>
 
   <textarea id="solution_content" type="text" name="solution[content]" class="hidden"></textarea>
-  <input id="upload-input" type="file" class="upload submission-control hidden" mu-upload-file-limit=<%= @max_file_size %> accept=".<%= @exercise.language.extension %>" />
+  <input id="mu-upload-input" type="file" class="upload submission-control hidden" mu-upload-file-limit=<%= @max_file_size %> accept=".<%= @exercise.language.extension %>" />
   <div>
-    <label id="mu-upload-label" for="upload-input" class="btn btn-success">
+    <label id="mu-upload-label" for="mu-upload-input" class="btn btn-success">
       <%= fa_icon(:upload, text: t(:select_file), id: "mu-upload-icon") %>
     </label>
     <div id="mu-upload-file-limit-exceeded" class="hidden">

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -111,6 +111,7 @@ en:
   failed: Oops, something went wrong
   feedback: Feedback
   female: Female
+  file_exceeds_max_size: "File size should not exceed %{size_kb}kb. Please select another file."
   finish: Finish
   first_name: First Name
   forbidden_explanation: Please verify you have logged in with the right account

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -233,6 +233,7 @@ en:
   running: running
   save: Save
   see_context: Watch exercise introduction animation
+  select_file: Select file
   sending_solution: Sending solution
   show: Show
   sign_in: Sign in
@@ -289,7 +290,6 @@ en:
   unprepared_organization_explanation: This path hasn't started yet.
   unsubscribe: Unsubscribe
   unsubscribed_successfully: You have successfully unsubscribed from reminders.
-  upload_solution: Upload Solution
   uploading_solution: "Uploading solution"
   upvote: Upvote
   upvotes_count_desc: Most voted

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -236,6 +236,7 @@ es-CL:
   running: procesando
   save: Guardar
   see_context: Mira la animación del principio
+  select_file: Seleccionar archivo
   send: Enviar
   sending_solution: Enviando solución
   show: Mostrar
@@ -297,7 +298,6 @@ es-CL:
   unprepared_organization_explanation: ¡Este recorrido aún no ha comenzado!
   unsubscribe: Dejar de recibir notificaciones
   unsubscribed_successfully: Te desuscribiste exitosamente de los recordatorios.
-  upload_solution: "Subir solución"
   uploading_solution: "Subiendo solución"
   upvote: Es útil
   upvotes_count_desc: Más útiles

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -109,6 +109,7 @@ es-CL:
   failed: Tu solución no pasó las pruebas
   feedback: Problemas que encontramos
   female: Mujer
+  file_exceeds_max_size: "El tamaño de archivo no debe exceder %{size_kb}kb. Por favor selecciona otro archivo."
   finish: Terminar
   first_name: Nombre
   forbidden_explanation: ¿Puede que hayas ingresado con una cuenta incorrecta?

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -117,6 +117,7 @@ es:
   failed: Tu solución no pasó las pruebas
   feedback: Problemas que encontramos
   female: Mujer
+  file_exceeds_max_size: "El tamaño de archivo no debe exceder %{size_kb}kb. Por favor seleccioná otro archivo."
   finish: Terminar
   first_name: Nombre
   forbidden_explanation: ¿Puede que hayas ingresado con una cuenta incorrecta?

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -251,6 +251,7 @@ es:
   running: procesando
   save: Guardar
   see_context: Mirá la animación del principio
+  select_file: Seleccionar archivo
   send: Enviar
   sending_solution: Enviando solución
   show: Mostrar
@@ -313,7 +314,6 @@ es:
   unprepared_organization_explanation: Este recorrido aún no ha comenzado
   unsubscribe: Dejar de recibir notificaciones
   unsubscribed_successfully: Te desuscribiste exitosamente de los recordatorios.
-  upload_solution: "Subir solución"
   uploading_solution: "Subiendo solución"
   upvote: Es útil
   upvotes_count_desc: Más útiles

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -240,6 +240,7 @@ pt:
   running: processamento
   save: Salvar
   see_context: Veja a animação desde o início
+  select_file: Selecione o arquivo
   send: Enviar
   sending_solution: Solução de envio
   show: Mostrar
@@ -296,7 +297,6 @@ pt:
   unmeet_expectations: Objetivos que não foram atendidos
   unprepared_organization_explanation: Este curso ainda não começou
   unsubscribe: Cancelar subscrição
-  upload_solution: Carregar solução
   uploading_solution: Uploading solution
   user: Usuário
   user_data_updated: Os seus dados foram atualizados corretamente

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -113,6 +113,7 @@ pt:
   failed: Sua solução não passou as provas
   feedback: Problemas que encontramos
   female: Feminino
+  file_exceeds_max_size: "O tamanho do arquivo não deve exceder %{size_kb}kb. Selecione outro arquivo."
   finish: Terminar
   first_name: Nome
   forbidden_explanation: Você poderia ter entrado com uma conta incorreta?

--- a/spec/javascripts/upload-spec.js
+++ b/spec/javascripts/upload-spec.js
@@ -9,10 +9,28 @@ describe('upload', () => {
     <div id="mu-upload-file-limit-exceeded" class="hidden"></div>
   `);
 
+  beforeEach(() => {
+    mumuki.upload._setUI();
+  });
+
+  function reader(file, done) {
+    let fileReader = new mumuki.upload.FileUploader(file).uploadFileIfValid();
+    if (fileReader) {
+      fileReader.addEventListener('load', () => done());
+      fileReader.addEventListener('error', done);
+      return fileReader;
+    } else {
+      done();
+    }
+  }
+
   describe('no file is uploaded', () => {
-    beforeEach(() => {
-      mumuki.upload._setUI();
-      new mumuki.upload.FileUploader(null).uploadFileIfValid();
+    beforeEach((done) => {
+      reader(null, done);
+    });
+
+    it('loads no solution', function () {
+      expect($('#solution_content').html()).toEqual('');
     });
 
     it('does not allow submitting', function () {
@@ -25,9 +43,12 @@ describe('upload', () => {
   });
 
   describe('small file is uploaded', () => {
-    beforeEach(() => {
-      mumuki.upload._setUI();
-      new mumuki.upload.FileUploader(new File(["short solution"], "short.txt")).uploadFileIfValid();
+    beforeEach((done) => {
+      reader(new File(["short solution"], "short.txt"), done);
+    });
+
+    it('loads solution', function () {
+      expect($('#solution_content').html()).toEqual('short solution');
     });
 
     it('allows submitting', function () {
@@ -37,12 +58,15 @@ describe('upload', () => {
     it('does not exceed max file size', function () {
       expect($('#mu-upload-file-limit-exceeded').hasClass('hidden')).toBe(true);
     });
-   });
+  });
 
   describe('large file is uploaded', () => {
-    beforeEach(() => {
-      mumuki.upload._setUI();
-      new mumuki.upload.FileUploader(new File(["solution that is too long to be allowed"], "long.txt")).uploadFileIfValid();
+    beforeEach((done) => {
+      reader(new File(["solution that is too long to be allowed"], "long.txt"), done);
+    });
+
+    it('loads no solution', function () {
+      expect($('#solution_content').html()).toEqual('');
     });
 
     it('does not allow submitting', function () {

--- a/spec/javascripts/upload-spec.js
+++ b/spec/javascripts/upload-spec.js
@@ -1,0 +1,56 @@
+describe('upload', () => {
+  const fileSizeLimit = 20;
+
+  fixture.set(`
+    <textarea id="solution_content" type="text" name="solution[content]" class="hidden"></textarea>
+    <input id="mu-upload-input" type="file" class="upload submission-control hidden" mu-upload-file-limit=${fileSizeLimit} accept=".txt" />
+    <label id="mu-upload-label" for="mu-upload-input" class="btn btn-success"></label>
+    <button class="btn btn-success btn-block btn-submit disabled"></button>
+    <div id="mu-upload-file-limit-exceeded" class="hidden"></div>
+  `);
+
+  describe('no file is uploaded', () => {
+    beforeEach(() => {
+      mumuki.upload._setUI();
+      new mumuki.upload.FileUploader(null).uploadFileIfValid();
+    });
+
+    it('does not allow submitting', function () {
+      expect($('.btn-submit').hasClass('disabled')).toBe(true);
+    });
+
+    it('does not exceed max file size', function () {
+      expect($('#mu-upload-file-limit-exceeded').hasClass('hidden')).toBe(true);
+    });
+  });
+
+  describe('small file is uploaded', () => {
+    beforeEach(() => {
+      mumuki.upload._setUI();
+      new mumuki.upload.FileUploader(new File(["short solution"], "short.txt")).uploadFileIfValid();
+    });
+
+    it('allows submitting', function () {
+      expect($('.btn-submit').hasClass('disabled')).toBe(false);
+    });
+
+    it('does not exceed max file size', function () {
+      expect($('#mu-upload-file-limit-exceeded').hasClass('hidden')).toBe(true);
+    });
+   });
+
+  describe('large file is uploaded', () => {
+    beforeEach(() => {
+      mumuki.upload._setUI();
+      new mumuki.upload.FileUploader(new File(["solution that is too long to be allowed"], "long.txt")).uploadFileIfValid();
+    });
+
+    it('does not allow submitting', function () {
+      expect($('.btn-submit').hasClass('disabled')).toBe(true);
+    });
+
+    it('exceeds max file size', function () {
+      expect($('#mu-upload-file-limit-exceeded').hasClass('hidden')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## :dart: Goal

Fix upload-type exercises, which currently do not work (an empty solution is sent instantaneously, without prompting the file selector).

## :spiral_notepad: Notes

This probably broke on the recent `submission.js` rewrites; clicking on the submit button overrides the original event (which should prompt the file selector) in favor of sending and processing a solution which, in the case of upload-type exercises, doesn't exist yet.

Instead of writing a custom editor, button or solution processor, I divided the upload process in two parts: select file first and then send the solution. I didn't come up with the prettiest of solutions from a UI standpoint, but I'm hoping the flow of action is not confusing (from a UX standpoint? :smile:)

____

The send solution button is disabled until a file is chosen.

![image](https://user-images.githubusercontent.com/11304439/106051283-05fa9a00-60c7-11eb-8376-2d91626f32aa.png)

____

It's enabled when chosen. See now the filename is shown instead of the `:select_file` message.

![image](https://user-images.githubusercontent.com/11304439/106051157-d6e42880-60c6-11eb-92ed-27641e0cb3dc.png)

____

After sending the solution, the rest is the same as it was.

![image](https://user-images.githubusercontent.com/11304439/106051734-9b962980-60c7-11eb-86dc-597968df92be.png)


## :warning: Related issue

* https://github.com/mumuki/mumuki-laboratory/issues/1557 ResultsBox doesn't finishing processing if file uploaded is ~3MB or bigger
