### PR TITLE
Small FAQs fixes

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/faqs.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/faqs.js
@@ -56,10 +56,10 @@ mumuki.faqs = class {
   }
 
   _createFaqsIcons() {
-    const $faqIcon = $('<i class="mu-faqs-group-icon fa fa-plus">');
+    const $faqIcon = $('<i class="mu-faqs-group-icon fas fa-chevron-down">');
     $faqIcon.click(function(e){
       const $elem = $(this);
-      $elem.toggleClass('fa-plus fa-minus');
+      $elem.toggleClass('fa-chevron-down fa-chevron-up');
       $elem.closest('.mu-faqs-group').toggleClass('active');
     });
     $('.mu-faqs-group').prepend($faqIcon);

--- a/app/assets/javascripts/mumuki_laboratory/application/faqs.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/faqs.js
@@ -25,9 +25,9 @@ mumuki.faqs = class {
   _createNavbar() {
     const $faqsNavbar = $(".mu-faqs-navbar nav ul");
     $('.mu-faqs-group').each((_index, faqGroup) => {
-      const $navItem = this._createNavbarItem($faqsNavbar, faqGroup)
+      const $navItem = this._createNavbarItem($faqsNavbar, faqGroup);
       const $faqGroup = $(faqGroup);
-      this._configureClickFor($navItem, $faqGroup, $faqsNavbar)
+      this._configureClickFor($navItem, $faqGroup, $faqsNavbar);
     });
   }
 
@@ -61,7 +61,7 @@ mumuki.faqs = class {
       const $elem = $(this);
       $elem.toggleClass('fa-plus fa-minus');
       $elem.closest('.mu-faqs-group').toggleClass('active');
-    })
+    });
     $('.mu-faqs-group').prepend($faqIcon);
   }
 
@@ -75,7 +75,7 @@ mumuki.faqs = class {
         newGroup = [];
       }
       newGroup.push(elem);
-      previousNodeName = elem.nodeName
+      previousNodeName = elem.nodeName;
     });
 
     elemsGroups.push(newGroup);

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_faqs.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_faqs.scss
@@ -17,6 +17,7 @@
       padding: 32px;
       box-shadow: 0 0.375em 2.8125em 0 #d2d5d9;
       margin-bottom: 32px;
+      word-wrap: anywhere;
 
       @media (max-width: 767px) {
         &:not(.active) {

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_faqs.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_faqs.scss
@@ -8,7 +8,7 @@
 
     width: 100%;
 
-    @media (min-width: 768px) {
+    @include media-breakpoint-up(md) {
       width: 75%;
       float: right;
     }
@@ -19,7 +19,7 @@
       margin-bottom: 32px;
       word-wrap: anywhere;
 
-      @media (max-width: 767px) {
+      @include media-breakpoint-down(md) {
         &:not(.active) {
           h3, p {
             display: none
@@ -45,7 +45,7 @@
         margin-top: 10px;
         cursor: pointer;
         display: none;
-        @media (max-width: 767px) {
+        @include media-breakpoint-down(md) {
           display: unset;
         }
       }

--- a/app/views/faqs/index.html.erb
+++ b/app/views/faqs/index.html.erb
@@ -9,7 +9,7 @@
     <div class="mu-faqs-content">
       <%= @faqs %>
     </div>
-    <div class="mu-faqs-navbar hidden-xs">
+    <div class="mu-faqs-navbar d-none d-md-block">
       <nav>
         <ul>
         </ul>


### PR DESCRIPTION
## :dart: Goal

Small visual fixes on FAQs view

## :memo: Details

* Plus and minus signs are replaced with chevrons
* The navbar at the left (the FAQ index) was showing in all screens because it was using obsolete `hidden-xs` class
* FAQ text doesn't overflow the container anymore (this was happening with long email addresses)
* Other minor code changes

## :camera_flash: Screenshots

![image](https://user-images.githubusercontent.com/11304439/117655596-a738c800-b16d-11eb-9b4c-8435ad43d9f1.png)


## :warning: Dependencies

None

## :back: Backwards compatibility

Full

## :soon: Future work

None