### PR TITLE
Feature introduce stale message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,3 +34,5 @@ group :development, :test do
   gem 'pry-stack_explorer'
   gem 'binding_of_caller'
 end
+
+gem 'mumuki-domain', github: 'mumuki/mumuki-domain', ref: '3031843ee7df4aec45addec64e902072bfb45307'

--- a/app/assets/javascripts/mumuki_laboratory/application/messages.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/messages.js
@@ -47,34 +47,9 @@ mumuki.load(() => {
     setMessagesInterval: function () {
       mumuki.setInterval(Chat.getMessages, 60000);
     },
-    submitMessagesForm: function (url, readUrl, errorUrl) {
-      var $container = $('.mu-view-messages');
-
-      function renderHTML(data) {
-        $container.empty();
-        $container.html(data);
-        $("a[data-bs-target='#messages']").click();
-      }
-
-      function success(data) {
-        renderHTML(data);
-        Chat.readMessages(readUrl);
-      }
-
-      function error(_xhr) {
-        Chat.tokenRequest({
-          url: errorUrl,
-          success: renderHTML,
-          xhrFields: {withCredentials: true}
-        });
-      }
-
-      $.ajax({
-        url: url,
-        success: success,
-        error: error,
-        xhrFields: {withCredentials: true}
-      });
+    submitMessagesForm: function (readUrl, errorUrl) {
+      $("a[data-bs-target='#messages']")[0].click();
+      this.readMessages(readUrl);
     },
     openNewMessageModal: function () {
       Chat.$newMessageModal().modal({backdrop: false, keyboard: false});
@@ -90,4 +65,3 @@ mumuki.load(() => {
   mumuki.Chat = Chat;
 
 });
-

--- a/app/assets/javascripts/mumuki_laboratory/application/messages.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/messages.js
@@ -19,6 +19,7 @@ mumuki.load(() => {
       $('.pending-messages-filter').removeClass('pending-messages-filter');
       $('button.btn-submit').removeClass('disabled');
       $('.pending-messages-text').remove();
+      $("a[data-bs-target='#messages']")[0].click();
     },
     readMessages: function (url) {
       Chat.tokenRequest({
@@ -46,10 +47,6 @@ mumuki.load(() => {
     },
     setMessagesInterval: function () {
       mumuki.setInterval(Chat.getMessages, 60000);
-    },
-    submitMessagesForm: function (readUrl, errorUrl) {
-      $("a[data-bs-target='#messages']")[0].click();
-      this.readMessages(readUrl);
     },
     openNewMessageModal: function () {
       Chat.$newMessageModal().modal({backdrop: false, keyboard: false});

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_editor.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_editor.scss
@@ -115,3 +115,6 @@ body.fullscreen {
   }
 }
 
+.pending-messages-text {
+  top: auto;
+}

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -16,10 +16,6 @@ class MessagesController < AjaxController
     redirect_to @exercise
   end
 
-  def errors
-    render 'messages/errors', layout: false
-  end
-
   private
 
   def set_exercise!

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,7 +2,8 @@ class MessagesController < AjaxController
   before_action :set_exercise!, only: [:create, :read_messages]
 
   def index
-    render json: {has_messages: has_messages?, messages_count: messages_count}
+    pending_messages = current_user.unread_messages
+    render json: {has_messages: pending_messages.present?, messages_count: pending_messages.count}
   end
 
   def read_messages

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -1,8 +1,4 @@
 module MessagesHelper
-  def messages_url(exercise)
-    exercise.messages_url_for(current_user) if current_user?
-  end
-
   def hidden_pending(assignment)
     assignment.pending_messages? ? '' : 'd-none'
   end

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -15,10 +15,6 @@ module MessagesHelper
     'pending-messages-filter' if assignment.pending_messages?
   end
 
-  def read_messages_caption(assignment)
-    assignment.pending_messages? ? :read_messages : :exit
-  end
-
   def sender_class(message)
     message.blank? || message.from_user?(current_user) ? 'self' : 'other'
   end

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -22,4 +22,8 @@ module MessagesHelper
   def sender_class(message)
     message.blank? || message.from_user?(current_user) ? 'self' : 'other'
   end
+
+  def staleness_class(message)
+    'mu-stale' if message.stale?
+  end
 end

--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -3,7 +3,7 @@
     <ol class="mu-chat">
       <li>
         <a href="javascript:{}"
-           onclick="mumuki.Chat.submitMessagesForm('<%= messages_url(@exercise) %>', '<%= read_messages_path(@exercise) %>', '<%= messages_errors_path %>')">
+           onclick="mumuki.Chat.submitMessagesForm('<%= read_messages_path(@exercise) %>', '<%= messages_errors_path %>')">
           <%= t :more_messages %>
         </a>
       </li>

--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -1,12 +1,6 @@
 <div class="mu-view-messages">
   <div class="mu-messages">
     <ol class="mu-chat">
-      <li>
-        <a href="javascript:{}"
-           onclick="mumuki.Chat.readMessages('<%= read_messages_path(@exercise) %>')">
-          <%= t :more_messages %>
-        </a>
-      </li>
       <% messages.each do |message| %>
           <li class="<%= sender_class(message) %> <%= staleness_class(message) %>">
             <div class="message">

--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -8,7 +8,7 @@
         </a>
       </li>
       <% messages.each do |message| %>
-          <li class="<%= sender_class(message) %>">
+          <li class="<%= sender_class(message) %> <%= staleness_class(message) %>">
             <div class="message">
               <p> <%= message.content_html %></p>
               <div class="sender"><%= message.sender unless message.sender == current_user_uid %></div>

--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -3,7 +3,7 @@
     <ol class="mu-chat">
       <li>
         <a href="javascript:{}"
-           onclick="mumuki.Chat.submitMessagesForm('<%= read_messages_path(@exercise) %>', '<%= messages_errors_path %>')">
+           onclick="mumuki.Chat.readMessages('<%= read_messages_path(@exercise) %>')">
           <%= t :more_messages %>
         </a>
       </li>

--- a/app/views/layouts/exercise_inputs/forms/_interactive_form.html.erb
+++ b/app/views/layouts/exercise_inputs/forms/_interactive_form.html.erb
@@ -15,7 +15,7 @@
     <% if @assignment.pending_messages? %>
         <span class="pending-messages-text"> <%= t :pending_messages_explanation %>
           <a href="javascript:{}"
-             onclick="mumuki.Chat.submitMessagesForm('<%= read_messages_path(exercise) %>')"
+             onclick="mumuki.Chat.readMessages('<%= read_messages_path(exercise) %>')"
              class="<%= hidden_pending(@assignment) %>"
              data-waiting="<%= t(:sending_solution) %>">
             <%= t :get_messages %>

--- a/app/views/layouts/exercise_inputs/forms/_interactive_form.html.erb
+++ b/app/views/layouts/exercise_inputs/forms/_interactive_form.html.erb
@@ -15,7 +15,7 @@
     <% if @assignment.pending_messages? %>
         <span class="pending-messages-text"> <%= t :pending_messages_explanation %>
           <a href="javascript:{}"
-             onclick="mumuki.Chat.submitMessagesForm('<%= messages_url(exercise) %>', '<%= read_messages_path(exercise) %>')"
+             onclick="mumuki.Chat.submitMessagesForm('<%= read_messages_path(exercise) %>')"
              class="<%= hidden_pending(@assignment) %>"
              data-waiting="<%= t(:sending_solution) %>">
             <%= t :get_messages %>

--- a/app/views/layouts/exercise_inputs/forms/_problem_form.html.erb
+++ b/app/views/layouts/exercise_inputs/forms/_problem_form.html.erb
@@ -23,7 +23,7 @@
     <% if @assignment.pending_messages? %>
         <span class="pending-messages-text"> <%= t :pending_messages_explanation %>
           <a href="javascript:{}"
-             onclick="mumuki.Chat.submitMessagesForm('<%= read_messages_path(exercise) %>')"
+             onclick="mumuki.Chat.readMessages('<%= read_messages_path(exercise) %>')"
              class="<%= hidden_pending(@assignment) %>"
              data-waiting="<%= t(:sending_solution) %>">
             <%= t :get_messages %>

--- a/app/views/layouts/exercise_inputs/forms/_problem_form.html.erb
+++ b/app/views/layouts/exercise_inputs/forms/_problem_form.html.erb
@@ -23,7 +23,7 @@
     <% if @assignment.pending_messages? %>
         <span class="pending-messages-text"> <%= t :pending_messages_explanation %>
           <a href="javascript:{}"
-             onclick="mumuki.Chat.submitMessagesForm('<%= messages_url(exercise) %>', '<%= read_messages_path(exercise) %>')"
+             onclick="mumuki.Chat.submitMessagesForm('<%= read_messages_path(exercise) %>')"
              class="<%= hidden_pending(@assignment) %>"
              data-waiting="<%= t(:sending_solution) %>">
             <%= t :get_messages %>

--- a/app/views/messages/errors.html.erb
+++ b/app/views/messages/errors.html.erb
@@ -1,1 +1,0 @@
-<p> <%= t :messages_error %> </p>

--- a/app/views/users/messages.html.erb
+++ b/app/views/users/messages.html.erb
@@ -16,7 +16,7 @@
     <% else %>
       <table class="table table-striped">
         <% @messages.each do |message| %>
-          <tr>
+          <tr class="<%= staleness_class(message) %>" >
             <td><%= icon_for_read(message.read?) %></td>
             <td><%= link_to message.exercise.name, exercise_path(message.exercise.id) %></td>
             <td><%= mail_to message.sender %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,7 +77,6 @@ Rails.application.routes.draw do
     resources :faqs, only: [:index]
 
     resources :messages, only: [:index, :create]
-    get '/messages/errors' => 'messages#errors'
 
     get 'certificates/verify/:code', to: 'certificates#verify', as: :verify_certificate
     get 'certificates/download/:code', to: 'certificates#download', as: :download_certificate

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -189,7 +189,6 @@ en:
   message: Message
   message_deleted: This message was deleted because it %{motive}, which violates the %{forum_terms}.
   messages: Messages
-  messages_error: Previous messages are unavailable. Please try again later.
   messages_pluralized:
     one: Message
     other: Messages

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -203,7 +203,6 @@ en:
     you_are: You're taking care of it
     you_will_confirmation: You'll take care of this discussion. If you change your mind, click the button again.
     you_wont_confirmation: You won't take care of this discussion.
-  more_messages: More
   my_account: My account
   my_doubts: My doubts
   my_profile: My profile

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -190,7 +190,6 @@ es-CL:
   message: Mensaje
   message_deleted: Este mensaje fue eliminado porque %{motive}, lo cual infringe las %{forum_terms}.
   messages: Mensajes
-  messages_error: Los mensajes anteriores no están disponibles en este momento. ¡Vuelve a intentar más tarde!
   messages_pluralized:
     one: Mensaje
     other: Mensajes

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -206,7 +206,6 @@ es-CL:
     you_are: Te estás ocupando
     you_will_confirmation: Te vas a ocupar de esta consulta. Si cambias de parecer, toca nuevamente el botón.
     you_wont_confirmation: No te vas a ocupar de esta consulta.
-  more_messages: Ver mensajes anteriores
   my_account: Mi cuenta
   my_doubts: Mis consultas
   my_profile: Mi perfil

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -216,7 +216,6 @@ es:
     you_are: Te estás ocupando
     you_will_confirmation: Te vas a ocupar de esta consulta. Si cambiás de parecer, tocá nuevamente el botón.
     you_wont_confirmation: No te vas a ocupar de esta consulta.
-  more_messages: Ver mensajes anteriores
   my_account: Mi cuenta
   my_doubts: Mis consultas
   my_profile: Mi perfil

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -200,7 +200,6 @@ es:
   message: Mensaje
   message_deleted: Este mensaje fue eliminado porque %{motive}, lo cual infringe las %{forum_terms}.
   messages: Mensajes
-  messages_error: Los mensajes anteriores no están disponibles en este momento. ¡Volvé a intentar mas tarde!
   messages_pluralized:
     one: Mensaje
     other: Mensajes

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -193,7 +193,6 @@ pt:
   message: Mensagem
   message_deleted: Esta mensagem foi excluída porque %{motive}, o que viola as %{forum_terms}.
   messages: Mensagens
-  messages_error: As mensagens acima não estão disponíveis no momento. Eu tentei novamente mais tarde!
     mais tarde!
   messages_pluralized:
     one: Mensagem

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -210,7 +210,6 @@ pt:
     you_are: Você está cuidando
     you_will_confirmation: Você vai cuidar dessa consulta. Se mudar de ideia, clique no botão novamente.
     you_wont_confirmation: Você não vai cuidar dessa consulta.
-  more_messages: Ver as mensagens anteriores
   my_account: Minha conta
   my_doubts: Minhas duvidas
   my_profile: Meu perfil

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210518100153) do
+ActiveRecord::Schema.define(version: 20210707143002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -384,7 +384,9 @@ ActiveRecord::Schema.define(version: 20210518100153) do
     t.integer "deletion_motive"
     t.datetime "deleted_at"
     t.bigint "deleted_by_id"
+    t.bigint "assignment_id"
     t.index ["approved_by_id"], name: "index_messages_on_approved_by_id"
+    t.index ["assignment_id"], name: "index_messages_on_assignment_id"
     t.index ["deleted_by_id"], name: "index_messages_on_deleted_by_id"
   end
 


### PR DESCRIPTION
# :dart: Goal

To make rise hand properly work again. 

# :memo: Details

This PR introduces several changes: 

1. Stale messages are consumed
2. As a consequence, there is no need to fetch messages from classroom, and that concern has been removed. A lot of boilerplate has been removed too. 

# :beetle: Fixes

This PR also fixes two issues: 

1. #1639: rise hand message were in a wrong place
2. Internal server errors introduced in 72a11ad9eaa0f937a48a67d12ff13b11a95821a2  

# :camera_flash: Screenshots


![Screenshot from 2021-07-12 12-45-11](https://user-images.githubusercontent.com/677436/125317211-33eb3800-e30f-11eb-9e5b-5653ef77808d.png)
![Screenshot from 2021-07-12 12-46-07](https://user-images.githubusercontent.com/677436/125317187-3188de00-e30f-11eb-8b64-6de7c7f62815.png)
![Screenshot from 2021-07-12 12-45-57](https://user-images.githubusercontent.com/677436/125317202-32ba0b00-e30f-11eb-8ad0-be6f1e6f2855.png)


# :movie_camera: Video demo

## Read pending messages

https://user-images.githubusercontent.com/677436/125315242-4bc1bc80-e30d-11eb-9e0e-8fefb30213d2.mp4

## Send initial message

https://user-images.githubusercontent.com/677436/125315238-4b292600-e30d-11eb-8eac-9cfa97d20c79.mp4

## Receive messages and read both active and stale answers

> Notice: teacher messages have been sent using the following code:
>
> ```ruby
> Assignment.last.receive_answer! sender: "someone@mumuki.org", content: "message"
> ```

https://user-images.githubusercontent.com/677436/125315227-48c6cc00-e30d-11eb-9c41-6ab2510e8ff8.mp4


# :warning: Dependencies

See https://github.com/mumuki/mumuki-domain/pull/226

# :back: Backwards compatibility

# :eyes: See also

* https://github.com/mumuki/mumuki-laboratory/issues/1639
* Closes #1639 }


# :soon: Future work

This PR may have also done some other things, but I tried to keep it atomic. As such, the following aspects are not covered: 

1. Redo the UI of rise hand - I dont like the blured editor. 
2. Display a notification badge next to the messages tabs indicating the amount of unread messages
3. Decouple unread messages concept from unread notifications
4. Introduce a new style for stale messages - I have just added a `mu-stale` class 
