### PR TITLE
Chore immersive fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,3 +40,6 @@ group :development, :test do
   gem 'teaspoon-jasmine'
   gem 'selenium-webdriver'
 end
+
+gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'chore-retenantize'
+gem 'mumukit-platform', github: 'mumuki/mumukit-platform', branch: 'chore-untenantize'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -91,14 +91,14 @@ class ApplicationController < ActionController::Base
   end
 
   def current_immersive_path_for(context, content)
-    resource = content ? polymorphic_path(content) : default_immersive_path_for(context)
-    context.url_for resource
+    resource_path = content ? polymorphic_path(content) : default_immersive_path_for(context)
+    context.retenantized_url_for(resource_path)
   end
 
   private
 
   def default_immersive_path_for(context)
-    subject.present? ? root_path : inorganic_path_for(request)
+    subject.present? ? root_path : request.path_info
   end
 
   def inorganic_path_for(request)

--- a/spec/features/immersive_redirection_spec.rb
+++ b/spec/features/immersive_redirection_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 feature 'Immersive redirection Flow', organization_workspace: :test, subdomain_redirection_without_port: true do
   def create_guide(name)
-    create(:guide, name: name)
+    create(:guide, name: name, exercises: create_list(:exercise, 3))
   end
 
   def create_immersive_organization(name, guides)
@@ -26,6 +26,9 @@ feature 'Immersive redirection Flow', organization_workspace: :test, subdomain_r
   let(:lesson_one) { create(:lesson, guide: guide_one) }
   let(:lesson_two) { create(:lesson, guide: guide_two) }
   let(:lesson_three) { create(:lesson, guide: guide_three) }
+
+  let(:discussion_exercise) { guide_one.exercises.first }
+  let(:discussion) { create(:discussion, item: discussion_exercise, organization: Organization.current) }
 
   before { book.update! chapters: [create(:chapter, lessons: [lesson_one, lesson_two, lesson_three])] }
   before { set_current_user! user }
@@ -79,6 +82,21 @@ feature 'Immersive redirection Flow', organization_workspace: :test, subdomain_r
     end
 
     context 'when navigating to a discussion' do
+      feature 'and forum enabled' do
+        before { immersive_orga.update(forum_enabled: true) }
+        before { visit exercise_discussion_path(discussion_exercise, discussion) }
+        it_behaves_like 'immersive redirection', 'immersive-orga'
+        it_behaves_like 'navigate to discussions main page'
+      end
+
+      feature 'and forum not enabled' do
+        before { visit exercise_discussion_path(discussion_exercise, discussion) }
+        it_behaves_like 'immersive redirection', 'immersive-orga'
+        it_behaves_like 'navigate to main page'
+      end
+    end
+
+    context 'when navigating to discussions page' do
       feature 'and forum enabled' do
         before { immersive_orga.update(forum_enabled: true) }
         before { visit discussions_path }


### PR DESCRIPTION
## :dart: Goal
Fix immersive redirections

## :memo: Details
You'll see that I'm not adding or changing any tests. This is because we are currently using `Subdomain` as the default organization_mapping and this PRs fixes the `Path` scenarios that were failing but they are untested.

## :warning: Dependencies
https://github.com/mumuki/mumuki-domain/pull/207
https://github.com/mumuki/mumukit-platform/pull/46

## :back: Backwards compatibility
100%

## :soon: Future work
Use `Path` as organization_mapping for tests
