### PR TITLE
Chore misc time zone fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,4 +35,4 @@ group :development, :test do
   gem 'binding_of_caller'
 end
 
-gem 'mumuki-domain', github: 'mumuki/mumuki-domain', ref: '3031843ee7df4aec45addec64e902072bfb45307'
+gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'chore-misc-time-zone-fixes'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,4 +48,8 @@ module ApplicationHelper
   def notification_preview_for(target)
     render "notifications/#{target.class.name.underscore}", { target: target }
   end
+
+  def current_time_zone_html
+    %Q{(<span class="select-date-timezone">#{Organization.current.time_zone}</span>)}.html_safe
+  end
 end

--- a/app/helpers/exam_registration_helper.rb
+++ b/app/helpers/exam_registration_helper.rb
@@ -6,8 +6,4 @@ module ExamRegistrationHelper
       { icon: :info_circle, class: :info, t: :exam_registration_explanation_html }
     end
   end
-
-  def current_time_zone_html
-    %Q{(<span class="select-date-timezone">#{Organization.current.time_zone}</span>)}.html_safe
-  end
 end

--- a/app/helpers/exam_registration_helper.rb
+++ b/app/helpers/exam_registration_helper.rb
@@ -8,6 +8,6 @@ module ExamRegistrationHelper
   end
 
   def current_time_zone_html
-    %Q{(<span class="select-date-timezone">#{Organization.current&.time_zone}</span>)}.html_safe
+    %Q{(<span class="select-date-timezone">#{Organization.current.time_zone}</span>)}.html_safe
   end
 end

--- a/app/views/layouts/_copyright.html.erb
+++ b/app/views/layouts/_copyright.html.erb
@@ -1,2 +1,2 @@
-&copy; 2015-<%= DateTime.now.year %>
+&copy; 2015-<%= Time.current.year %>
 <a href="http://mumuki.org/" class="mu-org-link"><span class="da da-mumuki-circle"></span> Mumuki</a>

--- a/app/views/user_mailer/1st_reminder.html.erb
+++ b/app/views/user_mailer/1st_reminder.html.erb
@@ -313,7 +313,7 @@
 
                             <td valign="top" class="muMailTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
 
-                              © Copyright 2015-<%= DateTime.now.year %>&nbsp;<a href="https://mumuki.org/home/">Mumuki</a><em>.</em><br>
+                              © Copyright 2015-<%= Time.current.year %>&nbsp;<a href="https://mumuki.org/home/">Mumuki</a><em>.</em><br>
                               <br>
                               <%= t :stop_emails? %><br>
                               <%= link_to t(:cancel_subscription), @organization.url_for("/user/unsubscribe?id=#{@unsubscribe_code}"), target: :_blank %>

--- a/app/views/user_mailer/1st_reminder.text.erb
+++ b/app/views/user_mailer/1st_reminder.text.erb
@@ -7,7 +7,7 @@
 <%= t :keep_learning %>
 
 
-© Copyright 2015-<%= DateTime.now.year %> Mumuki.
+© Copyright 2015-<%= Time.current.year %> Mumuki.
 
 <%= t :stop_emails? %>
 <%= t :cancel_subscription %>

--- a/app/views/user_mailer/2nd_reminder.html.erb
+++ b/app/views/user_mailer/2nd_reminder.html.erb
@@ -313,7 +313,7 @@
 
                             <td valign="top" class="muMailTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
 
-                              © Copyright 2015-<%= DateTime.now.year %>&nbsp;<a href="https://mumuki.org/home/">Mumuki</a><em>.</em><br>
+                              © Copyright 2015-<%= Time.current.year %>&nbsp;<a href="https://mumuki.org/home/">Mumuki</a><em>.</em><br>
                               <br>
                               <%= t :stop_emails? %><br>
                               <%= link_to t(:cancel_subscription), @organization.url_for("/user/unsubscribe?id=#{@unsubscribe_code}"), target: :_blank %>

--- a/app/views/user_mailer/2nd_reminder.text.erb
+++ b/app/views/user_mailer/2nd_reminder.text.erb
@@ -7,7 +7,7 @@
 <%= t :keep_learning %>
 
 
-© Copyright 2015-<%= DateTime.now.year %> Mumuki.
+© Copyright 2015-<%= Time.current.year %> Mumuki.
 
 <%= t :stop_emails? %>
 <%= t :cancel_subscription %>

--- a/app/views/user_mailer/3rd_reminder.html.erb
+++ b/app/views/user_mailer/3rd_reminder.html.erb
@@ -313,7 +313,7 @@
 
                             <td valign="top" class="muMailTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
 
-                              © Copyright 2015-<%= DateTime.now.year %>&nbsp;<a href="https://mumuki.org/home/">Mumuki</a><em>.</em><br>
+                              © Copyright 2015-<%= Time.current.year %>&nbsp;<a href="https://mumuki.org/home/">Mumuki</a><em>.</em><br>
                               <br>
                               <%= t :stop_emails? %><br>
                               <%= link_to t(:cancel_subscription), @organization.url_for("/user/unsubscribe?id=#{@unsubscribe_code}"), target: :_blank %>

--- a/app/views/user_mailer/3rd_reminder.text.erb
+++ b/app/views/user_mailer/3rd_reminder.text.erb
@@ -7,7 +7,7 @@
 <%= t :keep_learning %>
 
 
-© Copyright 2015-<%= DateTime.now.year %> Mumuki.
+© Copyright 2015-<%= Time.current.year %> Mumuki.
 
 <%= t :stop_emails? %>
 <%= t :cancel_subscription %>

--- a/app/views/user_mailer/certificate.html.erb
+++ b/app/views/user_mailer/certificate.html.erb
@@ -299,7 +299,7 @@
 
                             <td valign="top" class="muMailTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
 
-                              © Copyright 2015-<%= DateTime.now.year %>&nbsp;<a href="https://mumuki.org/home/">Mumuki</a><em>.</em><br>
+                              © Copyright 2015-<%= Time.current.year %>&nbsp;<a href="https://mumuki.org/home/">Mumuki</a><em>.</em><br>
                               <br>
                               <%= t :stop_emails? %><br>
                               <%= link_to t(:cancel_subscription), @organization.url_for("/user/unsubscribe?id=#{@unsubscribe_code}"), target: :_blank %>

--- a/app/views/user_mailer/certificate.text.erb
+++ b/app/views/user_mailer/certificate.text.erb
@@ -4,7 +4,7 @@
 <%= t :new_certificate_mailer_p2 %>
 
 
-© Copyright 2015-<%= DateTime.now.year %> Mumuki.
+© Copyright 2015-<%= Time.current.year %> Mumuki.
 
 <%= t :stop_emails? %>
 <%= t :cancel_subscription %>

--- a/app/views/user_mailer/no_submissions_reminder.html.erb
+++ b/app/views/user_mailer/no_submissions_reminder.html.erb
@@ -313,7 +313,7 @@
 
                             <td valign="top" class="muMailTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
 
-                              © Copyright 2015-<%= DateTime.now.year %>&nbsp;<a href="https://mumuki.org/home/">Mumuki</a><em>.</em><br>
+                              © Copyright 2015-<%= Time.current.year %>&nbsp;<a href="https://mumuki.org/home/">Mumuki</a><em>.</em><br>
                               <br>
                               <%= t :stop_emails? %><br>
                               <%= link_to t(:cancel_subscription), @organization.url_for("/user/unsubscribe?id=#{@unsubscribe_code}"), target: :_blank %>

--- a/app/views/user_mailer/no_submissions_reminder.text.erb
+++ b/app/views/user_mailer/no_submissions_reminder.text.erb
@@ -7,7 +7,7 @@
 <%= t :keep_learning %>
 
 
-© Copyright 2015-<%= DateTime.now.year %> Mumuki.
+© Copyright 2015-<%= Time.current.year %> Mumuki.
 
 <%= t :stop_emails? %>
 <%= t :cancel_subscription %>

--- a/spec/controllers/organizations_api_controller_spec.rb
+++ b/spec/controllers/organizations_api_controller_spec.rb
@@ -107,7 +107,9 @@ describe Api::OrganizationsController, type: :controller, organization_workspace
          name: 'a-name',
          public: false,
          book: book.slug,
-         locale: 'es'}
+         locale: 'es',
+         time_zone: 'Buenos Aires'
+        }
       end
 
       context 'with the admin permissions' do
@@ -138,6 +140,7 @@ describe Api::OrganizationsController, type: :controller, organization_workspace
              description: 'A description',
              book: book.slug,
              locale: 'es',
+             time_zone: 'Montevideo',
              public: false,
              login_methods: %w(facebook github),
              logo_url: 'http://a-logo-url.com',
@@ -155,6 +158,7 @@ describe Api::OrganizationsController, type: :controller, organization_workspace
           it { expect(organization.extension_javascript).to eq "window.a = function() { }" }
           it { expect(organization.terms_of_service).to eq 'A TOS' }
           it { expect(organization.faqs).to eq 'some faqs' }
+          it { expect(organization.time_zone).to eq 'Montevideo' }
         end
 
         context 'with missing values' do
@@ -166,6 +170,7 @@ describe Api::OrganizationsController, type: :controller, organization_workspace
             {
                 errors: {
                     name: ["can't be blank"],
+                    time_zone: ["can't be blank"],
                     locale: ['is not included in the list']
                 }
             }

--- a/spec/controllers/students_api_controller_spec.rb
+++ b/spec/controllers/students_api_controller_spec.rb
@@ -31,7 +31,7 @@ require 'spec_helper'
         it { expect(User.last.uid).to eq 'agus@mumuki.org' }
         it { expect(User.last.email).to eq 'agus@mumuki.org' }
         it { expect(User.last.gender).to eq 'male' }
-        it { expect(User.last.birthdate).to eq '2010-08-25'.to_datetime }
+        it { expect(User.last.birthdate).to eq '2010-08-25'.in_time_zone }
         it { expect(User.last.permissions.has_permission? role, 'anorganization/acode').to be true }
 
       end

--- a/spec/features/not_found_public_flow_spec.rb
+++ b/spec/features/not_found_public_flow_spec.rb
@@ -6,7 +6,7 @@ feature 'not found public on app' do
   let!(:some_orga) { create(:public_organization, name: 'someorga', profile: profile) }
 
   let(:profile) { Mumuki::Domain::Organization::Profile.parse json  }
-  let(:json) { { contact_email: 'some@email.com', locale: 'en', errors_explanations: { 404 => 'Some explanation'} } }
+  let(:json) { { contact_email: 'some@email.com', locale: 'en', time_zone: 'Brasilia', errors_explanations: { 404 => 'Some explanation'} } }
 
   scenario 'when route does not exist in explicit central' do
     set_subdomain_host! 'test'

--- a/spec/features/profile_flow_spec.rb
+++ b/spec/features/profile_flow_spec.rb
@@ -71,7 +71,7 @@ feature 'Profile Flow', organization_workspace: :test do
     before { set_current_user! user }
 
     context 'user with uncompleted profile after saving' do
-      before { user.update! last_name: 'last_name', birthdate: Time.now - 20.years, gender: 'female' }
+      before { user.update! last_name: 'last_name', birthdate: 20.years.ago, gender: 'female' }
 
       context 'when visiting an exercise' do
         scenario 'is redirected to previous path' do


### PR DESCRIPTION
# :dart: Goal

To normalize the usage of dates, times and time zones. 

# :memo: Details

This PR focuses on the same aspects the the corresponding domain PR: 

1. Prefer Time over DateTime
2. Prefer `in_time_zone` and `current` instead  of `to_time`/`to_datetime` and `now`

# :warning: Dependencies

* #1638 
* https://github.com/mumuki/mumuki-domain/pull/222

# :back: Backwards compatibility

This PR should be 100% backwards compatible

