### PR TITLE
add approved at/by to message model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,3 +40,5 @@ group :development, :test do
   gem 'teaspoon-jasmine'
   gem 'selenium-webdriver'
 end
+
+gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'feature-moderator-stats'

--- a/Gemfile
+++ b/Gemfile
@@ -41,4 +41,4 @@ group :development, :test do
   gem 'selenium-webdriver'
 end
 
-gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'feature-moderator-stats'
+gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'master'

--- a/app/controllers/discussions_messages_controller.rb
+++ b/app/controllers/discussions_messages_controller.rb
@@ -16,7 +16,7 @@ class DiscussionsMessagesController < AjaxController
   end
 
   def approve
-    current_message.toggle_approved!
+    current_message.toggle_approved! current_user
     head :ok
   end
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210302181654) do
+ActiveRecord::Schema.define(version: 20210308145910) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -368,6 +368,9 @@ ActiveRecord::Schema.define(version: 20210302181654) do
     t.integer "discussion_id"
     t.boolean "approved", default: false
     t.boolean "not_actually_a_question", default: false
+    t.datetime "approved_at"
+    t.bigint "approved_by_id"
+    t.index ["approved_by_id"], name: "index_messages_on_approved_by_id"
   end
 
   create_table "notifications", force: :cascade do |t|


### PR DESCRIPTION
## :dart: Goal
Add `approved_at` and `approved_by` fields to `Message` to save moderator who approved it

## :memo: Details
This is convenient to filter and visualize moderators forum activity

## :warning: Dependencies
https://github.com/mumuki/mumuki-domain/pull/195

## :back: Backwards compatibility
No problems