### PR TITLE
Chore delegate user discussion name

### DIFF
--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -12,7 +12,7 @@ module DiscussionsHelper
   end
 
   def user_discussions_link
-    discussions_link user_discussions_icon(t(:my_doubts)), user_path(anchor: 'discussions') if current_user.watched_discussions.present?
+    discussions_link(user_discussions_icon(t(:my_doubts)), discussions_user_path) if current_user.watched_discussions.present?
   end
 
   def others_discussions_icon(text)

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -195,4 +195,8 @@ module DiscussionsHelper
   def should_show_approved_for?(user, message)
     !user&.moderator_here? && message.approved? && !message.from_moderator?
   end
+
+  def discussion_user_name(user)
+    user.name
+  end
 end

--- a/app/views/discussions/_description_message.html.erb
+++ b/app/views/discussions/_description_message.html.erb
@@ -2,7 +2,7 @@
   <div class="discussion-message-bubble">
     <div class="discussion-message-bubble-header">
       <div class="discussion-message-bubble-title">
-        <%= discussion.initiator.name %>
+        <%= discussion_user_name(discussion.initiator) %>
         <span class="message-date">
           <%= t(:time_since, time: time_ago_in_words(discussion.created_at)) %>
         </span>

--- a/app/views/discussions/_message.html.erb
+++ b/app/views/discussions/_message.html.erb
@@ -2,7 +2,7 @@
   <div class="discussion-message-bubble">
     <div class="discussion-message-bubble-header">
       <div class="discussion-message-bubble-title">
-        <%= user.name %>
+        <%= discussion_user_name user %>
         <% if user.moderator_here? %>
           <span class="moderator-badge"><%= t(:moderation) %></span>
         <% end %>


### PR DESCRIPTION
## :dart: Goal

Let other apps replace a discusser's `name` in the forum with whatever they need.

## :memo: Details

Also fix that the `My discussions` link wasn't working since https://github.com/mumuki/mumuki-laboratory/pull/1566

