### PR TITLE
Paginate user discussions

### DIFF
--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
@@ -50,13 +50,6 @@ $moderator-badge-color: #dd9900;
     }
   }
 
-  .discussion-pagination {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-  }
-
   .discussion-language-icon {
     display: inline;
     padding-right: 5px;
@@ -70,6 +63,13 @@ $moderator-badge-color: #dd9900;
       margin-top: 10px;
     }
   }
+}
+
+.discussion-pagination {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
 }
 
 .discussions-no-filtered-results {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,7 +27,7 @@ class UsersController < ApplicationController
   end
 
   def discussions
-    @watched_discussions = current_user.watched_discussions_in_organization.scoped_query_by(discussion_filter_params)
+    @watched_discussions = current_user.watched_discussions_in_organization.scoped_query_by(discussion_filter_params).unread_first
   end
 
   def activity

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,7 +27,7 @@ class UsersController < ApplicationController
   end
 
   def discussions
-    @watched_discussions = current_user.watched_discussions_in_organization
+    @watched_discussions = current_user.watched_discussions_in_organization.scoped_query_by(discussion_filter_params)
   end
 
   def activity
@@ -70,5 +70,9 @@ class UsersController < ApplicationController
     else
       nil
     end
+  end
+
+  def discussion_filter_params
+    @filter_params ||= params.permit([:page])
   end
 end

--- a/app/helpers/icons_helper.rb
+++ b/app/helpers/icons_helper.rb
@@ -50,6 +50,6 @@ module IconsHelper
   end
 
   def icon_for_read(read)
-    tag('i', class: "fa#{read ? 'r' : 's'} fa-envelope")
+    tag('i', class: "fa#{read ? 'r' : 's'} fa-envelope#{read ? '-open' : ''}")
   end
 end

--- a/app/helpers/user_discussions_helper.rb
+++ b/app/helpers/user_discussions_helper.rb
@@ -31,7 +31,7 @@ module UserDiscussionsHelper
         </td>
         <td>#{link_to discussion.item.name, item_discussion_path(discussion)}</td>
         <td>#{discussion_user_name discussion.initiator}</td>
-        <td>#{time_ago_in_words discussion.last_message_date}</td>
+        <td>#{t(:time_since, time: time_ago_in_words(discussion.last_message_date))}</td>
       </tr>
     }.html_safe
   end

--- a/app/helpers/user_discussions_helper.rb
+++ b/app/helpers/user_discussions_helper.rb
@@ -1,4 +1,17 @@
 module UserDiscussionsHelper
+  def user_discussions_table_title(discussion, user, last_read)
+    %Q{
+      <tr></tr>
+      <thead>
+        <tr>
+          <td class="#{last_read.nil? ? '' : 'pt-5'}" colspan="4">
+            <strong>#{discussion.read_by?(user) ? t(:discussions_read) : t(:discussions_unread)}</strong>
+          </td>
+        </tr>
+      </thead>
+    }.html_safe
+  end
+
   def user_discussions_table_header
     %Q{
       <tr>

--- a/app/helpers/user_discussions_helper.rb
+++ b/app/helpers/user_discussions_helper.rb
@@ -9,4 +9,17 @@ module UserDiscussionsHelper
       </tr>
     }.html_safe
   end
+
+  def user_discussions_table_item(discussion, user)
+    %Q{
+      <tr>
+        <td class="text-center">
+          #{icon_for_read(discussion.read_by?(user))}
+        </td>
+        <td>#{link_to discussion.item.name, item_discussion_path(discussion)}</td>
+        <td>#{discussion_user_name discussion.initiator}</td>
+        <td>#{time_ago_in_words discussion.last_message_date}</td>
+      </tr>
+    }.html_safe
+  end
 end

--- a/app/helpers/user_discussions_helper.rb
+++ b/app/helpers/user_discussions_helper.rb
@@ -14,11 +14,11 @@ module UserDiscussionsHelper
 
   def user_discussions_table_header
     %Q{
-      <tr>
+      <tr class="fw-bold">
         <td></td>
-        <td><strong>#{t(:exercise)}</strong></td>
-        <td><strong>#{t(:discussion_created_by)}</strong></td>
-        <td><strong>#{t(:last_message)}</strong></td>
+        <td>#{t(:exercise)}</td>
+        <td>#{t(:discussion_created_by)}</td>
+        <td>#{t(:last_message)}</td>
       </tr>
     }.html_safe
   end

--- a/app/helpers/user_discussions_helper.rb
+++ b/app/helpers/user_discussions_helper.rb
@@ -1,0 +1,12 @@
+module UserDiscussionsHelper
+  def user_discussions_table_header
+    %Q{
+      <tr>
+        <td></td>
+        <td><strong>#{t(:exercise)}</strong></td>
+        <td><strong>#{t(:discussion_created_by)}</strong></td>
+        <td><strong>#{t(:last_message)}</strong></td>
+      </tr>
+    }.html_safe
+  end
+end

--- a/app/views/users/discussions.html.erb
+++ b/app/views/users/discussions.html.erb
@@ -26,13 +26,7 @@
                     <strong><%= @last_read ? t(:discussions_read) : t(:discussions_unread) %></strong></td>
                 </tr>
               </thead>
-              <tr>
-                <td></td>
-                <td><strong><%= t(:exercise) %></strong></td>
-                <td><strong><%= t(:discussion_created_by) %></strong></td>
-                <td><strong><%= t(:last_message) %></strong></td>
-              </tr>
-
+              <%= user_discussions_table_header %>
             <% end %>
             <tr>
               <td class="text-center">

--- a/app/views/users/discussions.html.erb
+++ b/app/views/users/discussions.html.erb
@@ -24,7 +24,7 @@
           </tr>
           <% @watched_discussions.each do |discussion| %>
             <tr>
-              <td>
+              <td class="text-center">
                 <%= icon_for_read(discussion.read_by?(@user)) %>
               </td>
               <td><%= link_to discussion.item.name, item_discussion_path(discussion) %></td>

--- a/app/views/users/discussions.html.erb
+++ b/app/views/users/discussions.html.erb
@@ -15,14 +15,25 @@
       </div>
     <% else %>
       <div class="table-responsive mb-3">
-        <table class="table table-striped">
-          <tr>
-            <td></td>
-            <td><strong><%= t(:exercise) %></strong></td>
-            <td><strong><%= t(:discussion_created_by) %></strong></td>
-            <td><strong><%= t(:last_message) %></strong></td>
-          </tr>
+        <table class="table">
           <% @watched_discussions.each do |discussion| %>
+            <% if discussion.read_by?(@user) != @last_read %>
+              <tr></tr>
+              <thead>
+                <tr>
+                  <td class="<%= @last_read.nil? ? '' : 'pt-5' %>" colspan="4">
+                    <% @last_read = discussion.read_by?(@user) %>
+                    <strong><%= @last_read ? t(:discussions_read) : t(:discussions_unread) %></strong></td>
+                </tr>
+              </thead>
+              <tr>
+                <td></td>
+                <td><strong><%= t(:exercise) %></strong></td>
+                <td><strong><%= t(:discussion_created_by) %></strong></td>
+                <td><strong><%= t(:last_message) %></strong></td>
+              </tr>
+
+            <% end %>
             <tr>
               <td class="text-center">
                 <%= icon_for_read(discussion.read_by?(@user)) %>

--- a/app/views/users/discussions.html.erb
+++ b/app/views/users/discussions.html.erb
@@ -14,17 +14,19 @@
         <%= t :discussions_will_be_here %>
       </div>
     <% else %>
-      <table class="table table-striped">
-        <% @watched_discussions.each do |discussion| %>
-          <tr>
-            <td>
-              <%= icon_for_read(discussion.read_by?(@user)) %>
-            </td>
-            <td><%= link_to discussion.item.name, item_discussion_path(discussion) %></td>
-            <td><%= time_ago_in_words discussion.last_message_date %></td>
-          </tr>
-        <% end %>
-      </table>
+      <div class="table-responsive mb-3">
+        <table class="table table-striped">
+          <% @watched_discussions.each do |discussion| %>
+            <tr>
+              <td>
+                <%= icon_for_read(discussion.read_by?(@user)) %>
+              </td>
+              <td><%= link_to discussion.item.name, item_discussion_path(discussion) %></td>
+              <td><%= time_ago_in_words discussion.last_message_date %></td>
+            </tr>
+          <% end %>
+        </table>
+      </div>
 
       <div class="discussion-pagination">
         <%= paginate @watched_discussions, nav_class: 'pagination' %>

--- a/app/views/users/discussions.html.erb
+++ b/app/views/users/discussions.html.erb
@@ -16,6 +16,12 @@
     <% else %>
       <div class="table-responsive mb-3">
         <table class="table table-striped">
+          <tr>
+            <td></td>
+            <td><strong><%= t(:exercise) %></strong></td>
+            <td><strong><%= t(:discussion_created_by) %></strong></td>
+            <td><strong><%= t(:last_message) %></strong></td>
+          </tr>
           <% @watched_discussions.each do |discussion| %>
             <tr>
               <td>

--- a/app/views/users/discussions.html.erb
+++ b/app/views/users/discussions.html.erb
@@ -22,6 +22,7 @@
                 <%= icon_for_read(discussion.read_by?(@user)) %>
               </td>
               <td><%= link_to discussion.item.name, item_discussion_path(discussion) %></td>
+              <td><%= discussion_user_name discussion.initiator %></td>
               <td><%= time_ago_in_words discussion.last_message_date %></td>
             </tr>
           <% end %>

--- a/app/views/users/discussions.html.erb
+++ b/app/views/users/discussions.html.erb
@@ -18,14 +18,9 @@
         <table class="table">
           <% @watched_discussions.each do |discussion| %>
             <% if discussion.read_by?(@user) != @last_read %>
-              <tr></tr>
-              <thead>
-                <tr>
-                  <td class="<%= @last_read.nil? ? '' : 'pt-5' %>" colspan="4">
-                    <% @last_read = discussion.read_by?(@user) %>
-                    <strong><%= @last_read ? t(:discussions_read) : t(:discussions_unread) %></strong></td>
-                </tr>
-              </thead>
+              <%= user_discussions_table_title(discussion, @user, @last_read) %>
+              <% @last_read = discussion.read_by?(@user) %>
+
               <%= user_discussions_table_header %>
             <% end %>
 

--- a/app/views/users/discussions.html.erb
+++ b/app/views/users/discussions.html.erb
@@ -25,6 +25,11 @@
           </tr>
         <% end %>
       </table>
+
+      <div class="discussion-pagination">
+        <%= paginate @watched_discussions, nav_class: 'pagination' %>
+      </div>
+
     <% end %>
   </div>
 </div>

--- a/app/views/users/discussions.html.erb
+++ b/app/views/users/discussions.html.erb
@@ -28,14 +28,8 @@
               </thead>
               <%= user_discussions_table_header %>
             <% end %>
-            <tr>
-              <td class="text-center">
-                <%= icon_for_read(discussion.read_by?(@user)) %>
-              </td>
-              <td><%= link_to discussion.item.name, item_discussion_path(discussion) %></td>
-              <td><%= discussion_user_name discussion.initiator %></td>
-              <td><%= time_ago_in_words discussion.last_message_date %></td>
-            </tr>
+
+            <%= user_discussions_table_item(discussion, @user) %>
           <% end %>
         </table>
       </div>

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -89,6 +89,8 @@ en:
   new_discussion_message: New message on %{title}
   discussion_updated: Discussion updated
   discussions: Discussions
+  discussions_read: Read
+  discussions_unread: Unread
   discussions_will_be_here: Your posts in the forum will appear here.
   dont_leave_us: Don't leave us! Learning is fun. You just have to keep at it.
   download: Download your solution
@@ -265,7 +267,6 @@ en:
   programming_since: Started programming
   progress: Progress
   publish_discussion: Publish discussion
-  read: Read
   refresh_or_wait: Please press F5 if results are not displayed after a few seconds
   reply_count:
     one: 1 reply

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -84,6 +84,7 @@ en:
   destroy_message: delete the message
   disabled_explanation: You are trying to visit a permamently disabled or deleted resource
   disabled_organization_explanation: This path has already finished.
+  discussion_created_by: Created by
   discussion_description_placeholder: You can add more information regarding your doubt.
   new_discussion_message: New message on %{title}
   discussion_updated: Discussion updated
@@ -170,6 +171,7 @@ en:
   keep_learning: Keep learning!
   kids_default_success: You did it great!
   language: Language
+  last_message: Last message
   last_name: Last Name
   last_submission_date: Last submission
   latest_exercises: Latest exercises

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -88,6 +88,7 @@ es-CL:
   disabled_explanation: Estás intentando acceder a un recurso que fue deshabilitado o eliminado de forma permanente
   disabled_organization_explanation: ¡Este recorrido ha finalizado!
   new_discussion_message: Mensaje nuevo en %{title}
+  discussion_created_by: Creada por
   discussion_updated: Consulta actualizada
   discussions: Consultas
   discussions_will_be_here: Las preguntas que realices en el espacio de consultas aparecerán aquí.
@@ -172,6 +173,7 @@ es-CL:
   kids_default_success: ¡Lo hiciste muy bien!
   language: Lenguaje
   languages: Lenguajes
+  last_message: Último mensaje
   last_name: Apellido
   last_submission_date: Última solución
   latest_exercises: Últimos ejercicios

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -91,6 +91,8 @@ es-CL:
   discussion_created_by: Creada por
   discussion_updated: Consulta actualizada
   discussions: Consultas
+  discussions_read: Leídas
+  discussions_unread: No leídas
   discussions_will_be_here: Las preguntas que realices en el espacio de consultas aparecerán aquí.
   dont_leave_us: ¡No nos abandones! Aprender a programar es divertido. Sólo tienes que seguir practicando.
   download: "Descarga lo que hiciste"
@@ -273,7 +275,6 @@ es-CL:
   profile_of: Perfil de %{username}
   progress: Progreso
   publish_discussion: Publicar consulta
-  read: Leído
   read_messages: Ver mensajes
   refresh_or_wait: Si no se muestra automáticamente en unos segundos, presiona F5
   reply_count:

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -97,6 +97,8 @@ es:
   discussion_updated: Consulta actualizada
   new_discussion_message: Mensaje nuevo en %{title}
   discussions: Consultas
+  discussions_read: Leídas
+  discussions_unread: No leídas
   discussions_will_be_here: Las preguntas que realices en el espacio de consultas aparecerán aquí.
   dont_leave_us: ¡No nos abandones! Aprender a programar es divertido. Sólo tenés que seguir practicando.
   download: "Descargá lo que hiciste"
@@ -283,7 +285,6 @@ es:
   programming_since: Programando desde
   progress: Progreso
   publish_discussion: Publicar consulta
-  read: Leido
   read_messages: Ver mensajes
   refresh_or_wait: Si no se muestra automáticamente en unos segundos, presioná F5
   reply_count:

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -92,6 +92,7 @@ es:
   details: Detalles
   disabled_explanation: Estás intentando acceder a un recurso que fue deshabilitado o eliminado de forma permamente
   disabled_organization_explanation: Este recorrido ha finalizado
+  discussion_created_by: Creada por
   discussion_description_placeholder: Podés agregar información para detallar más tu consulta
   discussion_updated: Consulta actualizada
   new_discussion_message: Mensaje nuevo en %{title}
@@ -181,6 +182,7 @@ es:
   kids_default_success: ¡Lo hiciste muy bien!
   language: Lenguaje
   languages: Lenguajes
+  last_message: Último mensaje
   last_name: Apellido
   last_submission_date: Última solución
   latest_exercises: Últimos ejercicios

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -93,6 +93,8 @@ pt:
   discussion_created_by: Criada por
   discussion_updated: Consulta actualizada
   discussions: Consultas
+  discussions_read: Não lidas
+  discussions_unread: Não lidos
   discussions_will_be_here: As perguntas que você fizer no espaço de consulta aparecerão aqui.
   download: Faça o download do que você fez
   edit: Editar
@@ -274,7 +276,6 @@ pt:
   programming_since: Sou programador
   progress: Progresso
   publish_discussion: Postar consulta
-  read: Ler
   read_messages: Ver mensagens
   refresh_or_wait: Se não mostrar automaticamente em alguns segundos, pressione F5
   reply_count:

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -90,6 +90,7 @@ pt:
   disabled_organization_explanation: Este curso terminou
   discussion_description_placeholder: Você pode adicionar mais informações sobre sua dúvida
   new_discussion_message: Nova mensagem em %{title}
+  discussion_created_by: Criada por
   discussion_updated: Consulta actualizada
   discussions: Consultas
   discussions_will_be_here: As perguntas que você fizer no espaço de consulta aparecerão aqui.
@@ -174,6 +175,7 @@ pt:
   kids_default_success: Você fez muito bem!
   language: Linguagem
   languages: Linguagens
+  last_message: Última mensagem
   last_name: Sobrenome
   last_submission_date: Última solução
   latest_exercises: Últimos exercícios

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 5.1.6"
 
-  s.add_dependency 'mumuki-domain', '~> 9.9.0'
+  s.add_dependency 'mumuki-domain', '~> 9.10.0'
   s.add_dependency 'mumukit-bridge', '~> 4.1'
   s.add_dependency 'mumukit-login', '~> 7.6'
   s.add_dependency 'mumukit-nuntius', '~> 6.1'


### PR DESCRIPTION
## :dart: Goal

Add pagination to user discussions. Closes https://github.com/mumuki/mumuki-laboratory/issues/1625.

## :memo: Details

* Unread discussions are prioritized and now show before read discussions. I was inspired by that Gmail configuration where you can always see your unread mails at the top regardless of their date. Please note that the motivation for this is so no unread discussions get lost in the second (or third or fourth) page. Otherwise, we'd have to add a `Unread` messages counter somewhere, or make it filterable, or something along those lines. I thought it was simpler to just show them at the top since that's what a user will mostly be interested in anyway.

* The table-striped look was replaced by a cleaner design (I hope!)

* The icon for a read discussion is now an open envelope.

* We now also show who created the discussion. This is useful especially for moderators, who participate in a wide variety of discussions. Note that a student could also benefit from it, as not only self-created discussions appear in this view, but those that they subscribed to as well.

## :camera_flash: Screenshots

### Before

![image](https://user-images.githubusercontent.com/11304439/127257881-76fb0ba1-003b-4eb6-806b-ceefa41ae355.png)

______

### After (first page)

![image](https://user-images.githubusercontent.com/11304439/127255775-fceeccca-c538-4761-8060-28f94505a522.png)

_____

### After (last page)

![image](https://user-images.githubusercontent.com/11304439/127256016-3368d995-e261-453f-95af-d5643c8d7c9f.png)


## :warning: Dependencies

https://github.com/mumuki/mumuki-domain/pull/231: Add scope for showing unread discussions first
