### PR TITLE
Rename FAQs locales

### DIFF
--- a/app/helpers/menu_bar_helper.rb
+++ b/app/helpers/menu_bar_helper.rb
@@ -48,6 +48,6 @@ module MenuBarHelper
   end
 
   def menu_link_to_faqs
-    li_tag menu_item('question', :faqs, faqs_path)
+    li_tag menu_item(:info, :faqs_abbreviated, faqs_path)
   end
 end

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -133,7 +133,8 @@ en:
   expected_state: Expected board
   explain_redirect: You have registered in another organization
   failed: Oops, something went wrong
-  faqs: FAQs
+  faqs: Frequently Asked Questions
+  faqs_abbreviated: FAQs
   feedback: Feedback
   female: Female
   file_exceeds_max_size: "File size should not exceed %{size_kb}kb. Please select another file."

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -132,7 +132,7 @@ es-CL:
   expected_state: Tablero esperado
   explain_redirect: Notamos que te registraste en otra organización.
   failed: Tu solución no pasó las pruebas
-  faqs: Preguntas Frecuentes
+  faqs: Información importante
   feedback: Problemas que encontramos
   female: Mujer
   file_exceeds_max_size: "El tamaño de archivo no debe exceder %{size_kb}kb. Por favor selecciona otro archivo."

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -133,6 +133,7 @@ es-CL:
   explain_redirect: Notamos que te registraste en otra organización.
   failed: Tu solución no pasó las pruebas
   faqs: Información importante
+  faqs_abbreviated: Información
   feedback: Problemas que encontramos
   female: Mujer
   file_exceeds_max_size: "El tamaño de archivo no debe exceder %{size_kb}kb. Por favor selecciona otro archivo."

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -140,7 +140,7 @@ es:
   expected_state: Tablero esperado
   explain_redirect: Notamos que te registraste en otra organización.
   failed: Tu solución no pasó las pruebas
-  faqs: Preguntas Frecuentes
+  faqs: Información importante
   feedback: Problemas que encontramos
   female: Mujer
   file_exceeds_max_size: "El tamaño de archivo no debe exceder %{size_kb}kb. Por favor seleccioná otro archivo."

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -141,6 +141,7 @@ es:
   explain_redirect: Notamos que te registraste en otra organización.
   failed: Tu solución no pasó las pruebas
   faqs: Información importante
+  faqs_abbreviated: Información
   feedback: Problemas que encontramos
   female: Mujer
   file_exceeds_max_size: "El tamaño de archivo no debe exceder %{size_kb}kb. Por favor seleccioná otro archivo."

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -136,6 +136,7 @@ pt:
   explain_redirect: Percebemos que você se registrou em outra organização.
   failed: Sua solução não passou as provas
   faqs: Informação importante
+  faqs_abbreviated: Informação
   feedback: Problemas que encontramos
   female: Feminino
   file_exceeds_max_size: "O tamanho do arquivo não deve exceder %{size_kb}kb. Selecione outro arquivo."

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -135,7 +135,7 @@ pt:
   expected_state: Tabuleiro esperado
   explain_redirect: Percebemos que você se registrou em outra organização.
   failed: Sua solução não passou as provas
-  faqs: Perguntas frequentes
+  faqs: Informação importante
   feedback: Problemas que encontramos
   female: Feminino
   file_exceeds_max_size: "O tamanho do arquivo não deve exceder %{size_kb}kb. Selecione outro arquivo."


### PR DESCRIPTION
## :dart: Goal

Rename "Preguntas frecuentes" to "Información importante" per @lauramangifesta's request.

## :memo: Details

Only the Spanish and Portuguese locales are changed. We're keeping it as FAQs in English because `Information` didn't sound too right. All code, fields, etc remain unchanged.

## :camera_flash: Screenshots

![image](https://user-images.githubusercontent.com/11304439/126543165-7ff089a1-25fc-4e28-a8f7-902faa13d09b.png)
___
![image](https://user-images.githubusercontent.com/11304439/126543710-bf079ce6-163c-4b95-ae74-1d82e296682e.png)
___
![image](https://user-images.githubusercontent.com/11304439/126543207-c10f49e2-2c9e-4a50-9444-b2d3d46d76dc.png)
