### PR TITLE
Fix bibliotheca url fragment

### DIFF
--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -84,6 +84,6 @@ module LinksHelper
   end
 
   def url_for_bibliotheca_guide(guide)
-    "#{url_for_application(:bibliotheca_ui)}/guides/#{guide.slug}"
+    "#{url_for_application(:bibliotheca_ui).chomp('/')}/guides/#{guide.slug}"
   end
 end

--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -84,6 +84,6 @@ module LinksHelper
   end
 
   def url_for_bibliotheca_guide(guide)
-    "#{url_for_application(:bibliotheca_ui)}/#/guides/#{guide.slug}"
+    "#{url_for_application(:bibliotheca_ui)}/guides/#{guide.slug}"
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -26,4 +26,14 @@ describe ApplicationHelper, organization_workspace: :test do
     it { expect(link_to_path_element(lesson)).to start_with '<a href="/lessons/1-foo">foo' }
   end
 
+  describe 'bibliotheca links' do
+    let(:current_user) { create(:user) }
+    let(:lesson) { create(:lesson, id: 1, name: 'foo') }
+    let(:guide) { lesson.guide }
+
+    before { current_user.make_editor_of! guide.slug  }
+
+    it { expect(url_for_bibliotheca_guide(guide)).to start_with 'http://bibliotheca.localmumuki.io/#/guides/mumuki/mumuki-test-lesson' }
+  end
+
 end


### PR DESCRIPTION
# :dart: Goal

To fix generation of bibliotheca routes, which are broken since platform 7 assumptions about application urls. 

# :memo: Details

Added new tests, and also started using `chomp` for ensuring no duplicated `/` are added. 

# :back: Backwards compatibility

100% backwards compatible. 
