### PR TITLE
Feature soft delete forum messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,4 +35,4 @@ group :development, :test do
   gem 'binding_of_caller'
 end
 
-gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'feature-soft-delete-forum-messages'
+gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'master'

--- a/Gemfile
+++ b/Gemfile
@@ -34,3 +34,5 @@ group :development, :test do
   gem 'pry-stack_explorer'
   gem 'binding_of_caller'
 end
+
+gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'feature-soft-delete-forum-messages'

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
@@ -325,7 +325,7 @@ $moderator-badge-color: #dd9900;
       }
       .actions {
         float: right;
-        a {
+        > a, .dropdown {
           margin-left: 20px;
           cursor: pointer;
         }

--- a/app/controllers/discussions_messages_controller.rb
+++ b/app/controllers/discussions_messages_controller.rb
@@ -11,7 +11,8 @@ class DiscussionsMessagesController < AjaxController
   end
 
   def destroy
-    current_message.destroy!
+    current_message.soft_delete! params[:motive], current_user
+    current_message.update! not_actually_a_question: true
     redirect_back(fallback_location: root_path)
   end
 

--- a/app/controllers/discussions_messages_controller.rb
+++ b/app/controllers/discussions_messages_controller.rb
@@ -14,7 +14,6 @@ class DiscussionsMessagesController < AjaxController
     authorize_moderator! unless params[:motive] == :self_deleted.to_s
 
     current_message.soft_delete! params[:motive], current_user
-    current_message.update! not_actually_a_question: true
     redirect_back(fallback_location: root_path)
   end
 

--- a/app/controllers/discussions_messages_controller.rb
+++ b/app/controllers/discussions_messages_controller.rb
@@ -11,6 +11,8 @@ class DiscussionsMessagesController < AjaxController
   end
 
   def destroy
+    authorize_moderator! unless params[:motive] == :self_deleted.to_s
+
     current_message.soft_delete! params[:motive], current_user
     current_message.update! not_actually_a_question: true
     redirect_back(fallback_location: root_path)

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -203,4 +203,9 @@ module DiscussionsHelper
   def undo_upvote_icon
     fa_icon 'thumbs-up', type: :regular, text: t(:undo_upvote)
   end
+
+  def discussion_delete_message_link(discussion, message)
+    link_to fa_icon('trash-alt', type: :regular, class: 'fa-lg'), discussion_message_path(discussion, message, motive: :self_deleted),
+            method: :delete, data: { confirm: t(:are_you_sure, action: t(:destroy_message)) }, class: 'discussion-delete-message'
+  end
 end

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -212,7 +212,7 @@ module DiscussionsHelper
   def discussion_delete_message_dropdown(discussion, message)
     %Q{
       <span class="dropdown">
-        #{content_tag :span, fa_icon('trash-alt', type: :regular, class: 'fa-lg'), role: 'menu', 'data-toggle': 'dropdown',
+        #{content_tag :span, fa_icon('trash-alt', type: :regular, class: 'fa-lg'), role: 'menu', 'data-bs-toggle': 'dropdown',
                       class: 'discussion-delete-message', id: 'deleteDiscussionDropdown'}
         <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="deleteDiscussionDropdown">
           #{discussion_delete_message_option discussion, message, :inappropriate_content, 'times-circle'}
@@ -227,7 +227,7 @@ module DiscussionsHelper
     %Q{
       <li>
         #{link_to fa_icon(icon, text: t("deletion_motive.#{motive}.present"), class: 'fa-fw fixed-icon'),
-                  discussion_message_path(discussion, message, motive: motive), method: :delete,
+                  discussion_message_path(discussion, message, motive: motive), method: :delete, class: 'dropdown-item',
                   role: 'menuitem', data: { confirm: t(:are_you_sure, action: t(:destroy_message)) } }
       </li>
     }.html_safe

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -217,6 +217,7 @@ module DiscussionsHelper
         <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="deleteDiscussionDropdown">
           #{discussion_delete_message_option discussion, message, :inappropriate_content, 'times-circle'}
           #{discussion_delete_message_option discussion, message, :shares_solution, :code}
+          #{discussion_delete_message_option discussion, message, :discloses_personal_information, 'user-tag'}
         </ul>
       </span>
     }.html_safe

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -215,18 +215,20 @@ module DiscussionsHelper
         #{content_tag :span, fa_icon('trash-alt', type: :regular, class: 'fa-lg'), role: 'menu', 'data-toggle': 'dropdown',
                       class: 'discussion-delete-message', id: 'deleteDiscussionDropdown'}
         <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="deleteDiscussionDropdown">
-          <li>
-            #{link_to fa_icon('times-circle', text: t("deletion_motive.#{:inappropriate_content}.present"), class: 'fa-fw fixed-icon'),
-                      discussion_message_path(discussion, message, motive: :inappropriate_content), method: :delete,
-                      role: 'menuitem', data: { confirm: t(:are_you_sure, action: t(:destroy_message)) } }
-          </li>
-          <li>
-            #{link_to fa_icon(:code, text: t("deletion_motive.#{:shares_solution}.present"), class: 'fa-fw fixed-icon'),
-                      discussion_message_path(discussion, message, motive: :shares_solution), method: :delete,
-                      role: 'menuitem', data: { confirm: t(:are_you_sure, action: t(:destroy_message)) } }
-          </li>
+          #{discussion_delete_message_option discussion, message, :inappropriate_content, 'times-circle'}
+          #{discussion_delete_message_option discussion, message, :shares_solution, :code}
         </ul>
       </span>
+    }.html_safe
+  end
+
+  def discussion_delete_message_option(discussion, message, motive, icon)
+    %Q{
+      <li>
+        #{link_to fa_icon(icon, text: t("deletion_motive.#{motive}.present"), class: 'fa-fw fixed-icon'),
+                  discussion_message_path(discussion, message, motive: motive), method: :delete,
+                  role: 'menuitem', data: { confirm: t(:are_you_sure, action: t(:destroy_message)) } }
+      </li>
     }.html_safe
   end
 

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -173,7 +173,7 @@ module DiscussionsHelper
   end
 
   def discussion_info(discussion)
-    "#{t(:time_since, time: time_ago_in_words(discussion.created_at))} · #{t(:message_count, count: discussion.messages.size)}"
+    "#{t(:time_since, time: time_ago_in_words(discussion.created_at))} · #{t(:message_count, count: discussion.visible_messages.size)}"
   end
 
   def discussion_filter_params_without_page

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -229,4 +229,8 @@ module DiscussionsHelper
       </div>
     }.html_safe
   end
+
+  def message_deleted_text(message)
+    t(:message_deleted, motive: t("deletion_motive.#{message.deletion_motive}.past").downcase, forum_terms: link_to_forum_terms).html_safe
+  end
 end

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -211,8 +211,8 @@ module DiscussionsHelper
 
   def discussion_delete_message_dropdown(discussion, message)
     %Q{
-      <div class="dropdown">
-        #{content_tag :div, fa_icon('trash-alt', type: :regular, class: 'fa-lg'), role: 'menu', 'data-toggle': 'dropdown',
+      <span class="dropdown">
+        #{content_tag :span, fa_icon('trash-alt', type: :regular, class: 'fa-lg'), role: 'menu', 'data-toggle': 'dropdown',
                       class: 'discussion-delete-message', id: 'deleteDiscussionDropdown'}
         <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="deleteDiscussionDropdown">
           <li>
@@ -226,7 +226,7 @@ module DiscussionsHelper
                       role: 'menuitem', data: { confirm: t(:are_you_sure, action: t(:destroy_message)) } }
           </li>
         </ul>
-      </div>
+      </span>
     }.html_safe
   end
 

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -208,4 +208,25 @@ module DiscussionsHelper
     link_to fa_icon('trash-alt', type: :regular, class: 'fa-lg'), discussion_message_path(discussion, message, motive: :self_deleted),
             method: :delete, data: { confirm: t(:are_you_sure, action: t(:destroy_message)) }, class: 'discussion-delete-message'
   end
+
+  def discussion_delete_message_dropdown(discussion, message)
+    %Q{
+      <div class="dropdown">
+        #{content_tag :div, fa_icon('trash-alt', type: :regular, class: 'fa-lg'), role: 'menu', 'data-toggle': 'dropdown',
+                      class: 'discussion-delete-message', id: 'deleteDiscussionDropdown'}
+        <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="deleteDiscussionDropdown">
+          <li>
+            #{link_to fa_icon('times-circle', text: t("deletion_motive.#{:inappropriate_content}.present"), class: 'fa-fw fixed-icon'),
+                      discussion_message_path(discussion, message, motive: :inappropriate_content), method: :delete,
+                      role: 'menuitem', data: { confirm: t(:are_you_sure, action: t(:destroy_message)) } }
+          </li>
+          <li>
+            #{link_to fa_icon(:code, text: t("deletion_motive.#{:shares_solution}.present"), class: 'fa-fw fixed-icon'),
+                      discussion_message_path(discussion, message, motive: :shares_solution), method: :delete,
+                      role: 'menuitem', data: { confirm: t(:are_you_sure, action: t(:destroy_message)) } }
+          </li>
+        </ul>
+      </div>
+    }.html_safe
+  end
 end

--- a/app/views/discussions/_message.html.erb
+++ b/app/views/discussions/_message.html.erb
@@ -23,7 +23,7 @@
                 </a>
               <% end %>
             <% end %>
-            <%= link_to fa_icon('trash-alt', type: :regular, class: 'fa-lg'), discussion_message_path(@discussion, message),
+            <%= link_to fa_icon('trash-alt', type: :regular, class: 'fa-lg'), discussion_message_path(@discussion, message, motive: :self_deleted),
                         method: :delete, data: { confirm: t(:are_you_sure, action: t(:destroy_message)) }, class: 'discussion-delete-message' %>
           <% end %>
           <% if should_show_approved_for?(current_user, message) %>

--- a/app/views/discussions/_message.html.erb
+++ b/app/views/discussions/_message.html.erb
@@ -41,6 +41,15 @@
       <div class="discussion-message-content">
         <% if message.deleted? %>
           <em><%= message_deleted_text message %></em>
+          <% if current_user&.moderator_here? %>
+            <a href='<%= "#deletedMessage#{message.id}" %>' data-toggle="collapse">
+              <%= t :show_message %>
+            </a>
+            <div id='<%= "deletedMessage#{message.id}" %>' class="collapse">
+              <hr>
+              <%= message.content_html %>
+            </div>
+          <% end %>
         <% else %>
           <%= message.content_html %>
         <% end %>

--- a/app/views/discussions/_message.html.erb
+++ b/app/views/discussions/_message.html.erb
@@ -10,7 +10,7 @@
           <%= t(:time_since, time: time_ago_in_words(message.created_at)) %>
         </span>
         <span class="actions">
-          <% if message.authorized? current_user %>
+          <% if message.authorized?(current_user) && !message.deleted? %>
             <% if current_user&.moderator_here? %>
               <a class="discussion-message-approved <%= 'selected' if message.approved? %>"
                  onclick="mumuki.Forum.discussionMessageToggleApprove('<%= approve_discussion_message_url(@discussion, message) %>', $(this))">

--- a/app/views/discussions/_message.html.erb
+++ b/app/views/discussions/_message.html.erb
@@ -48,7 +48,7 @@
             <hr>
             <%= t :deleted_by, deleter: message.deleted_by.name %>
             <%= t(:time_since, time: time_ago_in_words(message.deleted_at)) %>.
-            <a href='<%= "#deletedMessage#{message.id}" %>' data-toggle="collapse">
+            <a href='<%= "#deletedMessage#{message.id}" %>' data-bs-toggle="collapse">
               <%= t :show_message %>
             </a>
             <div id='<%= "deletedMessage#{message.id}" %>' class="collapse">

--- a/app/views/discussions/_message.html.erb
+++ b/app/views/discussions/_message.html.erb
@@ -23,8 +23,7 @@
                 </a>
               <% end %>
             <% end %>
-            <%= link_to fa_icon('trash-alt', type: :regular, class: 'fa-lg'), discussion_message_path(@discussion, message, motive: :self_deleted),
-                        method: :delete, data: { confirm: t(:are_you_sure, action: t(:destroy_message)) }, class: 'discussion-delete-message' %>
+            <%= discussion_delete_message_link @discussion, message %>
           <% end %>
           <% if should_show_approved_for?(current_user, message) %>
             <span class="discussion-message-approved selected">

--- a/app/views/discussions/_message.html.erb
+++ b/app/views/discussions/_message.html.erb
@@ -23,7 +23,11 @@
                 </a>
               <% end %>
             <% end %>
-            <%= discussion_delete_message_link @discussion, message %>
+            <% if message.from_user? current_user %>
+              <%= discussion_delete_message_link @discussion, message %>
+            <% else %>
+              <%= discussion_delete_message_dropdown @discussion, message %>
+            <% end %>
           <% end %>
           <% if should_show_approved_for?(current_user, message) %>
             <span class="discussion-message-approved selected">

--- a/app/views/discussions/_message.html.erb
+++ b/app/views/discussions/_message.html.erb
@@ -39,7 +39,11 @@
     </div>
     <div class="discussion-message-bubble-content">
       <div class="discussion-message-content">
-        <%= message.content_html %>
+        <% if message.deleted? %>
+          <em><%= message_deleted_text message %></em>
+        <% else %>
+          <%= message.content_html %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/discussions/_message.html.erb
+++ b/app/views/discussions/_message.html.erb
@@ -41,6 +41,9 @@
       <div class="discussion-message-content">
         <% if message.deleted? %>
           <em><%= message_deleted_text message %></em>
+          <% if message.from_user? current_user %>
+            <p><%= t :deleted_message_warning %></p>
+          <% end %>
           <% if current_user&.moderator_here? %>
             <hr>
             <%= t :deleted_by, deleter: message.deleted_by.name %>

--- a/app/views/discussions/_message.html.erb
+++ b/app/views/discussions/_message.html.erb
@@ -12,16 +12,19 @@
         <span class="actions">
           <% if message.authorized? current_user %>
             <% if current_user&.moderator_here? %>
-              <a class="discussion-message-approved <%= 'selected' if message.approved? %>" onclick="mumuki.Forum.discussionMessageToggleApprove('<%= approve_discussion_message_url(@discussion, message) %>', $(this))">
+              <a class="discussion-message-approved <%= 'selected' if message.approved? %>"
+                 onclick="mumuki.Forum.discussionMessageToggleApprove('<%= approve_discussion_message_url(@discussion, message) %>', $(this))">
                 <%= fa_icon(:check, class: 'fa-lg') %>
               </a>
               <% if message.from_initiator? %>
-                <a class="discussion-message-not-actually-a-question <%= 'selected' if message.not_actually_a_question? %>" onclick="mumuki.Forum.discussionMessageToggleNotActuallyAQuestion('<%= question_discussion_message_url(@discussion, message) %>', $(this))">
+                <a class="discussion-message-not-actually-a-question <%= 'selected' if message.not_actually_a_question? %>"
+                   onclick="mumuki.Forum.discussionMessageToggleNotActuallyAQuestion('<%= question_discussion_message_url(@discussion, message) %>', $(this))">
                   <%= fa_icon('question-circle', type: 'regular', class: 'fa-lg') %>
                 </a>
               <% end %>
             <% end %>
-            <%= link_to fa_icon('trash-alt', type: :regular, class: 'fa-lg'), discussion_message_path(@discussion, message), method: :delete, data: { confirm: t(:are_you_sure, action: t(:destroy_message)) }, class: 'discussion-delete-message' %>
+            <%= link_to fa_icon('trash-alt', type: :regular, class: 'fa-lg'), discussion_message_path(@discussion, message),
+                        method: :delete, data: { confirm: t(:are_you_sure, action: t(:destroy_message)) }, class: 'discussion-delete-message' %>
           <% end %>
           <% if should_show_approved_for?(current_user, message) %>
             <span class="discussion-message-approved selected">

--- a/app/views/discussions/_message.html.erb
+++ b/app/views/discussions/_message.html.erb
@@ -42,6 +42,9 @@
         <% if message.deleted? %>
           <em><%= message_deleted_text message %></em>
           <% if current_user&.moderator_here? %>
+            <hr>
+            <%= t :deleted_by, deleter: message.deleted_by.name %>
+            <%= t(:time_since, time: time_ago_in_words(message.deleted_at)) %>.
             <a href='<%= "#deletedMessage#{message.id}" %>' data-toggle="collapse">
               <%= t :show_message %>
             </a>

--- a/app/views/discussions/show.html.erb
+++ b/app/views/discussions/show.html.erb
@@ -37,7 +37,9 @@
         <%= render partial: 'discussions/description_message', locals: {discussion: @discussion} %>
       <% end %>
       <% @discussion.messages.each do |message| %>
-        <%= render partial: 'discussions/message', locals: {user: message.sender_user, message: message} %>
+        <% unless message.self_deleted? %>
+          <%= render partial: 'discussions/message', locals: {user: message.sender_user, message: message} %>
+        <% end %>
       <% end %>
       <% if @discussion.commentable_by?(current_user) %>
         <hr class="message-divider">

--- a/app/views/discussions/show.html.erb
+++ b/app/views/discussions/show.html.erb
@@ -36,10 +36,8 @@
       <% if @discussion.description.present? %>
         <%= render partial: 'discussions/description_message', locals: {discussion: @discussion} %>
       <% end %>
-      <% @discussion.messages.each do |message| %>
-        <% unless message.self_deleted? %>
+      <% @discussion.visible_messages.each do |message| %>
           <%= render partial: 'discussions/message', locals: {user: message.sender_user, message: message} %>
-        <% end %>
       <% end %>
       <% if @discussion.commentable_by?(current_user) %>
         <hr class="message-divider">

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -75,6 +75,9 @@ en:
     shares_solution:
       present: Shares the correct solution
       past: Shared the correct solution
+    discloses_personal_information:
+      present: Discloses personal information
+      past: Disclosed personal information
   description: Description
   destroy: Destroy
   destroy_message: delete the message

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -66,6 +66,7 @@ en:
   create_submission: Submit
   created_at: Created at
   date: Date
+  deleted_by: Deleted by %{deleter}
   deletion_motive:
     inappropriate_content:
       present: Includes inappropriate content

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -66,6 +66,13 @@ en:
   create_submission: Submit
   created_at: Created at
   date: Date
+  deletion_motive:
+    inappropriate_content:
+      present: Includes inappropriate content
+      past: Included inappropriate content
+    shares_solution:
+      present: Shares the correct solution
+      past: Shared the correct solution
   description: Description
   destroy: Destroy
   destroy_message: delete the message
@@ -176,6 +183,7 @@ en:
     one: 1 message
     other: '%{count} messages'
   message: Message
+  message_deleted: This message was deleted because it %{motive}, which violates the %{forum_terms}.
   messages: Messages
   messages_error: Previous messages are unavailable. Please try again later.
   moderation: Mentoring

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -262,6 +262,7 @@ en:
   select_file: Select file
   sending_solution: Sending solution
   show: Show
+  show_message: Show message
   sign_in: Sign in
   sign_in_action: sign in
   sign_out: Sign Out

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -67,6 +67,7 @@ en:
   created_at: Created at
   date: Date
   deleted_by: Deleted by %{deleter}
+  deleted_message_warning: If you repeateadly violate these or other rules, you may be prohibited from accessing the forum or you may suffer more severe consequences, such as being expulsed from the course.
   deletion_motive:
     inappropriate_content:
       present: Includes inappropriate content

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -65,6 +65,7 @@ es-CL:
   created_exercises: Ejercicios Creados
   created_guides: Lecciones Creadas
   date: Fecha
+  deleted_by: Eliminado por %{deleter}
   deletion_motive:
     inappropriate_content:
       present: Incluye contenido inapropiado

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -65,6 +65,13 @@ es-CL:
   created_exercises: Ejercicios Creados
   created_guides: Lecciones Creadas
   date: Fecha
+  deletion_motive:
+    inappropriate_content:
+      present: Incluye contenido inapropiado
+      past: Incluía contenido inapropiado
+    shares_solution:
+      present: Comparte la solución correcta
+      past: Compartía la solución correcta
   day: Día
   days: Días
   description: Descripción
@@ -176,6 +183,7 @@ es-CL:
     one: 1 mensaje
     other: '%{count} mensajes'
   message: Mensaje
+  message_deleted: Este mensaje fue eliminado porque %{motive}, lo cual infringe las %{forum_terms}.
   messages: Mensajes
   messages_error: Los mensajes anteriores no están disponibles en este momento. ¡Vuelve a intentar más tarde!
   messages_pluralized:

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -66,6 +66,7 @@ es-CL:
   created_guides: Lecciones Creadas
   date: Fecha
   deleted_by: Eliminado por %{deleter}
+  deleted_message_warning: Si infringes reiteradamente estas u otras reglas del Espacio de Consultas, se te puede prohibir el acceso al mismo o podrás sufrir consecuencias más severas, como la expulsión del curso.
   deletion_motive:
     inappropriate_content:
       present: Incluye contenido inapropiado

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -74,6 +74,9 @@ es-CL:
     shares_solution:
       present: Comparte la solución correcta
       past: Compartía la solución correcta
+    discloses_personal_information:
+      present: Divulga información personal
+      past: Divulgaba información personal
   day: Día
   days: Días
   description: Descripción

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -267,6 +267,7 @@ es-CL:
   send: Enviar
   sending_solution: Enviando solución
   show: Mostrar
+  show_message: Mostrar mensaje
   sign_in: Inicia sesión
   sign_in_action: iniciar sesión
   sign_out: Cerrar Sesión

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -72,6 +72,7 @@ es:
   created_guides: Lecciones Creadas
   date: Fecha
   deleted_by: Eliminado por %{deleter}
+  deleted_message_warning: Si infringís reiteradamente estas u otras reglas del Espacio de Consultas, se te puede prohibir el acceso al mismo o podrás sufrir consecuencias más severas, como la expulsión del curso.
   deletion_motive:
     inappropriate_content:
       present: Incluye contenido inapropiado

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -71,6 +71,7 @@ es:
   created_exercises: Ejercicios Creados
   created_guides: Lecciones Creadas
   date: Fecha
+  deleted_by: Eliminado por %{deleter}
   deletion_motive:
     inappropriate_content:
       present: Incluye contenido inapropiado

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -282,6 +282,7 @@ es:
   send: Enviar
   sending_solution: Enviando solución
   show: Mostrar
+  show_message: Mostrar mensaje
   sign_in: Iniciá sesión
   sign_in_action: iniciar sesión
   sign_out: Cerrar Sesión

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -71,6 +71,13 @@ es:
   created_exercises: Ejercicios Creados
   created_guides: Lecciones Creadas
   date: Fecha
+  deletion_motive:
+    inappropriate_content:
+      present: Incluye contenido inapropiado
+      past: Incluía contenido inapropiado
+    shares_solution:
+      present: Comparte la solución correcta
+      past: Compartía la solución correcta
   day: Día
   days: Días
   description: Descripción
@@ -187,6 +194,7 @@ es:
     one: 1 mensaje
     other: '%{count} mensajes'
   message: Mensaje
+  message_deleted: Este mensaje fue eliminado porque %{motive}, lo cual infringe las %{forum_terms}.
   messages: Mensajes
   messages_error: Los mensajes anteriores no están disponibles en este momento. ¡Volvé a intentar mas tarde!
   messages_pluralized:

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -80,6 +80,9 @@ es:
     shares_solution:
       present: Comparte la solución correcta
       past: Compartía la solución correcta
+    discloses_personal_information:
+      present: Divulga información personal
+      past: Divulgaba información personal
   day: Día
   days: Días
   description: Descripción

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -76,6 +76,9 @@ pt:
     shares_solution:
       present: Compartilhe a solução correta
       past: Compartilhou a solução correta
+    discloses_personal_information:
+      present: Divulga informações pessoais
+      past: Divulgar informações pessoais
   day: Dia
   days: Dias
   description: Descrição

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -1,4 +1,3 @@
----
 pt:
   aborted: Opa, não pudemos avaliar sua solução
   abort_explanation_html: <li>Verifique se o seu programa não possui recursão ou um loop infinito</li> <li>Verifique se você tem uma conexão com a internet</li> <li>Espere um pouco e tente novamente</li>
@@ -68,6 +67,13 @@ pt:
   created_exercises: Exercícios criados
   created_guides: Lições criadas
   date: Data
+  deletion_motive:
+    inappropriate_content:
+      present: Inclui conteúdo impróprio
+      past: Incluiu conteúdo impróprio
+    shares_solution:
+      present: Compartilhe a solução correta
+      past: Compartilhou a solução correta
   day: Dia
   days: Dias
   description: Descrição
@@ -181,6 +187,7 @@ pt:
     one: 1 mensagem
     other: '%{count} mensagens'
   message: Mensagem
+  message_deleted: Esta mensagem foi excluída porque %{motive}, o que viola as %{forum_terms}.
   messages: Mensagens
   messages_error: As mensagens acima não estão disponíveis no momento. Eu tentei novamente mais tarde!
     mais tarde!

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -68,6 +68,7 @@ pt:
   created_guides: Lições criadas
   date: Data
   deleted_by: Removido pelo
+  deleted_message_warning: Se você violar repetidamente essas ou outras regras da Área de Consulta, seu acesso a ela pode ser proibido ou você pode sofrer consequências mais graves, como a expulsão do curso.
   deletion_motive:
     inappropriate_content:
       present: Inclui conteúdo impróprio

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -67,6 +67,7 @@ pt:
   created_exercises: Exercícios criados
   created_guides: Lições criadas
   date: Data
+  deleted_by: Removido pelo
   deletion_motive:
     inappropriate_content:
       present: Inclui conteúdo impróprio

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -271,6 +271,7 @@ pt:
   send: Enviar
   sending_solution: Solução de envio
   show: Mostrar
+  show_message: Mostrar mensagem
   sign_in: Iniciar sessão
   sign_in_action: iniciar sessão
   sign_out: Fechar Sessão

--- a/spec/controllers/discussions_messages_controller_spec.rb
+++ b/spec/controllers/discussions_messages_controller_spec.rb
@@ -31,6 +31,72 @@ describe DiscussionsMessagesController, type: :controller, organization_workspac
     end
   end
 
+  describe 'delete' do
+    let(:message) { create(:message, discussion: discussion, sender: student.uid) }
+
+    describe 'for student' do
+      before { set_current_user! student }
+
+      describe 'own message with permitted motive' do
+        before do
+          delete :destroy, params: {id: message.id, discussion_id: discussion.id, motive: :self_deleted}
+          message.reload
+        end
+
+        it { expect(response.status).to eq 302 }
+        it { expect(message.deleted?).to be true }
+        it { expect(message.deleted_by).to eq student }
+        it { expect(message.deleted_at).to_not eq nil }
+        it { expect(message.deletion_motive).to eq 'self_deleted' }
+        it { expect(message.not_actually_a_question).to be true }
+      end
+
+      describe 'own message with forbidden motive' do
+        before do
+          delete :destroy, params: {id: message.id, discussion_id: discussion.id, motive: :shares_solution}
+          message.reload
+        end
+
+        it { expect(response.status).to eq 403 }
+        it { expect(message.deleted?).to be false }
+        it { expect(message.deleted_by).to eq nil }
+        it { expect(message.deleted_at).to eq nil }
+        it { expect(message.deletion_motive).to eq nil }
+        it { expect(message.not_actually_a_question).to be false }
+      end
+
+      describe 'someone else\'s message' do
+        let(:message) { create(:message, discussion: discussion, sender: moderator.uid) }
+        before do
+          delete :destroy, params: {id: message.id, discussion_id: discussion.id, motive: :self_deleted}
+          message.reload
+        end
+
+        it { expect(response.status).to eq 403 }
+        it { expect(message.deleted?).to be false }
+        it { expect(message.deleted_by).to eq nil }
+        it { expect(message.deleted_at).to eq nil }
+        it { expect(message.deletion_motive).to eq nil }
+        it { expect(message.not_actually_a_question).to be false }
+      end
+    end
+
+    describe 'for moderator' do
+      before do
+        set_current_user! moderator
+        delete :destroy, params: {id: message.id, discussion_id: discussion.id, motive: :inappropriate_content}
+        message.reload
+      end
+
+      it { expect(response.status).to eq 302 }
+      it { expect(message.deleted?).to be true }
+      it { expect(message.deleted_by).to eq moderator }
+      it { expect(message.deleted_at).to_not eq nil }
+      it { expect(message.deletion_motive).to eq 'inappropriate_content' }
+      it { expect(message.not_actually_a_question).to be true }
+    end
+  end
+
   describe 'approve' do
     let(:message) { create(:message, discussion: discussion, sender: student.uid) }
 
@@ -42,7 +108,7 @@ describe DiscussionsMessagesController, type: :controller, organization_workspac
       it { expect(message.reload.approved).to be false }
     end
 
-    describe 'for student' do
+    describe 'for moderator' do
       before { set_current_user! moderator }
       before { post :approve, params: {id: message.id, discussion_id: discussion.id} }
 
@@ -62,7 +128,7 @@ describe DiscussionsMessagesController, type: :controller, organization_workspac
       it { expect(message.reload.not_actually_a_question).to be false }
     end
 
-    describe 'for student' do
+    describe 'for moderator' do
       before { set_current_user! moderator }
       before { post :question, params: {id: message.id, discussion_id: discussion.id} }
 

--- a/spec/controllers/discussions_messages_controller_spec.rb
+++ b/spec/controllers/discussions_messages_controller_spec.rb
@@ -48,7 +48,6 @@ describe DiscussionsMessagesController, type: :controller, organization_workspac
         it { expect(message.deleted_by).to eq student }
         it { expect(message.deleted_at).to_not eq nil }
         it { expect(message.deletion_motive).to eq 'self_deleted' }
-        it { expect(message.not_actually_a_question).to be true }
       end
 
       describe 'own message with forbidden motive' do
@@ -62,7 +61,6 @@ describe DiscussionsMessagesController, type: :controller, organization_workspac
         it { expect(message.deleted_by).to eq nil }
         it { expect(message.deleted_at).to eq nil }
         it { expect(message.deletion_motive).to eq nil }
-        it { expect(message.not_actually_a_question).to be false }
       end
 
       describe 'someone else\'s message' do
@@ -77,7 +75,6 @@ describe DiscussionsMessagesController, type: :controller, organization_workspac
         it { expect(message.deleted_by).to eq nil }
         it { expect(message.deleted_at).to eq nil }
         it { expect(message.deletion_motive).to eq nil }
-        it { expect(message.not_actually_a_question).to be false }
       end
     end
 
@@ -93,7 +90,6 @@ describe DiscussionsMessagesController, type: :controller, organization_workspac
       it { expect(message.deleted_by).to eq moderator }
       it { expect(message.deleted_at).to_not eq nil }
       it { expect(message.deletion_motive).to eq 'inappropriate_content' }
-      it { expect(message.not_actually_a_question).to be true }
     end
   end
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210330175706) do
+ActiveRecord::Schema.define(version: 20210318191512) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -381,7 +381,11 @@ ActiveRecord::Schema.define(version: 20210330175706) do
     t.boolean "not_actually_a_question", default: false
     t.datetime "approved_at"
     t.bigint "approved_by_id"
+    t.integer "deletion_motive"
+    t.datetime "deleted_at"
+    t.bigint "deleted_by_id"
     t.index ["approved_by_id"], name: "index_messages_on_approved_by_id"
+    t.index ["deleted_by_id"], name: "index_messages_on_deleted_by_id"
   end
 
   create_table "notifications", force: :cascade do |t|

--- a/spec/features/discussion_flow_spec.rb
+++ b/spec/features/discussion_flow_spec.rb
@@ -162,6 +162,7 @@ feature 'Discussion Flow', organization_workspace: :test do
       end
 
       context 'and forum enabled' do
+        let!(:problem_2_discussion_message) { create(:message, discussion: problem_2_discussions.first, sender: another_student.uid) }
         before { Organization.current.update! forum_enabled: true }
 
         scenario 'newly created discussion' do
@@ -170,7 +171,11 @@ feature 'Discussion Flow', organization_workspace: :test do
           expect(page).to have_text('Open')
           expect(page).to have_text('Messages')
           expect(page).not_to have_text('Preview')
+          expect(page).to have_text(problem_2_discussion_message.content)
           expect(page).not_to have_xpath("//div[@class='discussion-actions']")
+          expect(page).to_not have_text('Includes inappropriate content')
+          expect(page).to_not have_text('Shares the correct solution')
+          expect(page).to_not have_text('Discloses personal information')
         end
 
         context 'for moderator' do
@@ -182,11 +187,14 @@ feature 'Discussion Flow', organization_workspace: :test do
             expect(page).to have_text('Open')
             expect(page).to have_text('Messages')
             expect(page).to have_text('Preview')
+            expect(page).to have_text(problem_2_discussion_message.content)
             expect(page).to have_xpath("//div[@class='discussion-actions']")
+            expect(page).to have_text('Includes inappropriate content')
+            expect(page).to have_text('Shares the correct solution')
+            expect(page).to have_text('Discloses personal information')
           end
         end
       end
     end
   end
-
 end


### PR DESCRIPTION
## :dart: Goal

Soft delete forum messages. Moderators can pick a motive.

## :memo: Details

https://github.com/mumuki/mumuki-domain/pull/206

## :camera_flash: Screenshots

![image](https://user-images.githubusercontent.com/11304439/114924870-cf4e3900-9e04-11eb-9628-8ee6a0c1f314.png)

![image](https://user-images.githubusercontent.com/11304439/114925051-fe64aa80-9e04-11eb-8996-4db32cb416b4.png)

![image](https://user-images.githubusercontent.com/11304439/114925110-10dee400-9e05-11eb-9af1-cc1889a1751c.png)


## :construction: TODO

* ~See mergeability~
* ~Add tests~
* ~I think some are breaking because of some missing migration or something~
* ~Implement some of the suggestions~
