### PR TITLE
Feature improve discussion requires attention

### DIFF
--- a/app/views/layouts/_discussions.html.erb
+++ b/app/views/layouts/_discussions.html.erb
@@ -23,8 +23,8 @@
 
       <% if current_user&.moderator_here? %>
         <div class="discussion-requires-attention float-end">
-          <%= label_tag :requires_moderator_response, t(:requires_attention) %>
-          <%= check_box_tag :requires_moderator_response, true, discussion_filter_params[:requires_moderator_response], class: 'form-check-input', onclick: 'mumuki.Forum.discussionsToggleCheckbox($(this))' %>
+          <%= label_tag :requires_attention, t(:requires_attention) %>
+          <%= check_box_tag :requires_attention, true, discussion_filter_params[:requires_attention], class: 'form-check-input', onclick: 'mumuki.Forum.discussionsToggleCheckbox($(this))' %>
         </div>
       <% end %>
 

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 5.1.6"
 
-  s.add_dependency 'mumuki-domain', '~> 9.7.0'
+  s.add_dependency 'mumuki-domain', '~> 9.8.0'
   s.add_dependency 'mumukit-bridge', '~> 4.1'
   s.add_dependency 'mumukit-login', '~> 7.6'
   s.add_dependency 'mumukit-nuntius', '~> 6.1'


### PR DESCRIPTION
## :dart: Goal

Use the new `requires_attention` filter instead of `requires_moderator_response`.

## :warning: Dependencies

https://github.com/mumuki/mumuki-domain/pull/221

## :soon: Future work

As I said on the Domain PR, I'm working on a slight redesign to the discussion view, where I'll indicate that a discussion requires attention (among other things).