### PR TITLE
Fix exam breaks on next for

### DIFF
--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 5.1.6"
 
-  s.add_dependency 'mumuki-domain', '~> 9.1.1'
+  s.add_dependency 'mumuki-domain', '~> 9.1.2'
   s.add_dependency 'mumukit-bridge', '~> 4.1'
   s.add_dependency 'mumukit-login', '~> 7.6'
   s.add_dependency 'mumukit-nuntius', '~> 6.1'

--- a/spec/helpers/with_navigation_spec.rb
+++ b/spec/helpers/with_navigation_spec.rb
@@ -116,5 +116,20 @@ describe WithStudentPathNavigation, organization_workspace: :test do
 
       it { expect(next_button(lesson_1)).to include "<a class=\"btn btn-complementary w-100\" role=\"button\" href=\"/chapters/#{chapter_2.friendly_name}\"><span class=\"fa5-text-r\">Next: #{chapter_2.name}</span><i class=\"fas fa-chevron-right\"></i></a>" }
     end
+
+    context "when finishing an exam" do
+      let!(:organization) { create :organization, exams: [exam] }
+
+      let(:exam) { create(:exam, exercises: [ exercise ]) }
+      let(:exercise) { create(:exercise) }
+
+      before do
+        organization.switch!
+        exercise.submit_solution!(current_user).passed!
+      end
+
+      it { expect { next_button(exercise) }.to_not raise_error }
+      it { expect(next_button(exercise)).to be_nil }
+    end
   end
 end


### PR DESCRIPTION
## :dart: Goal
Fix exams breaking when one of their exercises is asked for next content.

## :memo: Details
Adding some more tests in labo to make sure `next_button` method does not break.

## :camera_flash: Screenshots
None.

## :warning: Dependencies
https://github.com/mumuki/mumuki-domain/pull/212.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.