### PR TITLE
Update mumukit-login

### DIFF
--- a/app/controllers/concerns/with_authorization.rb
+++ b/app/controllers/concerns/with_authorization.rb
@@ -1,17 +1,12 @@
 module WithAuthorization
   extend ActiveSupport::Concern
 
-  (Mumukit::Auth::Roles::ROLES - [:editor, :writer]).each do |role|
-    define_method "authorize_#{role}!" do
-      authorize! role
-    end
-  end
-
   def authorization_slug
     protection_slug || '_/_'
   end
 
   def protection_slug
+    warn "protection_slug is nil, which is not probably what you want" unless @slug
     @slug
   end
 end

--- a/app/controllers/concerns/with_authorization.rb
+++ b/app/controllers/concerns/with_authorization.rb
@@ -1,20 +1,10 @@
 module WithAuthorization
   extend ActiveSupport::Concern
 
-  def authorize_janitor!
-    authorize! :janitor
-  end
-
-  def authorize_admin!
-    authorize! :admin
-  end
-
-  def authorize_owner!
-    authorize! :owner
-  end
-
-  def authorize_moderator!
-    authorize! :moderator
+  (Mumukit::Auth::Roles::ROLES - [:editor, :writer]).each do |role|
+    define_method "authorize_#{role}!" do
+      authorize! role
+    end
   end
 
   def authorization_slug

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'mumuki-domain', '~> 8.6.1'
   s.add_dependency 'mumukit-bridge', '~> 4.1'
-  s.add_dependency 'mumukit-login', '~> 7.3'
+  s.add_dependency 'mumukit-login', '~> 7.6'
   s.add_dependency 'mumukit-nuntius', '~> 6.1'
   s.add_dependency 'mumukit-auth', '~> 7.8'
   s.add_dependency 'mumukit-content-type', '~> 1.9'


### PR DESCRIPTION
# :dart: Goal

~To generalize the `authorize` methods, and allow all permissions to have its corresponding validation.~ 
To update `mumukit-login`

# :memo: Details

This started as a simple refactor, but then I decided to move the new code to the gem it should have always belonged.  

# :back: Backwards compatibility

100% backwards compatible


