### PR TITLE
Fix certificate styles and encoding

### DIFF
--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_certificate.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_certificate.scss
@@ -21,8 +21,8 @@
   width: 157px;
   border: none;
 }
+
 .mu-certificate-download-btn-icon {
-  border-right: 1px solid darken($mu-color-complementary, 10%);
   padding: 8px 6px 9px 6px;
   width: 35px;
 }

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_certificate.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_certificate.scss
@@ -26,8 +26,3 @@
   padding: 8px 6px 9px 6px;
   width: 35px;
 }
-.mu-certificate-download-btn-text {
-  display: inline-block;
-  width: 115px;
-  text-align: center;
-}

--- a/app/views/certificates/verify.html.erb
+++ b/app/views/certificates/verify.html.erb
@@ -22,9 +22,8 @@
           <a href="<%= linkedin_post_url @certificate %>" target="_blank">
             <img src="https://download.linkedin.com/desktop/add2profile/buttons/<%= t :linkedin_profile_button_locale %>.png" alt="LinkedIn Add to Profile button">
           </a>
-          <a class="btn btn-complementary mu-certificate-download-btn pull-right" href="<%= download_certificate_path @certificate.code %>" target="_blank">
-            <i class="fas fa-fw fa-lg fa-download mu-certificate-download-btn-icon"></i>
-            <span class="mu-certificate-download-btn-text"><%= t :certificate %></span>
+          <a class="btn btn-complementary mu-certificate-download-btn pull-end" href="<%= download_certificate_path @certificate.code %>" target="_blank">
+            <%= fa_icon(:download, class: 'fa-fw fa-lg mu-certificate-download-btn-icon', text: t(:certificate)) %>
           </a>
         </div>
       <% end %>

--- a/app/views/certificates/verify.html.erb
+++ b/app/views/certificates/verify.html.erb
@@ -7,7 +7,7 @@
 <div class="container">
   <div class="row mu-certificate-data">
     <div class="col-md-6">
-      <div class="row text-center jumbotron mb-4">
+      <div class="row text-center bg-light p-4 rounded-3 mb-4">
         <div class="col-md-12">
           <h3 class="mu-certificate-name">
             <%= t :completed_by %>

--- a/app/views/certificates/verify.html.erb
+++ b/app/views/certificates/verify.html.erb
@@ -7,7 +7,7 @@
 <div class="container">
   <div class="row mu-certificate-data">
     <div class="col-md-6">
-      <div class="row text-center jumbotron">
+      <div class="row text-center jumbotron mb-4">
         <div class="col-md-12">
           <h3 class="mu-certificate-name">
             <%= t :completed_by %>
@@ -18,12 +18,12 @@
         </div>
       </div>
       <% if @certificate.for_user? current_user %>
-        <div class="row mu-certificate-buttons">
-          <a href="<%= linkedin_post_url @certificate %>" target="_blank">
-            <img src="https://download.linkedin.com/desktop/add2profile/buttons/<%= t :linkedin_profile_button_locale %>.png" alt="LinkedIn Add to Profile button">
-          </a>
-          <a class="btn btn-complementary mu-certificate-download-btn pull-end" href="<%= download_certificate_path @certificate.code %>" target="_blank">
+        <div class="mu-certificate-buttons d-flex justify-content-evenly">
+          <a class="btn btn-complementary mu-certificate-download-btn mx-2" href="<%= download_certificate_path @certificate.code %>" target="_blank">
             <%= fa_icon(:download, class: 'fa-fw fa-lg mu-certificate-download-btn-icon', text: t(:certificate)) %>
+          </a>
+          <a href="<%= linkedin_post_url @certificate %>" class="mx-2" target="_blank">
+            <img src="https://download.linkedin.com/desktop/add2profile/buttons/<%= t :linkedin_profile_button_locale %>.png" alt="LinkedIn Add to Profile button">
           </a>
         </div>
       <% end %>

--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -1,0 +1,5 @@
+require 'wicked_pdf'
+
+WickedPdf.config = {
+  encoding: 'utf8'
+}


### PR DESCRIPTION
## :dart: Goal

Add utf8 encoding to all PDFs so characters like `áéíóúñ` render properly on certificates.

Also, fix the certificates view, which was done simultaneously with the upgrade to Bootstrap 5 and wasn't properly tested.

## :camera_flash: Screenshots

### Desktop
![image](https://user-images.githubusercontent.com/11304439/123897004-12667580-d939-11eb-95f2-4b402330e007.png)

### Mobile
![image](https://user-images.githubusercontent.com/11304439/123897042-2611dc00-d939-11eb-89cf-d00a37ebaa8a.png)

## :soon: Future work

We should decide if we want to make the QR code slightly bigger. Also, on smaller screens, the footer is not at the bottom but midway through and the page is also oftentimes too wide. I think it must be because of some `height/max-height/min-height/width/etc` CSS property being set for the rendering.