### PR TITLE
Miscellaneous changes on discussion view

### DIFF
--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
@@ -394,31 +394,6 @@ $moderator-badge-color: #dd9900;
   }
 }
 
-$statuses: (
-  closed: ($danger white $danger),
-  opened: (white #333333 #eaeaea),
-  solved: ($success white $success),
-  pending_review: ($success white $success)
-);
-
-@each $status, $style in $statuses {
-  $background-color: nth($style, 1);
-  $font-color: nth($style, 2);
-  $border-color: nth($style, 3);
-
-  .btn-discussion-#{$status} {
-    background-color: $background-color;
-    color: $font-color;
-    border-color: $border-color;
-    margin-left: 5px;
-    &:hover {
-      color: $font-color;
-      border-color: darken($border-color, 3%);
-      background-color: darken($background-color, 3%);
-    }
-  }
-}
-
 .discussion-requires-attention {
   margin-right: 20px;
   label {

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -192,6 +192,10 @@ module DiscussionsHelper
     user.abbreviated_name
   end
 
+  def linked_discussion_user_name(user)
+    content_tag :a, discussion_user_name(user)
+  end
+
   def subscription_icon
     fa_icon :bell, text: t(:subscribe)
   end

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -177,7 +177,7 @@ module DiscussionsHelper
   end
 
   def discussion_info(discussion)
-    "#{t(:time_since, time: time_ago_in_words(discussion.created_at))} · #{t(:message_count, count: discussion.visible_messages.size)}"
+    "#{t(:time_since, time: time_ago_in_words(discussion.created_at))} · #{t(:reply_count, count: discussion.visible_messages.size)}"
   end
 
   def discussion_filter_params_without_page

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -83,8 +83,12 @@ module DiscussionsHelper
   def discussion_update_status_button(status)
     button_to t("to_#{status}"),
               item_discussion_path(@discussion, {status: status}),
-              class: "btn btn-discussion-#{status}",
+              class: "btn btn-#{btn_type_for_discussion_statuses[status.to_sym]}",
               method: :put
+  end
+
+  def btn_type_for_discussion_statuses
+    { closed: 'danger', solved: 'success', opened: 'light' }
   end
 
   def new_discussion_link(teaser_text, link_text)

--- a/app/views/discussions/_description_message.html.erb
+++ b/app/views/discussions/_description_message.html.erb
@@ -2,7 +2,7 @@
   <div class="discussion-message-bubble">
     <div class="discussion-message-bubble-header">
       <div class="discussion-message-bubble-title">
-        <%= discussion_user_name(discussion.initiator) %>
+        <%= linked_discussion_user_name(discussion.initiator) %>
         <span class="message-date">
           <%= t(:time_since, time: time_ago_in_words(discussion.created_at)) %>
         </span>

--- a/app/views/discussions/_message.html.erb
+++ b/app/views/discussions/_message.html.erb
@@ -2,7 +2,7 @@
   <div class="discussion-message-bubble">
     <div class="discussion-message-bubble-header">
       <div class="discussion-message-bubble-title">
-        <%= discussion_user_name user %>
+        <%= linked_discussion_user_name user %>
         <% if user.moderator_here? %>
           <span class="moderator-badge"><%= t(:moderation) %></span>
         <% end %>

--- a/app/views/discussions/_new_message.html.erb
+++ b/app/views/discussions/_new_message.html.erb
@@ -3,7 +3,7 @@
     <div class="discussion-message-bubble">
       <div class="discussion-message-bubble-header">
         <div class="discussion-message-bubble-title">
-          <%= user.name %>
+          <%= discussion_user_name user %>
         </div>
       </div>
       <div class="discussion-message-bubble-content">

--- a/app/views/discussions/new.html.erb
+++ b/app/views/discussions/new.html.erb
@@ -15,7 +15,7 @@
     <div class="discussion-message-bubble" id="new-discussion-description-container">
       <div class="discussion-message-bubble-header">
         <div class="discussion-message-bubble-title">
-          <%= @discussion.initiator.name %>
+          <%= discussion_user_name @discussion.initiator %>
         </div>
       </div>
       <div class="discussion-message-bubble-content">

--- a/app/views/exercises/_read_only.html.erb
+++ b/app/views/exercises/_read_only.html.erb
@@ -28,7 +28,7 @@
               <span class="discussion-initiator-name">
                 <%= discussion_user_name @discussion.initiator %>
               </span>
-              <span class="d-none d-sm-inline"><%= discussion_info(@discussion) unless @discussion.new_record? %></span>
+              <span><%= discussion_info(@discussion) unless @discussion.new_record? %></span>
             </span>
           </div>
           <% if @discussion.last_moderator_access_visible_for?(current_user) %>

--- a/app/views/exercises/_read_only.html.erb
+++ b/app/views/exercises/_read_only.html.erb
@@ -26,7 +26,7 @@
             <%= label_for_contextualization(@discussion, class: 'd-none d-sm-inline') %> ·
             <span class="discussion-info">
               <span class="discussion-initiator-name">
-                <%= @discussion.initiator.name %>
+                <%= discussion_user_name @discussion.initiator %>
               </span>
               <span class="d-none d-sm-inline"><%= discussion_info(@discussion) unless @discussion.new_record? %></span>
             </span>
@@ -34,7 +34,7 @@
           <% if @discussion.last_moderator_access_visible_for?(current_user) %>
             <h5 class="my-2 me-3">
               <span class="badge bg-primary text-wrap">
-                <%= t :last_seen, name: @discussion.last_moderator_access_by.full_name %>
+                <%= t :last_seen, name: discussion_user_name(@discussion.last_moderator_access_by) %>
                 <%= t :time_since, time: time_ago_in_words(@discussion.last_moderator_access_at) %>
               </span>
             </h5>

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -186,9 +186,6 @@ en:
   male: Male
   manual_evaluation_pending: Thanks for submitting your solution! It will be revised by the course teachers soon
   medal: Medal
-  message_count:
-    one: 1 message
-    other: '%{count} messages'
   message: Message
   message_deleted: This message was deleted because it %{motive}, which violates the %{forum_terms}.
   messages: Messages
@@ -255,6 +252,9 @@ en:
   progress: Progresss
   read: Read
   refresh_or_wait: Please press F5 if results are not displayed after a few seconds
+  reply_count:
+    one: 1 reply
+    other: '%{count} replies'
   requires_attention: Requires attention
   reset_query: Clear current search filters
   responses_count_asc: By less validated replies

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -186,9 +186,6 @@ es-CL:
   male: Hombre
   manual_evaluation_pending: ¡Gracias por enviar tu solución! Tus docentes la corregirán pronto
   medal: Medalla
-  message_count:
-    one: 1 mensaje
-    other: '%{count} mensajes'
   message: Mensaje
   message_deleted: Este mensaje fue eliminado porque %{motive}, lo cual infringe las %{forum_terms}.
   messages: Mensajes
@@ -262,6 +259,9 @@ es-CL:
   read: Leído
   read_messages: Ver mensajes
   refresh_or_wait: Si no se muestra automáticamente en unos segundos, presiona F5
+  reply_count:
+    one: 1 respuesta
+    other: '%{count} respuestas'
   reset_query: Borrar los filtros de búsqueda actuales
   restart: Reiniciar
   results_hidden: ¡Tu solución fue enviada con éxito!

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -197,9 +197,6 @@ es:
   male: Hombre
   manual_evaluation_pending: ¡Gracias por enviar tu solución! Tus docentes la corregirán pronto
   medal: Medalla
-  message_count:
-    one: 1 mensaje
-    other: '%{count} mensajes'
   message: Mensaje
   message_deleted: Este mensaje fue eliminado porque %{motive}, lo cual infringe las %{forum_terms}.
   messages: Mensajes
@@ -274,6 +271,9 @@ es:
   read: Leido
   read_messages: Ver mensajes
   refresh_or_wait: Si no se muestra automáticamente en unos segundos, presioná F5
+  reply_count:
+    one: 1 respuesta
+    other: '%{count} respuestas'
   requires_attention: Requiere atención
   reset_query: Borrar los filtros de búsqueda actuales
   responses_count_asc: Con menos respuestas validadas

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -190,9 +190,6 @@ pt:
   male: Masculino
   manual_evaluation_pending: Obrigado por enviar sua solução! Seus professores irão corrigi-lo em breve
   medal: Medalha
-  message_count:
-    one: 1 mensagem
-    other: '%{count} mensagens'
   message: Mensagem
   message_deleted: Esta mensagem foi excluída porque %{motive}, o que viola as %{forum_terms}.
   messages: Mensagens
@@ -265,6 +262,9 @@ pt:
   read: Ler
   read_messages: Ver mensagens
   refresh_or_wait: Se não mostrar automaticamente em alguns segundos, pressione F5
+  reply_count:
+    one: 1 resposta
+    other: '%{count} respostas'
   requires_attention: Requer atenção
   reset_query: Limpar filtros de pesquisa atuais
   restart: Reiniciar


### PR DESCRIPTION
## :dart: Goal

Improve the discussion view.

## :memo: Details

- The discussor name is now abbreviated everywhere, including the discussion title and new message field.
- The buttons for changing status are now Bootstrap's defaults, which gives them the proper hightlighting when focusing and hovering (and deletes a lot of code!)
- We now show the replies count instead of messages count, so it doesn't say there are 0 messages when there's always an initial message by the discussion initiator
- Date of discussion creation and replies count now shows even on smaller screens.

## :camera_flash: Screenshots

All screenshots on a before/after fashion

### Full name now abbreviated
![image](https://user-images.githubusercontent.com/11304439/118010530-83b87d80-b325-11eb-9c20-2bf37deadc0b.png)

### Reply count instead of message count (also abbreviated name)
![image](https://user-images.githubusercontent.com/11304439/118010991-e873d800-b325-11eb-8046-7fae4daef778.png)

### Color-correct shadow boxes when hovering, clicking, focusing, etc
![image](https://user-images.githubusercontent.com/11304439/118011324-46a0bb00-b326-11eb-9f15-17a82167f637.png)

### All key information not hidden anymore on mobile screens
![image](https://user-images.githubusercontent.com/11304439/118011652-ae570600-b326-11eb-988d-a6573f823b77.png)
