### PR TITLE
Hide messages count from Activity view if organization doesn't have forum

### DIFF
--- a/app/views/users/activity.html.erb
+++ b/app/views/users/activity.html.erb
@@ -17,11 +17,13 @@
                      stats: exercises_activity_stats
                    } %>
 
-        <%= render partial: 'activity_indicator',
-                   locals: {
-                     title: t(:forum),
-                     stats: messages_activity_stats
-                   } %>
+        <% if Organization.current.forum_enabled? %>
+          <%= render partial: 'activity_indicator',
+                     locals: {
+                       title: t(:forum),
+                       stats: messages_activity_stats
+                     } %>
+          <% end %>
       </div>
       <div class="col-lg-4 mu-tab-body">
         <div class="nav nav-pills flex-column">

--- a/app/views/users/activity.html.erb
+++ b/app/views/users/activity.html.erb
@@ -5,7 +5,7 @@
 <div class="row">
   <%= render partial: 'layouts/user_menu' %>
 
-  <div class="col-md-9">
+  <div class="col-md-9 mu-tab-body">
     <div class="mu-user-header">
       <h1><%= t(:activity) %></h1>
     </div>

--- a/spec/features/user_activity_flow_spec.rb
+++ b/spec/features/user_activity_flow_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 feature 'User Activity Flow', organization_workspace: :test do
   let(:user) { create(:user) }
+  let(:organization) { Organization.locate!('test') }
+
   before { set_current_user!(user) }
 
   let(:fake_stats) { double('stats') }
@@ -30,21 +32,39 @@ feature 'User Activity Flow', organization_workspace: :test do
       expect(page).to have_text('solved')
     end
 
-    scenario 'displays messages count' do
-      expect(page).to have_text('12')
-      expect(page).to have_text('messages')
-    end
-
-    scenario 'displays validated messages count' do
-      expect(page).to have_text('6')
-      expect(page).to have_text('validated')
-    end
-
     scenario 'displays recent weeks' do
       expect(page).to have_text 'Week of 2020-10-12'
       expect(page).to have_text 'Week of 2020-10-05'
       expect(page).to have_text 'Week of 2020-09-28'
     end
+
+    context 'on organization with no forum' do
+      scenario 'does not display messages count' do
+        expect(page).to_not have_text('messages')
+      end
+
+      scenario 'does not display validated messages count' do
+        expect(page).to_not have_text('validated')
+      end
+    end
+
+    context 'on organization with forum' do
+      before do
+        organization.update! forum_enabled: true
+        visit activity_user_path
+      end
+
+      scenario 'displays messages count' do
+        expect(page).to have_text('12')
+        expect(page).to have_text('messages')
+      end
+
+      scenario 'displays validated messages count' do
+        expect(page).to have_text('6')
+        expect(page).to have_text('validated')
+      end
+    end
+
   end
 
   context 'selecting a specific week' do


### PR DESCRIPTION
## :dart: Goal

Only show Exercises progress if organization doesn't have forum enabled.

## :camera_flash: Screenshots

![image](https://user-images.githubusercontent.com/11304439/117673625-529f4800-b181-11eb-9166-69170bc29029.png)

## :soon: Future work

I'd like to do the same for the `Exams`, `Certifications` and even `Messages` links on the user menu. We're already hiding the `Discussions` (consultas) link if there's no forum enabled, but I think it makes no sense to show all those other options if they're not supported. How do you think we could do this @fedescarpa? Is there a better way than adding boolean settings to each organization?
