### PR TITLE
Fix text positioning on short chapter descriptions

### DIFF
--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_content_show.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_content_show.scss
@@ -1,3 +1,3 @@
-.chapter-description p {
+.chapter-description {
   display: inline-block;
 }


### PR DESCRIPTION
## :dart: Goal

Fix some wrong positioning when the chapter description is very short. I haven't seen any real chapters like this, but I found it when creating a test chapter.


## :camera_flash: Screenshots

### Monolesson - before/after

![Screenshot_2021-02-18 upload - Aprendé a Programar Recorrido Extendido(1)](https://user-images.githubusercontent.com/11304439/108388804-c585cc00-71ed-11eb-9c77-a49aed5c5285.png)
_____

![Screenshot_2021-02-18 upload - Aprendé a Programar Recorrido Extendido](https://user-images.githubusercontent.com/11304439/108388807-c61e6280-71ed-11eb-9cfe-b785e856aec5.png)
______

### Multiple lessons - before/after

![Screenshot_2021-02-18 Test topic - Aprendé a Programar Recorrido Extendido](https://user-images.githubusercontent.com/11304439/108388812-c74f8f80-71ed-11eb-9953-dcc32eed11d7.png)
____

![Screenshot_2021-02-18 Test topic - Aprendé a Programar Recorrido Extendido(1)](https://user-images.githubusercontent.com/11304439/108388809-c6b6f900-71ed-11eb-8ba3-a523731a4c87.png)