### PR TITLE
Add current_user? to progress_listing cache

### DIFF
--- a/app/views/layouts/_progress_listing.html.erb
+++ b/app/views/layouts/_progress_listing.html.erb
@@ -1,6 +1,6 @@
 <ul class="progress-listing">
   <% guide.assignments_for(current_user).each do |assignment| %>
-      <% cache [assignment.exercise, assignment.status, Organization.current, current_user?] do %>
+      <% cache [assignment.exercise, assignment.status, Organization.current.name, current_user?] do %>
           <li <%= turbolinks_enable_for(assignment.exercise) %>>
             <%= assignment_status_icon assignment %>
             <%= link_to_path_element(assignment.exercise) %>

--- a/app/views/layouts/_progress_listing.html.erb
+++ b/app/views/layouts/_progress_listing.html.erb
@@ -1,6 +1,6 @@
 <ul class="progress-listing">
   <% guide.assignments_for(current_user).each do |assignment| %>
-      <% cache [assignment.exercise, assignment.status, Organization.current] do %>
+      <% cache [assignment.exercise, assignment.status, Organization.current, current_user?] do %>
           <li <%= turbolinks_enable_for(assignment.exercise) %>>
             <%= assignment_status_icon assignment %>
             <%= link_to_path_element(assignment.exercise) %>


### PR DESCRIPTION
## :memo: Details

Currently we have a subtle bug regarding the progress_listing cache. We are using exercise, status and organization to cache this view, which makes sense! 
There is a tiny bit mistake there. The view also depends on another value, `current_user?`. Particularly this line: https://github.com/mumuki/mumuki-laboratory/blob/ff6ed8faaac14cf7ac629e49b3499d17627c71f6/app/helpers/icons_helper.rb#L12.
This is what causes that for not logged in users it is rendered as:

![Screenshot_2021-02-26 Fundamentos - Aprendé a programar](https://user-images.githubusercontent.com/11860076/109323186-f25f6200-7831-11eb-85c8-6a394d0a0b88.png)

but for logged users to be rendered as:

![Screenshot_2021-02-26 Fundamentos - Aprendé a programar(1)](https://user-images.githubusercontent.com/11860076/109323237-02774180-7832-11eb-8dbe-9dbdf6c70fa7.png)

If we don't take current_user? into consideration we may get cases like: 
![Screenshot_2021-02-26 Fundamentos - Aprendé a programar(2)](https://user-images.githubusercontent.com/11860076/109325880-37d15e80-7835-11eb-84f7-24a9b38d1701.png)
because the first used that accessed some exercise, with status `pending` and some orga was not logged in, so it would cache that template for logged in users with same exercise, same orga and same status.


On a separate note, I'm changing Organization.current cache key for Organization.current.name. The reason behind this change  is twofold: Calculating the actual digest for a string is cheaper than for a full object and the cache won't be invalidated after the organization is updated. In our case, no setting of the organization impacts on this layout, so it's safe!