### PR TITLE
Add faqs to organization params

### DIFF
--- a/app/controllers/concerns/organizations_controller_template.rb
+++ b/app/controllers/concerns/organizations_controller_template.rb
@@ -26,6 +26,7 @@ module OrganizationsControllerTemplate
       .require(:organization)
       .permit(:book,
               :name,
+              :faqs,
               *Mumuki::Domain::Organization::Profile.attributes,
               *Mumuki::Domain::Organization::Theme.attributes,
               *(Mumuki::Domain::Organization::Settings.attributes - [:login_methods]),

--- a/spec/controllers/organizations_api_controller_spec.rb
+++ b/spec/controllers/organizations_api_controller_spec.rb
@@ -143,7 +143,8 @@ describe Api::OrganizationsController, type: :controller, organization_workspace
              logo_url: 'http://a-logo-url.com',
              theme_stylesheet: '.theme { color: red }',
              extension_javascript: 'window.a = function() { }',
-             terms_of_service: 'A TOS'}
+             terms_of_service: 'A TOS',
+             faqs: 'some faqs'}
           end
 
           it { expect(organization.public?).to eq false }
@@ -153,6 +154,7 @@ describe Api::OrganizationsController, type: :controller, organization_workspace
           it { expect(organization.theme_stylesheet).to eq ".theme { color: red }" }
           it { expect(organization.extension_javascript).to eq "window.a = function() { }" }
           it { expect(organization.terms_of_service).to eq 'A TOS' }
+          it { expect(organization.faqs).to eq 'some faqs' }
         end
 
         context 'with missing values' do


### PR DESCRIPTION
## :dart: Goal
Allow updating organization faqs through API.

## :memo: Details
Not much to it, simply adding faqs to list of allowed controller params.

## :camera_flash: Screenshots
None.

## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.