### PR TITLE
Feature add user menu

### DIFF
--- a/app/assets/stylesheets/mumuki_laboratory/application/_modules.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/_modules.scss
@@ -27,4 +27,5 @@
 @import "modules/terms";
 @import "modules/timer";
 @import "modules/upload";
+@import "modules/user_menu";
 @import "modules/user_profile";

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_menu.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_menu.scss
@@ -15,6 +15,9 @@
 
   a {
     color: $brand-primary;
+    &.active {
+      font-weight: bold;
+    }
   }
 }
 

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_menu.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_menu.scss
@@ -1,17 +1,12 @@
 .mu-user-menu {
   display: flex;
-  justify-content: space-around;
-}
-
-.mu-user-menu-section {
-  margin-bottom: 30px;
 }
 
 .mu-user-menu-header {
   font-size: 15px;
   color: $mu-color-disabled;
   text-transform: uppercase;
-  margin-bottom: 5px;
+  margin-bottom: 30px;
 }
 
 .mu-user-menu-item {
@@ -24,13 +19,14 @@
 }
 
 .mu-user-menu-divider {
-  display: inline-block;
-
   &.vertical {
-    border-left: 3px solid $mu-color-separator;
+    border-left: 2px solid $mu-color-separator;
   }
 
   &.horizontal {
-    border-top: 3px solid $mu-color-separator;
+    border-top: 2px solid $mu-color-separator;
+
+    margin: 25px 0;
+    width: 100%
   }
 }

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_menu.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_menu.scss
@@ -17,6 +17,10 @@
 .mu-user-menu-item {
   font-size: 17px;
   margin-bottom: 5px;
+
+  a {
+    color: $brand-primary;
+  }
 }
 
 .mu-user-menu-vertical-divider {

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_menu.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_menu.scss
@@ -1,0 +1,25 @@
+.mu-user-menu {
+  display: flex;
+  justify-content: space-around;
+}
+
+.mu-user-menu-section {
+  margin-bottom: 30px;
+}
+
+.mu-user-menu-header {
+  font-size: 15px;
+  color: $mu-color-disabled;
+  text-transform: uppercase;
+  margin-bottom: 5px;
+}
+
+.mu-user-menu-item {
+  font-size: 17px;
+  margin-bottom: 5px;
+}
+
+.mu-user-menu-vertical-divider {
+  border-left: 3px solid $mu-color-separator;
+  display: inline-block;
+}

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_menu.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_menu.scss
@@ -23,7 +23,14 @@
   }
 }
 
-.mu-user-menu-vertical-divider {
-  border-left: 3px solid $mu-color-separator;
+.mu-user-menu-divider {
   display: inline-block;
+
+  &.vertical {
+    border-left: 3px solid $mu-color-separator;
+  }
+
+  &.horizontal {
+    border-top: 3px solid $mu-color-separator;
+  }
 }

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_profile.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_user_profile.scss
@@ -31,11 +31,19 @@
   }
 }
 
+.mu-profile-info {
+  display: flex;
+  flex-wrap: wrap;
+
+  margin-top: 20px;
+}
+
 .mu-profile-info-left {
   display: flex;
   flex-direction: column;
   align-items: center;
   text-align: center;
+  flex-grow: 1;
 
   .mu-level-progress {
     position: relative;
@@ -62,8 +70,11 @@
 }
 
 .mu-profile-info-right {
+  flex-grow: 2;
+
   font-size: 20px;
   margin-top: 5px;
+
   div {
     margin-bottom: 15px;
     .italic {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,10 +5,6 @@ class UsersController < ApplicationController
   before_action :set_user!
   skip_before_action :validate_accepted_role_terms!
 
-  def show
-    @watched_discussions = current_user.watched_discussions_in_organization
-  end
-
   def update
     current_user.update_and_notify! user_params
     current_user.accept_profile_terms!
@@ -28,6 +24,10 @@ class UsersController < ApplicationController
 
   def messages
     @messages ||= current_user.messages_in_organization
+  end
+
+  def discussions
+    @watched_discussions = current_user.watched_discussions_in_organization
   end
 
   def unsubscribe

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,6 @@ class UsersController < ApplicationController
   skip_before_action :validate_accepted_role_terms!
 
   def show
-    @messages = current_user.messages_in_organization
     @watched_discussions = current_user.watched_discussions_in_organization
   end
 
@@ -25,6 +24,10 @@ class UsersController < ApplicationController
 
   def terms
     @profile_terms ||= Term.profile_terms_for(current_user)
+  end
+
+  def messages
+    @messages ||= current_user.messages_in_organization
   end
 
   def unsubscribe

--- a/app/helpers/breadcrumbs_helper.rb
+++ b/app/helpers/breadcrumbs_helper.rb
@@ -41,6 +41,10 @@ module BreadcrumbsHelper
     discussion.friendly.truncate_words(4)
   end
 
+  def breadcrumbs_for_my_account
+    header_breadcrumbs + breadcrumb_list_item(t(:my_account), 'last')
+  end
+
   private
 
   def breadcrumbs_for_linkable(e, extra=nil, last='')

--- a/app/helpers/menu_bar_helper.rb
+++ b/app/helpers/menu_bar_helper.rb
@@ -18,7 +18,7 @@ module MenuBarHelper
   end
 
   def link_to_profile
-    menu_item('user', :profile, user_path)
+    menu_item('user', :my_account, user_path)
   end
 
   def link_to_classroom

--- a/app/helpers/user_menu_helper.rb
+++ b/app/helpers/user_menu_helper.rb
@@ -2,4 +2,12 @@ module UserMenuHelper
   def profile_user_menu_link
     link_to t(:profile), user_path
   end
+
+  def messages_user_menu_link
+    link_to t(:messages), messages_user_path
+  end
+
+  def discussions_user_menu_link
+    link_to t(:discussions), discussions_user_path
+  end
 end

--- a/app/helpers/user_menu_helper.rb
+++ b/app/helpers/user_menu_helper.rb
@@ -1,6 +1,6 @@
 module UserMenuHelper
   def profile_user_menu_link
-    link_to t(:profile), user_path
+    link_to t(:my_profile), user_path
   end
 
   def messages_user_menu_link

--- a/app/helpers/user_menu_helper.rb
+++ b/app/helpers/user_menu_helper.rb
@@ -1,13 +1,18 @@
 module UserMenuHelper
   def profile_user_menu_link
-    link_to t(:my_profile), user_path
+    user_menu_link t(:my_profile), user_path, 'show'
   end
 
   def messages_user_menu_link
-    link_to t(:messages), messages_user_path
+    user_menu_link t(:messages), messages_user_path, 'messages'
   end
 
   def discussions_user_menu_link
-    link_to t(:discussions), discussions_user_path
+    user_menu_link t(:discussions), discussions_user_path, 'discussions'
+  end
+
+  def user_menu_link(label, path, active_on)
+    link_klass = 'active' if action_name == active_on
+    link_to label, path, { class: link_klass }.compact
   end
 end

--- a/app/helpers/user_menu_helper.rb
+++ b/app/helpers/user_menu_helper.rb
@@ -10,4 +10,8 @@ module UserMenuHelper
   def discussions_user_menu_link
     link_to t(:discussions), discussions_user_path
   end
+
+  def should_show_discussions?
+    Organization.current.forum_enabled?
+  end
 end

--- a/app/helpers/user_menu_helper.rb
+++ b/app/helpers/user_menu_helper.rb
@@ -10,8 +10,4 @@ module UserMenuHelper
   def discussions_user_menu_link
     link_to t(:discussions), discussions_user_path
   end
-
-  def should_show_discussions?
-    Organization.current.forum_enabled?
-  end
 end

--- a/app/helpers/user_menu_helper.rb
+++ b/app/helpers/user_menu_helper.rb
@@ -1,0 +1,5 @@
+module UserMenuHelper
+  def profile_user_menu_link
+    link_to t(:profile), user_path
+  end
+end

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -22,5 +22,6 @@
       <% end %>
     </div>
   </div>
-  <div class="mu-user-menu-vertical-divider hidden-sm hidden-xs"></div>
+  <div class="mu-user-menu-divider vertical hidden-sm hidden-xs"></div>
 </div>
+<div class="mu-user-menu-divider horizontal visible-sm visible-xs"></div>

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -15,7 +15,7 @@
       <div class="mu-user-menu-item">
         <%= messages_user_menu_link %>
       </div>
-      <% if should_show_discussions? %>
+      <% if current_user&.can_discuss_here? %>
         <div class="mu-user-menu-item">
           <%= discussions_user_menu_link %>
         </div>

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -1,0 +1,13 @@
+<div class="col-md-3 mu-tab-body mu-user-menu">
+  <div>
+    <div class="mu-user-menu-section">
+      <div class="mu-user-menu-header">
+        <%= t(:my_account) %>
+      </div>
+      <div class="mu-user-menu-item">
+        <%= profile_user_menu_link %>
+      </div>
+    </div>
+  </div>
+  <div class="mu-user-menu-vertical-divider"></div>
+</div>

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -1,26 +1,20 @@
 <div class="col-md-3 mu-tab-body mu-user-menu">
-  <div>
-    <div class="mu-user-menu-section">
-      <div class="mu-user-menu-header">
-        <%= t(:my_account) %>
-      </div>
-      <div class="mu-user-menu-item">
-        <%= profile_user_menu_link %>
-      </div>
+  <div class="col-md-12">
+    <div class="mu-user-menu-header">
+      <%= t(:my_account) %>
     </div>
-    <div class="mu-user-menu-section">
-      <div class="mu-user-menu-header">
-        <%= t(:messages) %>
-      </div>
-      <div class="mu-user-menu-item">
-        <%= messages_user_menu_link %>
-      </div>
-      <% if current_user&.can_discuss_here? %>
-        <div class="mu-user-menu-item">
-          <%= discussions_user_menu_link %>
-        </div>
-      <% end %>
+    <div class="mu-user-menu-item">
+      <%= profile_user_menu_link %>
     </div>
+    <div class="mu-user-menu-divider horizontal"></div>
+    <div class="mu-user-menu-item">
+      <%= messages_user_menu_link %>
+    </div>
+    <% if current_user&.can_discuss_here? %>
+      <div class="mu-user-menu-item">
+        <%= discussions_user_menu_link %>
+      </div>
+    <% end %>
   </div>
   <div class="mu-user-menu-divider vertical hidden-sm hidden-xs"></div>
 </div>

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -8,6 +8,19 @@
         <%= profile_user_menu_link %>
       </div>
     </div>
+    <div class="mu-user-menu-section">
+      <div class="mu-user-menu-header">
+        <%= t(:messages) %>
+      </div>
+      <div class="mu-user-menu-item">
+        <%= messages_user_menu_link %>
+      </div>
+      <% if @watched_discussions.present? %>
+        <div class="mu-user-menu-item">
+          <%= discussions_user_menu_link %>
+        </div>
+      <% end %>
+    </div>
   </div>
   <div class="mu-user-menu-vertical-divider hidden-sm hidden-xs"></div>
 </div>

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -15,7 +15,7 @@
       <div class="mu-user-menu-item">
         <%= messages_user_menu_link %>
       </div>
-      <% if @watched_discussions.present? %>
+      <% if should_show_discussions? %>
         <div class="mu-user-menu-item">
           <%= discussions_user_menu_link %>
         </div>

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -9,5 +9,5 @@
       </div>
     </div>
   </div>
-  <div class="mu-user-menu-vertical-divider"></div>
+  <div class="mu-user-menu-vertical-divider hidden-sm hidden-xs"></div>
 </div>

--- a/app/views/users/_user_form.html.erb
+++ b/app/views/users/_user_form.html.erb
@@ -4,8 +4,8 @@
     <%= edit_profile_button %>
   </div>
 </div>
-<div class="row mu-tab-body">
-  <div class="col-md-4 mu-profile-info-left">
+<div class="mu-profile-info">
+  <div class="mu-profile-info-left">
     <%= profile_picture_for(@user, id: 'mu-user-avatar', class: 'mu-user-avatar') %>
     <% if in_gamified_context? %>
       <svg class="mu-level-progress" width="300" height="300" viewBox="0 0 100 100">
@@ -18,7 +18,7 @@
       </div>
     <% end %>
   </div>
-  <div class="col-md-8 mu-profile-info-right">
+  <div class="mu-profile-info-right">
     <% if @user.age.present? %>
       <div>
         <span> <strong><%= t :age %>:</strong> <%= "#{@user.age} #{t :years}" %> </span>
@@ -31,8 +31,7 @@
       <span> <strong><%= t :programming_since %>:</strong> <%= t(:time_since, time: time_ago_in_words(@user.created_at)) %> </span>
     </div>
   </div>
-
-  <div class="mu-profile-actions mobile visible-xs">
-    <%= edit_profile_button %>
-  </div>
+</div>
+<div class="mu-profile-actions mobile visible-xs">
+  <%= edit_profile_button %>
 </div>

--- a/app/views/users/_user_form.html.erb
+++ b/app/views/users/_user_form.html.erb
@@ -1,5 +1,5 @@
 <div class="mu-user-header">
-  <h1><%= t(:profile) %></h1>
+  <h1><%= t(:my_profile) %></h1>
   <div class="mu-profile-actions hidden-xs">
     <%= edit_profile_button %>
   </div>

--- a/app/views/users/_user_form.html.erb
+++ b/app/views/users/_user_form.html.erb
@@ -1,5 +1,5 @@
 <div class="mu-user-header">
-  <h1><%= @user.name %></h1>
+  <h1><%= t(:profile) %></h1>
   <div class="mu-profile-actions hidden-xs">
     <%= edit_profile_button %>
   </div>
@@ -19,6 +19,9 @@
     <% end %>
   </div>
   <div class="mu-profile-info-right">
+    <div>
+      <span> <strong><%= t :name %>:</strong> <%= "#{@user.name}" %> </span>
+    </div>
     <% if @user.age.present? %>
       <div>
         <span> <strong><%= t :age %>:</strong> <%= "#{@user.age} #{t :years}" %> </span>

--- a/app/views/users/discussions.html.erb
+++ b/app/views/users/discussions.html.erb
@@ -1,0 +1,19 @@
+<%= content_for :breadcrumbs do %>
+  <%= breadcrumbs @user %>
+<% end %>
+
+<%= render partial: 'layouts/user_menu' %>
+
+<div class="col-md-9 mu-tab-body">
+  <table class="table table-striped">
+    <% @watched_discussions.each do |discussion| %>
+      <tr>
+        <td>
+          <%= icon_for_read(discussion.read_by?(@user)) %>
+        </td>
+        <td><%= link_to discussion.item.name, item_discussion_path(discussion) %></td>
+        <td><%= time_ago_in_words discussion.last_message_date %></td>
+      </tr>
+    <% end %>
+  </table>
+</div>

--- a/app/views/users/discussions.html.erb
+++ b/app/views/users/discussions.html.erb
@@ -8,15 +8,21 @@
   <div class="mu-user-header">
     <h1><%= t(:discussions) %></h1>
   </div>
-  <table class="table table-striped">
-    <% @watched_discussions.each do |discussion| %>
-      <tr>
-        <td>
-          <%= icon_for_read(discussion.read_by?(@user)) %>
-        </td>
-        <td><%= link_to discussion.item.name, item_discussion_path(discussion) %></td>
-        <td><%= time_ago_in_words discussion.last_message_date %></td>
-      </tr>
-    <% end %>
-  </table>
+  <% if @watched_discussions.empty? %>
+    <div class="mu-tab-body">
+      <%= t :discussions_will_be_here %>
+    </div>
+  <% else %>
+    <table class="table table-striped">
+      <% @watched_discussions.each do |discussion| %>
+        <tr>
+          <td>
+            <%= icon_for_read(discussion.read_by?(@user)) %>
+          </td>
+          <td><%= link_to discussion.item.name, item_discussion_path(discussion) %></td>
+          <td><%= time_ago_in_words discussion.last_message_date %></td>
+        </tr>
+      <% end %>
+    </table>
+  <% end %>
 </div>

--- a/app/views/users/discussions.html.erb
+++ b/app/views/users/discussions.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :breadcrumbs do %>
-  <%= breadcrumbs @user %>
+  <%= breadcrumbs_for_my_account %>
 <% end %>
 
 <%= render partial: 'layouts/user_menu' %>

--- a/app/views/users/discussions.html.erb
+++ b/app/views/users/discussions.html.erb
@@ -5,6 +5,9 @@
 <%= render partial: 'layouts/user_menu' %>
 
 <div class="col-md-9 mu-tab-body">
+  <div class="mu-user-header">
+    <h1><%= t(:discussions) %></h1>
+  </div>
   <table class="table table-striped">
     <% @watched_discussions.each do |discussion| %>
       <tr>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :breadcrumbs do %>
-  <%= breadcrumbs @user %>
+  <%= breadcrumbs_for_my_account %>
 <% end %>
 
 <%= render partial: 'edit_user_form' %>

--- a/app/views/users/messages.html.erb
+++ b/app/views/users/messages.html.erb
@@ -1,0 +1,24 @@
+<%= content_for :breadcrumbs do %>
+  <%= breadcrumbs @user %>
+<% end %>
+
+<%= render partial: 'layouts/user_menu' %>
+
+<div class="col-md-9 mu-tab-body">
+  <% if @messages.empty? %>
+    <div class="mu-tab-body">
+      <%= t :no_messages %>
+    </div>
+  <% else %>
+    <table class="table table-striped">
+      <% @messages.each do |message| %>
+        <tr>
+          <td><%= icon_for_read(message.read?) %></td>
+          <td><%= link_to message.exercise.name, exercise_path(message.exercise.id) %></td>
+          <td><%= mail_to message.sender %></td>
+          <td><%= time_ago_in_words message.created_at %></td>
+        </tr>
+      <% end %>
+    </table>
+  <% end %>
+</div>

--- a/app/views/users/messages.html.erb
+++ b/app/views/users/messages.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :breadcrumbs do %>
-  <%= breadcrumbs @user %>
+  <%= breadcrumbs_for_my_account %>
 <% end %>
 
 <%= render partial: 'layouts/user_menu' %>

--- a/app/views/users/messages.html.erb
+++ b/app/views/users/messages.html.erb
@@ -5,6 +5,9 @@
 <%= render partial: 'layouts/user_menu' %>
 
 <div class="col-md-9 mu-tab-body">
+  <div class="mu-user-header">
+    <h1><%= t(:messages) %></h1>
+  </div>
   <% if @messages.empty? %>
     <div class="mu-tab-body">
       <%= t :no_messages %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,56 +1,5 @@
 <%= content_for :breadcrumbs do %>
-    <%= breadcrumbs @user %>
+  <%= breadcrumbs @user %>
 <% end %>
 
-<ul class="nav nav-tabs" role="tablist">
-  <li role="presentation" class="active">
-    <a data-target="#info" aria-controls="info" role="tab" data-toggle="tab"><%= t :profile %></a>
-  </li>
-  <li role="presentation">
-    <a data-target="#messages" aria-controls="messages" role="tab" data-toggle="tab"><%= t :messages %></a>
-  </li>
-  <% if @watched_discussions.present? %>
-    <li role="presentation">
-      <a data-target="#discussions" aria-controls="discussions" role="tab" data-toggle="tab"><%= t :discussions %></a>
-    </li>
-  <% end %>
-</ul>
-
-<div class="tab-content">
-  <div role="tabpanel" class="tab-pane active" id="info">
-    <%= render partial: 'user_form' %>
-  </div>
-  <div role="tabpanel" class="tab-pane" id="messages">
-    <% if @messages.empty? %>
-        <div class="row mu-tab-body col-md-12">
-          <%= t :no_messages %>
-        </div>
-    <% else %>
-      <table class="table table-striped">
-        <% @messages.each do |message| %>
-            <tr>
-              <td><%= icon_for_read(message.read?) %></td>
-              <td><%= link_to message.exercise.name, exercise_path(message.exercise.id) %></td>
-              <td><%= mail_to message.sender %></td>
-              <td><%= time_ago_in_words message.created_at %></td>
-            </tr>
-        <% end %>
-      </table>
-    <% end %>
-  </div>
-  <% if @watched_discussions.present? %>
-    <div role="tabpanel" class="tab-pane" id="discussions">
-      <table class="table table-striped">
-        <% @watched_discussions.each do |discussion| %>
-          <tr>
-            <td>
-              <%= icon_for_read(discussion.read_by?(@user)) %>
-            </td>
-            <td><%= link_to discussion.item.name, item_discussion_path(discussion) %></td>
-            <td><%= time_ago_in_words discussion.last_message_date %></td>
-          </tr>
-        <% end %>
-      </table>
-    </div>
-  <% end %>
-</div>
+<%= render partial: 'user_form' %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :breadcrumbs do %>
-  <%= breadcrumbs @user %>
+  <%= breadcrumbs_for_my_account %>
 <% end %>
 
 <%= render partial: 'layouts/user_menu' %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,4 +2,8 @@
   <%= breadcrumbs @user %>
 <% end %>
 
-<%= render partial: 'user_form' %>
+<%= render partial: 'layouts/user_menu' %>
+
+<div class="col-md-9 mu-tab-body">
+  <%= render partial: 'user_form' %>
+</div>

--- a/app/views/users/terms.html.erb
+++ b/app/views/users/terms.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :breadcrumbs do %>
   <% if current_logged_user? %>
-    <%= breadcrumbs @user %>
+    <%= breadcrumbs_for_my_account %>
   <% else %>
     <%= header_breadcrumbs %>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,8 @@ Rails.application.routes.draw do
 
       # Notification subscriptions
       get :unsubscribe
+
+      get :messages
     end
 
     resources :messages, only: [:index, :create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
       get :unsubscribe
 
       get :messages
+      get :discussions
     end
 
     resources :messages, only: [:index, :create]

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -170,6 +170,7 @@ en:
   moderation: Mentoring
   moderator: Mentor
   more_messages: More
+  my_account: My account
   my_doubts: My doubts
   my_submissions: My Submissions
   name: Name

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -68,6 +68,7 @@ en:
   new_discussion_message: New message on %{title}
   discussion_updated: Discussion updated
   discussions: Discussions
+  discussions_will_be_here: Your posts in the forum will appear here.
   dont_leave_us: Don't leave us! Learning is fun. You just have to keep at it.
   download: Download your solution
   edit: Edit

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -173,6 +173,7 @@ en:
   more_messages: More
   my_account: My account
   my_doubts: My doubts
+  my_profile: My profile
   my_submissions: My Submissions
   name: Name
   navigation_continue: 'Next: %{sibling}'
@@ -219,7 +220,6 @@ en:
   previous_exercise: Previous
   problem_with_exercise: '[Mumuki] Problem with exercise: %{title}'
   processing_your_solution: We are processing you solution
-  profile: Profile
   profile_of: Profile of %{username}
   programming_since: Started programming
   progress: Progresss

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -68,6 +68,7 @@ es-CL:
   new_discussion_message: Mensaje nuevo en %{title}
   discussion_updated: Consulta actualizada
   discussions: Consultas
+  discussions_will_be_here: Las preguntas que realices en el espacio de consultas aparecerán aquí.
   dont_leave_us: ¡No nos abandones! Aprender a programar es divertido. Sólo tienes que seguir practicando.
   download: "Descarga lo que hiciste"
   edit: Editar

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -171,6 +171,7 @@ es-CL:
   moderation: Mentoría
   moderator: Mentor
   more_messages: Ver mensajes anteriores
+  my_account: Mi cuenta
   my_doubts: Mis consultas
   name: Nombre
   navigation_continue: 'Siguiente %{kind}: %{sibling}'

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -174,6 +174,7 @@ es-CL:
   more_messages: Ver mensajes anteriores
   my_account: Mi cuenta
   my_doubts: Mis consultas
+  my_profile: Mi perfil
   name: Nombre
   navigation_continue: 'Siguiente %{kind}: %{sibling}'
   navigation_next: Siguiente %{kind}
@@ -225,7 +226,6 @@ es-CL:
   previous_exercise: Anterior
   problem_with_exercise: '[Mumuki] Error con el ejercicio: %{title}'
   processing_your_solution: Estamos procesando tu solución
-  profile: Perfil
   profile_of: Perfil de %{username}
   progress: Progreso
   read: Leído

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -185,6 +185,7 @@ es:
   more_messages: Ver mensajes anteriores
   my_account: Mi cuenta
   my_doubts: Mis consultas
+  my_profile: Mi perfil
   name: Nombre
   navigation_continue: 'Siguiente %{kind}: %{sibling}'
   navigation_next: Siguiente %{kind}
@@ -236,7 +237,6 @@ es:
   previous_exercise: Anterior
   problem_with_exercise: '[Mumuki] Error con el ejercicio: %{title}'
   processing_your_solution: Estamos procesando tu solución
-  profile: Perfil
   profile_of: Perfil de %{username}
   programming_since: Programando desde
   progress: Progreso

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -182,6 +182,7 @@ es:
   moderation: Mentoría
   moderator: Mentor
   more_messages: Ver mensajes anteriores
+  my_account: Mi cuenta
   my_doubts: Mis consultas
   name: Nombre
   navigation_continue: 'Siguiente %{kind}: %{sibling}'

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -75,6 +75,7 @@ es:
   discussion_updated: Consulta actualizada
   new_discussion_message: Mensaje nuevo en %{title}
   discussions: Consultas
+  discussions_will_be_here: Las preguntas que realices en el espacio de consultas aparecerán aquí.
   dont_leave_us: ¡No nos abandones! Aprender a programar es divertido. Sólo tenés que seguir practicando.
   download: "Descargá lo que hiciste"
   edit: Editar

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -176,6 +176,7 @@ pt:
   moderation: Mentoria
   moderator: Mentor
   more_messages: Ver as mensagens anteriores
+  my_account: Minha conta
   my_doubts: Minhas duvidas
   name: Nome
   navigation_continue: "Próximo %{kind}: %{sibling}"

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -179,6 +179,7 @@ pt:
   more_messages: Ver as mensagens anteriores
   my_account: Minha conta
   my_doubts: Minhas duvidas
+  my_profile: Meu perfil
   name: Nome
   navigation_continue: "Próximo %{kind}: %{sibling}"
   navigation_next: Próximo %{kind}
@@ -227,7 +228,6 @@ pt:
   previous_exercise: Anterior
   problem_with_exercise: '[Mumuki] Erro com exercício %{title}'
   processing_your_solution: Estamos processando sua solução
-  profile: Perfil
   profile_of: Perfil de %{username}
   programming_since: Sou programador
   progress: Progresso

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -72,6 +72,7 @@ pt:
   new_discussion_message: Nova mensagem em %{title}
   discussion_updated: Consulta actualizada
   discussions: Consultas
+  discussions_will_be_here: As perguntas que você fizer no espaço de consulta aparecerão aqui.
   download: Faça o download do que você fez
   edit: Editar
   edit_profile: Editar perfil

--- a/spec/features/exercise_flow_spec.rb
+++ b/spec/features/exercise_flow_spec.rb
@@ -106,19 +106,19 @@ feature 'Exercise Flow', organization_workspace: :test do
       scenario 'visit exercise by id, standalone mode' do
         visit "/exercises/#{problem_1.id}"
         expect(page).to have_text('Functional Programming 1')
-        expect(page).to have_text('Profile')
+        expect(page).to have_text('My account')
       end
       scenario 'visit exercise by id, embedded mode in non embeddable organization' do
         visit "/exercises/#{problem_1.id}?embed=true"
         expect(page).to have_text('Functional Programming 1')
-        expect(page).to have_text('Profile')
+        expect(page).to have_text('My account')
       end
       scenario 'visit exercise by id, embedded mode in embeddable organization' do
         Organization.current.tap { |it| it.embeddable = true }.save!
 
         visit "/exercises/#{problem_1.id}?embed=true"
         expect(page).to_not have_text('Functional Programming 1')
-        expect(page).to_not have_text('Profile')
+        expect(page).to_not have_text('My account')
       end
     end
 

--- a/spec/features/login_flow_spec.rb
+++ b/spec/features/login_flow_spec.rb
@@ -64,6 +64,6 @@ feature 'Login Flow', organization_workspace: :test do
 
     expect(page).to_not have_text('Sign in')
     expect(page).to have_text('Sign Out')
-    expect(page).to have_text('Profile')
+    expect(page).to have_text('My profile')
   end
 end

--- a/spec/features/menu_bar_spec.rb
+++ b/spec/features/menu_bar_spec.rb
@@ -16,7 +16,7 @@ feature 'menu bar' do
       scenario 'should not see menu bar' do
         visit '/'
 
-        expect(page).not_to have_text('Profile')
+        expect(page).not_to have_text('My account')
         expect(page).not_to have_text('Classroom')
         expect(page).not_to have_text('Bibliotheca')
       end
@@ -30,7 +30,7 @@ feature 'menu bar' do
       scenario 'should not see menu bar' do
         visit '/'
 
-        expect(page).not_to have_text('Profile')
+        expect(page).not_to have_text('My account')
         expect(page).not_to have_text('Classroom')
         expect(page).not_to have_text('Bibliotheca')
         expect(page).not_to have_text('Solve other\'s doubts')
@@ -48,11 +48,11 @@ feature 'menu bar' do
     let(:admin) { create(:user, permissions: {student: 'private/*', admin: 'private/*'}) }
     let(:owner) { create(:user, permissions: {student: 'private/*', owner: 'private/*'}) }
 
-    scenario 'visitor should only see profile' do
+    scenario 'visitor should only see their account' do
       set_current_user! visitor
 
       visit '/'
-      expect(page).to have_text('Profile')
+      expect(page).to have_text('My account')
       expect(page).not_to have_text('Classroom')
       expect(page).not_to have_text('Bibliotheca')
       expect(page).not_to have_text('Solve other\'s doubts')
@@ -60,23 +60,23 @@ feature 'menu bar' do
     end
 
     context 'student with no discussions should' do
-      scenario 'only see profile if forum is not enabled' do
+      scenario 'only see their account if forum is not enabled' do
         set_current_user! student
 
         visit '/'
-        expect(page).to have_text('Profile')
+        expect(page).to have_text('My account')
         expect(page).not_to have_text('Classroom')
         expect(page).not_to have_text('Bibliotheca')
         expect(page).not_to have_text('Solve other\'s doubts')
         expect(page).not_to have_text('My doubts')
       end
 
-      scenario 'see profile and solve_other_doubts links if forum is enabled' do
+      scenario 'see their account and solve_other_doubts links if forum is enabled' do
         set_current_user! student
         private_organization.update! forum_enabled: true
 
         visit '/'
-        expect(page).to have_text('Profile')
+        expect(page).to have_text('My account')
         expect(page).not_to have_text('Classroom')
         expect(page).not_to have_text('Bibliotheca')
         expect(page).to have_text('Solve other\'s doubts')
@@ -87,12 +87,12 @@ feature 'menu bar' do
     context 'student with discussions should' do
       let(:discussion) { create(:discussion, item: lesson.exercises.last, initiator: student)}
 
-      scenario 'only see profile if forum is not enabled' do
+      scenario 'only see their account if forum is not enabled' do
         set_current_user! student
         student.subscribe_to! discussion
 
         visit '/'
-        expect(page).to have_text('Profile')
+        expect(page).to have_text('My account')
         expect(page).not_to have_text('Classroom')
         expect(page).not_to have_text('Bibliotheca')
         expect(page).not_to have_text('Solve other\'s doubts')
@@ -105,21 +105,21 @@ feature 'menu bar' do
         student.subscribe_to! discussion
 
         visit '/'
-        expect(page).to have_text('Profile')
+        expect(page).to have_text('My account')
         expect(page).not_to have_text('Classroom')
         expect(page).not_to have_text('Bibliotheca')
         expect(page).to have_text('Solve other\'s doubts')
         expect(page).to have_text('My doubts')
       end
 
-      scenario 'only see profile if forum is enabled in a forum_only_for_trusted organization' do
+      scenario 'only see their account if forum is enabled in a forum_only_for_trusted organization' do
         set_current_user! student
         student.subscribe_to! discussion
         private_organization.update! forum_enabled: true
         private_organization.update! forum_only_for_trusted: true
 
         visit '/'
-        expect(page).to have_text('Profile')
+        expect(page).to have_text('My account')
         expect(page).not_to have_text('Classroom')
         expect(page).not_to have_text('Bibliotheca')
         expect(page).not_to have_text('Solve other\'s doubts')
@@ -134,7 +134,7 @@ feature 'menu bar' do
         private_organization.update! forum_only_for_trusted: true
 
         visit '/'
-        expect(page).to have_text('Profile')
+        expect(page).to have_text('My account')
         expect(page).not_to have_text('Classroom')
         expect(page).not_to have_text('Bibliotheca')
         expect(page).to have_text('Solve other\'s doubts')
@@ -142,54 +142,54 @@ feature 'menu bar' do
       end
     end
 
-    scenario 'teacher should see profile and classroom' do
+    scenario 'teacher should see their account and classroom' do
       set_current_user! teacher
 
       visit '/'
 
-      expect(page).to have_text('Profile')
+      expect(page).to have_text('My account')
       expect(page).to have_text('Classroom')
       expect(page).not_to have_text('Bibliotheca')
       expect(page).not_to have_text('Solve other\'s doubts')
       expect(page).not_to have_text('My doubts')
     end
 
-    scenario 'writer should see profile and bibliotheca' do
+    scenario 'writer should see their account and bibliotheca' do
       set_current_user! writer
 
       visit '/'
 
-      expect(page).to have_text('Profile')
+      expect(page).to have_text('My account')
       expect(page).not_to have_text('Classroom')
       expect(page).to have_text('Bibliotheca')
     end
 
-    scenario 'janitor should see profile and classroom' do
+    scenario 'janitor should see their account and classroom' do
       set_current_user! janitor
 
       visit '/'
 
-      expect(page).to have_text('Profile')
+      expect(page).to have_text('My account')
       expect(page).to have_text('Classroom')
       expect(page).not_to have_text('Bibliotheca')
     end
 
-    scenario 'admin should see profile, classroom and bibliotheca' do
+    scenario 'admin should their account, classroom and bibliotheca' do
       set_current_user! admin
 
       visit '/'
 
-      expect(page).to have_text('Profile')
+      expect(page).to have_text('My account')
       expect(page).to have_text('Classroom')
       expect(page).to have_text('Bibliotheca')
     end
 
-    scenario 'owner should see profile, classroom and bibliotheca' do
+    scenario 'owner should see their account, classroom and bibliotheca' do
       set_current_user! owner
 
       visit '/'
 
-      expect(page).to have_text('Profile')
+      expect(page).to have_text('My account')
       expect(page).to have_text('Classroom')
       expect(page).to have_text('Bibliotheca')
     end

--- a/spec/features/profile_flow_spec.rb
+++ b/spec/features/profile_flow_spec.rb
@@ -103,25 +103,23 @@ feature 'Profile Flow', organization_workspace: :test do
     end
 
     context 'with no messages' do
-
-      pending 'visit messages tab' do
-        visit "/user#messages"
+      scenario 'visit messages' do
+        visit "/user/messages"
 
         expect(page).to have_text('It seems you don\'t have any messages yet!')
       end
     end
 
     context 'with messages' do
-      pending 'visit messages tab' do
+      scenario 'visit messages' do
         Organization.find_by_name('test').switch!
         problem.submit_solution! user, {content: 'something'}
         Message.import_from_resource_h! message
-        visit "/user#messages"
+        visit "/user/messages"
 
         expect(page).to_not have_text('It seems you don\'t have any messages yet!')
         expect(page).to have_text(problem.name)
       end
     end
   end
-
 end

--- a/spec/features/profile_flow_spec.rb
+++ b/spec/features/profile_flow_spec.rb
@@ -97,7 +97,7 @@ feature 'Profile Flow', organization_workspace: :test do
 
           click_on(button_options)
           expect(page).to have_text('Your data was updated successfully')
-          expect(page).to have_text('Profile')
+          expect(page).to have_text('My profile')
         end
       end
     end

--- a/spec/features/profile_flow_spec.rb
+++ b/spec/features/profile_flow_spec.rb
@@ -104,7 +104,7 @@ feature 'Profile Flow', organization_workspace: :test do
 
     context 'with no messages' do
 
-      scenario 'visit messages tab' do
+      pending 'visit messages tab' do
         visit "/user#messages"
 
         expect(page).to have_text('It seems you don\'t have any messages yet!')
@@ -112,7 +112,7 @@ feature 'Profile Flow', organization_workspace: :test do
     end
 
     context 'with messages' do
-      scenario 'visit messages tab' do
+      pending 'visit messages tab' do
         Organization.find_by_name('test').switch!
         problem.submit_solution! user, {content: 'something'}
         Message.import_from_resource_h! message


### PR DESCRIPTION
## :dart: Goal

Add a new user menu that replaces the profile / messages / discussions nav tabs.

## :memo: Details

This decision is motivated by many factors:

* We decided it'd look better (see https://github.com/mumuki/mumuki-laboratory/issues/1540#issuecomment-763138684)
* All tabs are currently eagerly loaded, meaning each visit to the profile triggers queries for messages, discussions, and soon, intensive queries on indicators
* While it won't fix other pages where we're using same-page anchors, it at least eliminates this bug https://github.com/mumuki/mumuki-laboratory/issues/1560 for the profile view

There are a few things up for consideration which I'll write in a couple comments.

## :camera_flash: Screenshots

### Profile view (`/organization/user`)

![image](https://user-images.githubusercontent.com/11304439/106909712-508ba000-66df-11eb-8cf2-178302847e7f.png)

____

### Messages view (`/organization/user/messages`)
![image](https://user-images.githubusercontent.com/11304439/106909912-7ca72100-66df-11eb-807a-4de1654d8fec.png)

____

### Discussions view (`/organization/user/discussions`)
![image](https://user-images.githubusercontent.com/11304439/106909953-86c91f80-66df-11eb-926f-3dacb4d48135.png)

![image](https://user-images.githubusercontent.com/11304439/106910178-ba0bae80-66df-11eb-83e5-2e90318fe1d9.png)

____

### Mobile view

Not the prettiest, but not broken either...

<img src="https://user-images.githubusercontent.com/11304439/106910337-e3c4d580-66df-11eb-8688-6e8f1e9113bf.png" width="375" height="812" />

____


## :soon: Future work

This is the intended final view:
![image](https://user-images.githubusercontent.com/11304439/106912617-f0e2c400-66e1-11eb-8983-c271064fd227.png)

The naming or the way the links are grouped can change. Still:

* `Preferencias` waits for settings such as https://github.com/mumuki/mumuki-laboratory/pull/1532 (I'll reupload that on a new PR) and https://github.com/mumuki/mumuki-laboratory/pull/1531 which are not quite ready yet. 
* `Mi actividad` waits for https://github.com/mumuki/mumuki-laboratory/issues/1540
* `Mis exámenes`, for https://github.com/mumuki/mumuki-laboratory/pull/1559
* `Mis certificados` is beyond the scope of `mumuki-laboratory`.

