### PR TITLE
Disable save profile button only if required fields are not completed

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/profile.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/profile.js
@@ -9,11 +9,10 @@ mumuki.load(function() {
   let avatarId = "";
   let avatarType = "";
 
-  let originalData = $userForm.serialize();
-  let originalProfilePicture = $userAvatar.attr('src');
+  toggleEditButtonIfRequiredFieldsNotCompleted();
 
   $userForm.on('change keyup', function() {
-    toggleEditButtonIfThereAreChanges();
+    toggleEditButtonIfRequiredFieldsNotCompleted();
   });
 
   $avatarItem.on('keypress click', function(e) {
@@ -25,26 +24,19 @@ mumuki.load(function() {
       const clickedAvatarType = $(this).attr('type');
       avatarId = clickedAvatarId || "";
       avatarType = clickedAvatarType || "";
-
-      toggleEditButtonIfThereAreChanges();
     });
   });
 
-  function toggleEditButtonIfThereAreChanges() {
-    let shouldEnable = requiredFieldsAreFilled() && (dataChanged() || avatarChanged());
-
-    $editButton.prop('disabled', !shouldEnable);
+  function toggleEditButtonIfRequiredFieldsNotCompleted() {
+    $editButton.prop('disabled', !requiredFieldsAreCompleted());
   }
 
-  const requiredFieldsAreFilled = () =>
-    $userForm.find('select, textarea, input').toArray().every(elem => {
+  function requiredFieldsAreCompleted() {
+    return $userForm.find('select, textarea, input').toArray().every(elem => {
       const $elem = $(elem);
       return !($elem.prop('required')) || !!$elem.val();
     });
-
-  const dataChanged = () => $userForm.serialize() !== originalData;
-
-  const avatarChanged = () => $userAvatar.attr('src') !== originalProfilePicture;
+  }
 
   $('#mu-user-image').on('keypress click', function(e){
     onClickOrSpacebarOrEnter($(this), e, function() {

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -8,6 +8,6 @@ module ProfileHelper
   end
 
   def save_edit_profile_button(form)
-    form.submit t(:save), disabled: true, class: 'btn btn-complementary mu-edit-profile-btn'
+    form.submit t(:save), class: 'btn btn-complementary mu-edit-profile-btn'
   end
 end

--- a/spec/features/profile_flow_spec.rb
+++ b/spec/features/profile_flow_spec.rb
@@ -73,19 +73,12 @@ feature 'Profile Flow', organization_workspace: :test do
     context 'user with uncompleted profile after saving' do
       before { user.update! last_name: 'last_name', birthdate: Time.now - 20.years, gender: 'female' }
 
-      let(:button_options) do
-        # Match :first is used because there are two buttons: mobile and desktop.
-        { class: 'mu-edit-profile-btn', match: :first }.tap do |options|
-          options.merge!(disabled: true) unless run_with_selenium?
-        end
-      end
-
       context 'when visiting an exercise' do
         scenario 'is redirected to previous path' do
           visit "/exercises/#{exercise.transparent_id}"
           fill_in('user_first_name', with: 'first_name')
 
-          click_on(button_options)
+          click_on(class: 'mu-edit-profile-btn', match: :first)
           expect(page).to have_text(exercise.description)
         end
       end
@@ -95,7 +88,7 @@ feature 'Profile Flow', organization_workspace: :test do
           visit "/user/edit"
           fill_in('user_first_name', with: 'first_name')
 
-          click_on(button_options)
+          click_on(class: 'mu-edit-profile-btn', match: :first)
           expect(page).to have_text('Your data was updated successfully')
           expect(page).to have_text('My profile')
         end


### PR DESCRIPTION
## :dart: Goal

Fix a bug when, a checkbox field is added as a profile field, the profile can't be saved unless the checkbox is selected. This is because we were disabling the save button unless there were changes.


