### PR TITLE
Feature forum message preview

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/discussions.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/discussions.js
@@ -3,11 +3,11 @@ mumuki.load(() => {
   var $upvoteSpans = $('.discussion-upvote > span');
   let $messagePreviewButton = $('.discussion-new-message-preview-button.preview');
   let $messageEditButton = $('.discussion-new-message-preview-button.edit');
-  let $discussionNewMessageContent = $('.discussion-new-message-content');
-  let $newDiscussionMessagePreview = $('#new-discussion-message-preview');
+  let $newMessageContent = $('.discussion-new-message-content');
+  let $newMessagePreview = $('#discussion-new-message-preview');
 
   function createNewMessageEditor() {
-    var $textarea = $("#new-discussion-message");
+    var $textarea = $("#discussion-new-message");
     var textarea = $textarea[0];
     if (!textarea) return;
 
@@ -96,7 +96,7 @@ mumuki.load(() => {
   };
 
   function showPreview(preview) {
-    $newDiscussionMessagePreview.html($.parseHTML(preview));
+    $newMessagePreview.html($.parseHTML(preview));
     togglePreviewAndEditButtons();
     togglePreviewAndContentMessage();
   }
@@ -107,8 +107,8 @@ mumuki.load(() => {
   }
 
   function togglePreviewAndContentMessage() {
-    $newDiscussionMessagePreview.toggleClass('hidden');
-    $discussionNewMessageContent.toggleClass('hidden');
+    $newMessagePreview.toggleClass('hidden');
+    $newMessageContent.toggleClass('hidden');
   }
 
   mumuki.Forum = Forum;

--- a/app/assets/javascripts/mumuki_laboratory/application/discussions.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/discussions.js
@@ -1,6 +1,7 @@
 mumuki.load(() => {
   var $subscriptionSpans = $('.discussion-subscription > span');
   var $upvoteSpans = $('.discussion-upvote > span');
+  let $messagePreview = $('#mu-message-preview');
 
   function createNewMessageEditor() {
     var $textarea = $("#new-discussion-message");
@@ -26,7 +27,7 @@ mumuki.load(() => {
   }
 
   createReadOnlyEditors();
-  createNewMessageEditor();
+  let editor = createNewMessageEditor();
 
   var Forum = {
     toggleButton: function (spans) {
@@ -67,6 +68,16 @@ mumuki.load(() => {
       const params = new URLSearchParams(location.search);
       elem.is(':checked') ? params.set(key, elem.val()) : params.delete(key);
       location.search = params.toString();
+    },
+    discussionMessagePreview: function (url) {
+      return Forum.tokenRequest({
+        url: url,
+        method: 'GET',
+        processData: false,
+        dataType: 'json',
+        data: new URLSearchParams({ content: encodeURIComponent(editor.getValue()) } ),
+        xhrFields: {withCredentials: true}
+      });
     }
   };
 

--- a/app/assets/javascripts/mumuki_laboratory/application/discussions.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/discussions.js
@@ -2,7 +2,8 @@ mumuki.load(() => {
   var $subscriptionSpans = $('.discussion-subscription > span');
   var $upvoteSpans = $('.discussion-upvote > span');
   let $messagePreviewButton = $('.discussion-new-message-preview-button');
-  let $messagePreview = $('#mu-message-preview');
+  let $discussionNewMessageContent = $('.discussion-new-message-content')
+  let $newDiscussionMessagePreview = $('#new-discussion-message-preview');
 
   function createNewMessageEditor() {
     var $textarea = $("#new-discussion-message");
@@ -86,7 +87,9 @@ mumuki.load(() => {
   };
 
   function showPreview(preview) {
-    $messagePreview.html($.parseHTML(preview));
+    $newDiscussionMessagePreview.html($.parseHTML(preview));
+    $newDiscussionMessagePreview.toggleClass('hidden');
+    $discussionNewMessageContent.toggleClass('hidden');
   }
 
   mumuki.Forum = Forum;

--- a/app/assets/javascripts/mumuki_laboratory/application/discussions.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/discussions.js
@@ -82,6 +82,10 @@ mumuki.load(() => {
         success: function (response) {
           showPreview(response.preview);
         },
+        error: function (e) {
+          error = $messagePreviewButton.attr('error-text');
+          showPreview(error);
+        },
         xhrFields: {withCredentials: true}
       });
     },

--- a/app/assets/javascripts/mumuki_laboratory/application/discussions.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/discussions.js
@@ -1,8 +1,9 @@
 mumuki.load(() => {
   var $subscriptionSpans = $('.discussion-subscription > span');
   var $upvoteSpans = $('.discussion-upvote > span');
-  let $messagePreviewButton = $('.discussion-new-message-preview-button');
-  let $discussionNewMessageContent = $('.discussion-new-message-content')
+  let $messagePreviewButton = $('.discussion-new-message-preview-button.preview');
+  let $messageEditButton = $('.discussion-new-message-preview-button.edit');
+  let $discussionNewMessageContent = $('.discussion-new-message-content');
   let $newDiscussionMessagePreview = $('#new-discussion-message-preview');
 
   function createNewMessageEditor() {
@@ -83,11 +84,25 @@ mumuki.load(() => {
         },
         xhrFields: {withCredentials: true}
       });
+    },
+    hidePreviewAndShowEditor: function(elem) {
+      togglePreviewAndEditButtons();
+      togglePreviewAndContentMessage();
     }
   };
 
   function showPreview(preview) {
     $newDiscussionMessagePreview.html($.parseHTML(preview));
+    togglePreviewAndEditButtons();
+    togglePreviewAndContentMessage();
+  }
+
+  function togglePreviewAndEditButtons() {
+    $messagePreviewButton.toggleClass('hidden');
+    $messageEditButton.toggleClass('hidden');
+  }
+
+  function togglePreviewAndContentMessage() {
     $newDiscussionMessagePreview.toggleClass('hidden');
     $discussionNewMessageContent.toggleClass('hidden');
   }

--- a/app/assets/javascripts/mumuki_laboratory/application/discussions.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/discussions.js
@@ -78,7 +78,7 @@ mumuki.load(() => {
         method: 'GET',
         processData: false,
         dataType: 'json',
-        data: new URLSearchParams({ content: encodeURIComponent(editor.getValue()) } ),
+        data: new URLSearchParams({ content: editor.getValue() } ),
         success: function (response) {
           showPreview(response.preview);
         },

--- a/app/assets/javascripts/mumuki_laboratory/application/discussions.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/discussions.js
@@ -1,6 +1,7 @@
 mumuki.load(() => {
   var $subscriptionSpans = $('.discussion-subscription > span');
   var $upvoteSpans = $('.discussion-upvote > span');
+  let $messagePreviewButton = $('.discussion-new-message-preview-button');
   let $messagePreview = $('#mu-message-preview');
 
   function createNewMessageEditor() {
@@ -76,10 +77,17 @@ mumuki.load(() => {
         processData: false,
         dataType: 'json',
         data: new URLSearchParams({ content: encodeURIComponent(editor.getValue()) } ),
+        success: function (response) {
+          showPreview(response.preview);
+        },
         xhrFields: {withCredentials: true}
       });
     }
   };
+
+  function showPreview(preview) {
+    $messagePreview.html($.parseHTML(preview));
+  }
 
   mumuki.Forum = Forum;
 

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
@@ -287,9 +287,21 @@ summary.discussion-summary {
   }
 }
 
+.discussion-new-message-buttons {
+  display: flex;
+  margin: 0 -10px;
+
+  .btn {
+    margin: 15px 10px;
+  }
+}
+
+.discussion-new-message-preview-button {
+  flex-grow: 0.2;
+}
+
 .discussion-new-message-button {
-  border-radius: 0;
-  margin-top: 15px;
+  flex-grow: 1;
 }
 
 .discussion-message {

--- a/app/controllers/discussions_messages_controller.rb
+++ b/app/controllers/discussions_messages_controller.rb
@@ -16,7 +16,7 @@ class DiscussionsMessagesController < AjaxController
   end
 
   def preview
-    render json: { preview: Message.new(content: URI.decode(params[:content])).content_html }
+    render json: { preview: Message.new(content: params[:content]).content_html }
   end
 
   def approve

--- a/app/controllers/discussions_messages_controller.rb
+++ b/app/controllers/discussions_messages_controller.rb
@@ -3,7 +3,7 @@ class DiscussionsMessagesController < AjaxController
 
   before_action :set_discussion!, only: [:create, :destroy]
   before_action :authorize_user!, only: [:destroy]
-  before_action :authorize_moderator!, only: [:question, :approve]
+  before_action :authorize_moderator!, only: [:question, :approve, :preview]
 
   def create
     @discussion.submit_message! message_params, current_user

--- a/app/controllers/discussions_messages_controller.rb
+++ b/app/controllers/discussions_messages_controller.rb
@@ -15,6 +15,10 @@ class DiscussionsMessagesController < AjaxController
     redirect_back(fallback_location: root_path)
   end
 
+  def preview
+    render json: { preview: Message.new(content: URI.decode(params[:content])).content_html }
+  end
+
   def approve
     current_message.toggle_approved!
     head :ok

--- a/app/views/discussions/_new_message.html.erb
+++ b/app/views/discussions/_new_message.html.erb
@@ -12,7 +12,7 @@
             <div class="discussion-new-message-content">
               <%= f.editor :content, '', { id: 'new-discussion-message', class: 'form-control', placeholder: t(:message) } %>
             </div>
-            <div id="mu-message-preview"></div>
+            <div class="discussion-message-content hidden" id="new-discussion-message-preview"></div>
           </div>
         </div>
       </div>

--- a/app/views/discussions/_new_message.html.erb
+++ b/app/views/discussions/_new_message.html.erb
@@ -19,7 +19,7 @@
     </div>
     <div class="discussion-new-message-buttons">
       <% if user.moderator_here? %>
-        <button class="btn btn-default discussion-new-message-preview-button preview" type="button"
+        <button class="btn btn-default discussion-new-message-preview-button preview" type="button" error-text="<%= t :preview_error %>"
                 onclick="mumuki.Forum.discussionMessagePreview('<%= discussion_preview_message_url(@discussion) %>')"> <%= t :preview %> </button>
         <button class="btn btn-default discussion-new-message-preview-button edit hidden" type="button"
                 onclick="mumuki.Forum.hidePreviewAndShowEditor()"> <%= t :edit_message %> </button>

--- a/app/views/discussions/_new_message.html.erb
+++ b/app/views/discussions/_new_message.html.erb
@@ -20,7 +20,7 @@
     <div class="discussion-new-message-buttons">
       <% if user.moderator_here? %>
         <button class="btn btn-default discussion-new-message-preview-button preview" type="button" error-text="<%= t :preview_error %>"
-                onclick="mumuki.Forum.discussionMessagePreview('<%= discussion_preview_message_url(@discussion) %>')"> <%= t :preview %> </button>
+                onclick="mumuki.Forum.discussionMessagePreview('<%= preview_discussion_message_url %>')"> <%= t :preview %> </button>
         <button class="btn btn-default discussion-new-message-preview-button edit hidden" type="button"
                 onclick="mumuki.Forum.hidePreviewAndShowEditor()"> <%= t :edit_message %> </button>
       <% end %>

--- a/app/views/discussions/_new_message.html.erb
+++ b/app/views/discussions/_new_message.html.erb
@@ -12,12 +12,13 @@
             <div class="discussion-new-message-content">
               <%= f.editor :content, '', { id: 'new-discussion-message', class: 'form-control', placeholder: t(:message) } %>
             </div>
+            <div id="mu-message-preview"></div>
           </div>
         </div>
       </div>
     </div>
     <div class="discussion-new-message-buttons">
-      <button class="btn btn-default discussion-new-message-preview-button"> <%= t :preview %> </button>
+      <button class="btn btn-default discussion-new-message-preview-button" type="button" onclick="mumuki.Forum.discussionMessagePreview('<%= discussion_preview_message_url(@discussion) %>')"> <%= t :preview %> </button>
       <%= f.submit t(:comment), class: 'btn btn-success discussion-new-message-button' %>
     </div>
   <% end %>

--- a/app/views/discussions/_new_message.html.erb
+++ b/app/views/discussions/_new_message.html.erb
@@ -16,6 +16,6 @@
         </div>
       </div>
     </div>
-    <button class="btn btn-success btn-block discussion-new-message-button"> <%= t :comment %> </button>
+    <%= f.submit t(:comment), class: 'btn btn-success btn-block discussion-new-message-button' %>
   <% end %>
 <% end %>

--- a/app/views/discussions/_new_message.html.erb
+++ b/app/views/discussions/_new_message.html.erb
@@ -18,8 +18,12 @@
       </div>
     </div>
     <div class="discussion-new-message-buttons">
-      <button class="btn btn-default discussion-new-message-preview-button preview" type="button" onclick="mumuki.Forum.discussionMessagePreview('<%= discussion_preview_message_url(@discussion) %>')"> <%= t :preview %> </button>
-      <button class="btn btn-default discussion-new-message-preview-button edit hidden" type="button" onclick="mumuki.Forum.hidePreviewAndShowEditor()"> <%= t :edit_message %> </button>
+      <% if user.moderator_here? %>
+        <button class="btn btn-default discussion-new-message-preview-button preview" type="button"
+                onclick="mumuki.Forum.discussionMessagePreview('<%= discussion_preview_message_url(@discussion) %>')"> <%= t :preview %> </button>
+        <button class="btn btn-default discussion-new-message-preview-button edit hidden" type="button"
+                onclick="mumuki.Forum.hidePreviewAndShowEditor()"> <%= t :edit_message %> </button>
+      <% end %>
       <%= f.submit t(:comment), class: 'btn btn-success discussion-new-message-button' %>
     </div>
   <% end %>

--- a/app/views/discussions/_new_message.html.erb
+++ b/app/views/discussions/_new_message.html.erb
@@ -16,6 +16,9 @@
         </div>
       </div>
     </div>
-    <%= f.submit t(:comment), class: 'btn btn-success btn-block discussion-new-message-button' %>
+    <div class="discussion-new-message-buttons">
+      <button class="btn btn-default discussion-new-message-preview-button"> <%= t :preview %> </button>
+      <%= f.submit t(:comment), class: 'btn btn-success discussion-new-message-button' %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/discussions/_new_message.html.erb
+++ b/app/views/discussions/_new_message.html.erb
@@ -18,7 +18,8 @@
       </div>
     </div>
     <div class="discussion-new-message-buttons">
-      <button class="btn btn-default discussion-new-message-preview-button" type="button" onclick="mumuki.Forum.discussionMessagePreview('<%= discussion_preview_message_url(@discussion) %>')"> <%= t :preview %> </button>
+      <button class="btn btn-default discussion-new-message-preview-button preview" type="button" onclick="mumuki.Forum.discussionMessagePreview('<%= discussion_preview_message_url(@discussion) %>')"> <%= t :preview %> </button>
+      <button class="btn btn-default discussion-new-message-preview-button edit hidden" type="button" onclick="mumuki.Forum.hidePreviewAndShowEditor()"> <%= t :edit_message %> </button>
       <%= f.submit t(:comment), class: 'btn btn-success discussion-new-message-button' %>
     </div>
   <% end %>

--- a/app/views/discussions/_new_message.html.erb
+++ b/app/views/discussions/_new_message.html.erb
@@ -10,9 +10,9 @@
         <div class="container-fluid">
           <div class="row">
             <div class="discussion-new-message-content">
-              <%= f.editor :content, '', { id: 'new-discussion-message', class: 'form-control', placeholder: t(:message) } %>
+              <%= f.editor :content, '', { id: 'discussion-new-message', class: 'form-control', placeholder: t(:message) } %>
             </div>
-            <div class="discussion-message-content hidden" id="new-discussion-message-preview"></div>
+            <div class="discussion-message-content hidden" id="discussion-new-message-preview"></div>
           </div>
         </div>
       </div>

--- a/app/views/discussions/_new_message.html.erb
+++ b/app/views/discussions/_new_message.html.erb
@@ -20,11 +20,13 @@
     <div class="discussion-new-message-buttons">
       <% if user.moderator_here? %>
         <button class="btn btn-default discussion-new-message-preview-button preview" type="button" error-text="<%= t :preview_error %>"
-                onclick="mumuki.Forum.discussionMessagePreview('<%= preview_discussion_message_url %>')"> <%= t :preview %> </button>
+                onclick="mumuki.Forum.discussionMessagePreview('<%= preview_discussion_message_url %>')"> <%= fa_icon('eye', text: t(:preview)) %> </button>
         <button class="btn btn-default discussion-new-message-preview-button edit hidden" type="button"
-                onclick="mumuki.Forum.hidePreviewAndShowEditor()"> <%= t :edit_message %> </button>
+                onclick="mumuki.Forum.hidePreviewAndShowEditor()"> <%= fa_icon('pencil-alt', text: t(:edit_message)) %> </button>
       <% end %>
-      <%= f.submit t(:comment), class: 'btn btn-success discussion-new-message-button' %>
+      <%= button_tag type: 'submit', class: 'btn btn-success discussion-new-message-button', data: { disable: true } do %>
+        <%= fa_icon('comment', text: t(:comment)) %>
+      <% end %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/discussions/new.html.erb
+++ b/app/views/discussions/new.html.erb
@@ -22,7 +22,7 @@
         <div class="container-fluid">
           <div class="row">
             <div class="discussion-new-message-content">
-              <%= f.editor :description, '', {id: 'new-discussion-message', class: 'form-control', placeholder: t(:discussion_description_placeholder)} %>
+              <%= f.editor :description, '', {id: 'discussion-new-message', class: 'form-control', placeholder: t(:discussion_description_placeholder)} %>
             </div>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,8 +20,8 @@ Rails.application.routes.draw do
         post :approve, on: :member
         post :question, on: :member
       end
-      get '/messages/preview', to: 'discussions_messages#preview', as: :preview_message
     end
+    get '/discussions/messages/preview', to: 'discussions_messages#preview', as: :preview_discussion_message
 
     resources :exam_registrations, only: [:show]
     resources :exam_authorization_requests, only: [:show, :create, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
         post :approve, on: :member
         post :question, on: :member
       end
+      get '/messages/preview', to: 'discussions_messages#preview', as: :preview_message
     end
 
     resources :exam_registrations, only: [:show]

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -79,6 +79,7 @@ en:
   dont_leave_us: Don't leave us! Learning is fun. You just have to keep at it.
   download: Download your solution
   edit: Edit
+  edit_message: Edit message
   edit_profile: Edit profile
   editor_placeholder: "write your solution here..."
   email: Email

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -229,6 +229,7 @@ en:
   permissions: Permissions
   please_fill_profile_data: Please complete your profile data to continue!
   please_validate: 'Please validate your data before continue:'
+  preview: Preview
   previous_exercise: Previous
   problem_with_exercise: '[Mumuki] Problem with exercise: %{title}'
   processing_your_solution: We are processing you solution

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -231,6 +231,7 @@ en:
   please_fill_profile_data: Please complete your profile data to continue!
   please_validate: 'Please validate your data before continue:'
   preview: Preview
+  preview_error: The preview cannot be shown. Check your internet connection or try with a shorter message.
   previous_exercise: Previous
   problem_with_exercise: '[Mumuki] Problem with exercise: %{title}'
   processing_your_solution: We are processing you solution

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -80,6 +80,7 @@ es-CL:
   dont_leave_us: ¡No nos abandones! Aprender a programar es divertido. Sólo tienes que seguir practicando.
   download: "Descarga lo que hiciste"
   edit: Editar
+  edit_message: Editar mensaje
   editor_placeholder: "...escribe tu solución acá..."
   email: Email
   error_description: Esto es lo que se conoce como <span class="error-link">%{error}</span>.

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -236,6 +236,7 @@ es-CL:
   permissions: Permisos
   please_fill_profile_data: ¡Completa tus datos personales para continuar!
   please_validate: 'Estás a punto de ingresar al curso. Para poder ofrecerte una mejor experiencia, por favor valida que tus datos a continuación sean reales y correctos.'
+  preview: Vista previa
   previous_exercise: Anterior
   problem_with_exercise: '[Mumuki] Error con el ejercicio: %{title}'
   processing_your_solution: Estamos procesando tu solución

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -238,6 +238,7 @@ es-CL:
   please_fill_profile_data: ¡Completa tus datos personales para continuar!
   please_validate: 'Estás a punto de ingresar al curso. Para poder ofrecerte una mejor experiencia, por favor valida que tus datos a continuación sean reales y correctos.'
   preview: Vista previa
+  preview_error: No se puede mostrar la vista previa. Revisa tu conexión a internet o prueba con un mensaje más corto.
   previous_exercise: Anterior
   problem_with_exercise: '[Mumuki] Error con el ejercicio: %{title}'
   processing_your_solution: Estamos procesando tu solución

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -249,6 +249,7 @@ es:
   please_fill_profile_data: ¡Completá tus datos personales para continuar!
   please_validate: 'Estás a punto de ingresar al curso. Para poder ofrecerte una mejor experiencia, por favor validá que tus datos a continuación sean reales y correctos.'
   preview: Vista previa
+  preview_error: No se puede mostrar la vista previa. Revisá tu conexión a internet o probá con un mensaje más corto.
   previous_exercise: Anterior
   problem_with_exercise: '[Mumuki] Error con el ejercicio: %{title}'
   processing_your_solution: Estamos procesando tu solución

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -87,6 +87,7 @@ es:
   dont_leave_us: ¡No nos abandones! Aprender a programar es divertido. Sólo tenés que seguir practicando.
   download: "Descargá lo que hiciste"
   edit: Editar
+  edit_message: Editar mensaje
   edit_profile: Editar perfil
   editor_placeholder: "...escribí tu solución acá..."
   email: Email

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -247,6 +247,7 @@ es:
   permissions: Permisos
   please_fill_profile_data: ¡Completá tus datos personales para continuar!
   please_validate: 'Estás a punto de ingresar al curso. Para poder ofrecerte una mejor experiencia, por favor validá que tus datos a continuación sean reales y correctos.'
+  preview: Vista previa
   previous_exercise: Anterior
   problem_with_exercise: '[Mumuki] Error con el ejercicio: %{title}'
   processing_your_solution: Estamos procesando tu solución

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -239,6 +239,7 @@ pt:
   permissions: Permissões
   please_fill_profile_data: Preencha suas informações pessoais para continuar!
   please_validate: Você está prestes a entrar no curso. Para oferecer uma experiência melhor, valide que seus dados abaixo sejam reais e corretos.
+  preview: Vista prévia
   previous_exercise: Anterior
   problem_with_exercise: '[Mumuki] Erro com exercício %{title}'
   processing_your_solution: Estamos processando sua solução

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -241,6 +241,7 @@ pt:
   please_fill_profile_data: Preencha suas informações pessoais para continuar!
   please_validate: Você está prestes a entrar no curso. Para oferecer uma experiência melhor, valide que seus dados abaixo sejam reais e corretos.
   preview: Vista prévia
+  preview_error: A visualizaçao não pode ser mostrada. Verifique sua conexão com a internet ou tente com uma mensagem mais curta.
   previous_exercise: Anterior
   problem_with_exercise: '[Mumuki] Erro com exercício %{title}'
   processing_your_solution: Estamos processando sua solução

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -83,6 +83,7 @@ pt:
   discussions_will_be_here: As perguntas que você fizer no espaço de consulta aparecerão aqui.
   download: Faça o download do que você fez
   edit: Editar
+  edit_message: Editar mensagem
   edit_profile: Editar perfil
   editor_placeholder: ... Escreva sua solução aqui ...
   email: E-mail

--- a/spec/features/discussion_flow_spec.rb
+++ b/spec/features/discussion_flow_spec.rb
@@ -169,6 +169,7 @@ feature 'Discussion Flow', organization_workspace: :test do
           expect(page).to have_text(problem_2.name)
           expect(page).to have_text('Open')
           expect(page).to have_text('Messages')
+          expect(page).not_to have_text('Preview')
           expect(page).not_to have_xpath("//div[@class='discussion-actions']")
         end
 
@@ -180,6 +181,7 @@ feature 'Discussion Flow', organization_workspace: :test do
             expect(page).to have_text(problem_2.name)
             expect(page).to have_text('Open')
             expect(page).to have_text('Messages')
+            expect(page).to have_text('Preview')
             expect(page).to have_xpath("//div[@class='discussion-actions']")
           end
         end


### PR DESCRIPTION
## :dart: Goal

Let moderators preview their forum messages before sending.

## :memo: Details

We'll be keeping this to moderators and up for now as talked with @rgonzalezt and @lauramangifesta. We might extend this to students in the future if we add some kind of document or guidelines for Markdown editing.

## :camera_flash: Screenshots
![image](https://user-images.githubusercontent.com/11304439/111531108-dec55e00-8742-11eb-9c68-d7ffc52cdd84.png)

____
![image](https://user-images.githubusercontent.com/11304439/111531166-ef75d400-8742-11eb-9c74-c872e881f57b.png)

