### PR TITLE
Fix Firefox bug where the wrong solution would appear on the editor

### DIFF
--- a/app/views/layouts/exercise_inputs/editors/_code.html.erb
+++ b/app/views/layouts/exercise_inputs/editors/_code.html.erb
@@ -3,7 +3,8 @@
                   placeholder: t(:editor_placeholder),
                   class: 'form-control editor',
                   value: @current_content,
-                  data: {lines: 17} %>
+                  data: {lines: 17},
+                  autocomplete: 'off' %>
   <div class="mu-overlapped">
     <a class="editor-resize"> <%= expand_icon %></a>
     <a class="editor-format"><%= format_icon %></a>


### PR DESCRIPTION
## :dart: Goal

Fix #1271.

## :memo: Details

As commented on the turbolinks issue linked on #1271, turning autocomplete off seems to be the solution.

I couldn't reproduce the bug again after adding that. Please, Firefox users, let me know if you can. Also I don't think it broke anything else.