### PR TITLE
New discussions index view

### DIFF
--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
@@ -63,16 +63,12 @@ $moderator-badge-color: #dd9900;
     font-size: 1.3rem;
   }
 
-  .discussion-icon {
-    -ms-transform: scale(0.8, 0.8);
-    -webkit-transform: scale(0.8, 0.8);
-    transform: scale(0.8, 0.8);
-    margin-left: 5px;
-    float: right;
-    .fa-stack-1x {
-      -ms-transform: scale(0.9, 0.9);
-      -webkit-transform: scale(0.9, 0.9);
-      transform: scale(0.9, 0.9);
+  .discussion-validated-messages-count {
+    .fa-check {
+      font-size: 0.5rem;
+      position: absolute;
+      margin-left: -16px;
+      margin-top: 11px;
     }
   }
 }

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
@@ -315,6 +315,7 @@ $moderator-badge-color: #dd9900;
   border: 1px solid $discussion-message-border-color;
   border-radius: 3px;
   position: relative;
+  margin-bottom: 20px;
   .discussion-message-bubble-header {
     background-color: $mu-color-highlight-background;
     height: 40px;

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
@@ -58,8 +58,8 @@ $moderator-badge-color: #dd9900;
   }
 
   .discussion-language-icon {
-    display: flex;
-    align-items: center;
+    display: inline;
+    padding-right: 5px;
   }
 
   .discussion-validated-messages-count {
@@ -88,7 +88,7 @@ $moderator-badge-color: #dd9900;
 }
 
 .discussion-status-icon {
-  padding-right: 10px;
+  padding-right: 5px;
 }
 
 .discussion-row {
@@ -118,10 +118,6 @@ $moderator-badge-color: #dd9900;
   }
   .discussion-initiator {
     font-size: calc(#{$font-size-base} * 0.85);
-
-    img {
-      margin-top: -2px;
-    }
   }
 }
 

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
@@ -60,14 +60,13 @@ $moderator-badge-color: #dd9900;
   .discussion-language-icon {
     display: flex;
     align-items: center;
-    font-size: 1.3rem;
   }
 
   .discussion-validated-messages-count {
     .fa-check {
       font-size: 0.5rem;
       position: absolute;
-      margin-left: -16px;
+      margin-left: -13px;
       margin-top: 11px;
     }
   }
@@ -101,7 +100,12 @@ $moderator-badge-color: #dd9900;
   }
   .discussion-title-icons {
     display: flex;
+    flex-shrink: 0;
     align-items: center;
+
+    > * {
+      padding-left: 20px;
+    }
   }
   .discussion-description {
     overflow: hidden;

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
@@ -400,13 +400,3 @@ $moderator-badge-color: #dd9900;
     font-weight: normal;
   }
 }
-
-.discussion-moderator-access {
-  margin-right: 20px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  .moderator-initials {
-    font-size: 14px;
-  }
-}

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
@@ -64,10 +64,10 @@ $moderator-badge-color: #dd9900;
 
   .discussion-validated-messages-count {
     .fa-check {
-      font-size: 0.5rem;
+      font-size: calc(#{$font-size-base} * 0.5);
       position: absolute;
       margin-left: -13px;
-      margin-top: 11px;
+      margin-top: 10px;
     }
   }
 }
@@ -102,6 +102,7 @@ $moderator-badge-color: #dd9900;
     display: flex;
     flex-shrink: 0;
     align-items: center;
+    font-size: calc(#{$font-size-base} * 0.95);
 
     > * {
       padding-left: 20px;
@@ -113,8 +114,11 @@ $moderator-badge-color: #dd9900;
     text-overflow: ellipsis;
     white-space: nowrap;
     margin-bottom: 20px;
+    font-size: calc(#{$font-size-base} * 0.95);
   }
   .discussion-initiator {
+    font-size: calc(#{$font-size-base} * 0.85);
+
     img {
       margin-top: -2px;
     }

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
@@ -58,12 +58,9 @@ $moderator-badge-color: #dd9900;
   }
 
   .discussion-language-icon {
-    float: right;
-    margin-right: 10px;
-    margin-top: 6px;
-    -ms-transform: scale(1.4, 1.4);
-    -webkit-transform: scale(1.4, 1.4);
-    transform: scale(1.4, 1.4);
+    display: flex;
+    align-items: center;
+    font-size: 1.3rem;
   }
 
   .discussion-icon {
@@ -105,6 +102,10 @@ $moderator-badge-color: #dd9900;
   .discussion-title {
     font-size: 18px;
     font-weight: bold;
+  }
+  .discussion-title-icons {
+    display: flex;
+    align-items: center;
   }
   .discussion-description {
     overflow: hidden;

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
@@ -88,7 +88,7 @@ $moderator-badge-color: #dd9900;
 }
 
 .discussion-status-icon {
-  padding-right: 5px;
+  padding-left: 2px;
 }
 
 .discussion-row {

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
@@ -111,6 +111,12 @@ $moderator-badge-color: #dd9900;
     display: block;
     text-overflow: ellipsis;
     white-space: nowrap;
+    margin-bottom: 20px;
+  }
+  .discussion-initiator {
+    img {
+      margin-top: -2px;
+    }
   }
 }
 

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -60,7 +60,15 @@ module DiscussionsHelper
     }.html_safe
   end
 
-  def discussion_messages_icon(discussion)
+  def discussion_messages_count(discussion)
+    %Q{
+      <span class="discussion-messages-count">
+        #{fa_icon :comments, type: :regular, text: discussion.messages_count}
+      </span>
+    }.html_safe
+  end
+
+  def discussion_validated_messages_count(discussion)
     %Q{
       <span class="discussion-validated-messages-count">
         #{fa_icon :comment, type: :regular}

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -62,9 +62,9 @@ module DiscussionsHelper
 
   def discussion_messages_icon(discussion)
     %Q{
-      <span class="discussion-icon fa-stack fa-xs">
-        <i class="far fa-comment fa-stack-2x"></i>
-        <i class="fas fa-stack-1x">#{discussion.validated_messages_count}</i>
+      <span class="discussion-validated-messages-count">
+        #{fa_icon :comment, type: :regular}
+        #{fa_icon :check, text: discussion.validated_messages_count}
       </span>
     }.html_safe
   end

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -71,8 +71,7 @@ module DiscussionsHelper
   def discussion_validated_messages_count(discussion)
     %Q{
       <span class="discussion-validated-messages-count">
-        #{fa_icon :comment, type: :regular}
-        #{fa_icon :check, text: discussion.validated_messages_count}
+        #{fa_icon :comment, type: :regular}#{fa_icon :check, text: discussion.validated_messages_count}
       </span>
     }.html_safe
   end

--- a/app/views/discussions/new.html.erb
+++ b/app/views/discussions/new.html.erb
@@ -28,6 +28,6 @@
         </div>
       </div>
     </div>
-    <%= f.submit t(:save), class: 'btn btn-complementary w-100 discussion-new-message-button' %>
+    <%= f.submit t(:publish_discussion), class: 'btn btn-complementary w-100 discussion-new-message-button' %>
   <% end %>
 <% end %>

--- a/app/views/layouts/_discussions.html.erb
+++ b/app/views/layouts/_discussions.html.erb
@@ -40,43 +40,7 @@
       </span>
     </div>
   <% else %>
-    <div class="discussions">
-      <% @filtered_discussions.each do |discussion| %>
-        <%= link_to exercise_discussion_path(discussion.exercise.id, discussion) do %>
-          <div class="discussion">
-            <div class="discussion-row">
-              <%= discussion_messages_icon(discussion) %>
-              <% unless @debatable.respond_to? :language %>
-                <div class="discussion-language-icon">
-                  <%= language_icon(discussion.exercise.language) %>
-                </div>
-              <% end %>
-              <div>
-                <div class="discussion-title">
-                  <span class="discussion-status-icon">
-                    <%= discussion_status_fa_icon(discussion) %>
-                  </span>
-                  <span class="d-none d-lg-inline"><%= discussion.exercise.guide.name %> -</span>
-                  <span><%= discussion.exercise.name %></span>
-                  <% if discussion.current_responsible_visible_for?(current_user) %>
-                    <div class="float-end discussion-moderator-access" >
-                      <%= profile_picture_for(discussion.responsible_moderator_by, height: 32) %>
-                      <span class="moderator-initials">
-                        <%= discussion.responsible_moderator_by.name_initials %>
-                      </span>
-                    </div>
-                  <% end %>
-
-                </div>
-                <span class="discussion-description">
-                  <%= discussion.description %>
-                </span>
-              </div>
-            </div>
-          </div>
-        <% end %>
-      <% end %>
-    </div>
+    <%= render partial: 'layouts/discussions_list' %>
 
     <div class="discussion-pagination">
       <%= paginate @filtered_discussions, nav_class: 'pagination' %>

--- a/app/views/layouts/_discussions_list.html.erb
+++ b/app/views/layouts/_discussions_list.html.erb
@@ -11,7 +11,7 @@
               <span class="d-none d-lg-inline"><%= discussion.exercise.guide.name %> -</span>
               <span><%= discussion.exercise.name %></span>
               <% if discussion.current_responsible_visible_for?(current_user) %>
-                <span class="badge bg-light text-dark">
+                <span class="badge ms-1 bg-dark">
                   <%= responsible_moderator_text_for(discussion, current_user)%>
                 </span>
               <% end %>

--- a/app/views/layouts/_discussions_list.html.erb
+++ b/app/views/layouts/_discussions_list.html.erb
@@ -1,6 +1,6 @@
 <div class="discussions">
   <% @filtered_discussions.each do |discussion| %>
-    <%= link_to exercise_discussion_path(discussion.exercise.id, discussion) do %>
+    <%= link_to exercise_discussion_path(discussion.exercise.id, discussion), class: 'discussion-link' do %>
       <div class="discussion">
         <div class="discussion-row">
           <div class="d-flex justify-content-between">

--- a/app/views/layouts/_discussions_list.html.erb
+++ b/app/views/layouts/_discussions_list.html.erb
@@ -1,0 +1,37 @@
+<div class="discussions">
+  <% @filtered_discussions.each do |discussion| %>
+    <%= link_to exercise_discussion_path(discussion.exercise.id, discussion) do %>
+      <div class="discussion">
+        <div class="discussion-row">
+          <%= discussion_messages_icon(discussion) %>
+          <% unless @debatable.respond_to? :language %>
+            <div class="discussion-language-icon">
+              <%= language_icon(discussion.exercise.language) %>
+            </div>
+          <% end %>
+          <div>
+            <div class="discussion-title">
+              <span class="discussion-status-icon">
+                <%= discussion_status_fa_icon(discussion) %>
+              </span>
+              <span class="d-none d-lg-inline"><%= discussion.exercise.guide.name %> -</span>
+              <span><%= discussion.exercise.name %></span>
+              <% if discussion.current_responsible_visible_for?(current_user) %>
+                <div class="float-end discussion-moderator-access" >
+                  <%= profile_picture_for(discussion.responsible_moderator_by, height: 32) %>
+                  <span class="moderator-initials">
+                    <%= discussion.responsible_moderator_by.name_initials %>
+                  </span>
+                </div>
+              <% end %>
+
+            </div>
+            <span class="discussion-description">
+              <%= discussion.description %>
+            </span>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/layouts/_discussions_list.html.erb
+++ b/app/views/layouts/_discussions_list.html.erb
@@ -22,7 +22,8 @@
                   <%= language_icon(discussion.exercise.language) %>
                 </div>
               <% end %>
-              <%= discussion_messages_icon(discussion) %>
+              <%= discussion_messages_count(discussion) %>
+              <%= discussion_validated_messages_count(discussion) %>
             </div>
           </div>
           <span class="discussion-description">

--- a/app/views/layouts/_discussions_list.html.erb
+++ b/app/views/layouts/_discussions_list.html.erb
@@ -3,7 +3,7 @@
     <%= link_to exercise_discussion_path(discussion.exercise.id, discussion) do %>
       <div class="discussion">
         <div class="discussion-row">
-          <div class="d-flex">
+          <div class="d-flex justify-content-between">
             <div class="discussion-title">
               <span class="discussion-status-icon">
                 <%= discussion_status_fa_icon(discussion) %>
@@ -17,12 +17,12 @@
               <% end %>
             </div>
             <div class="discussion-title-icons">
-              <%= discussion_messages_icon(discussion) %>
               <% unless @debatable.respond_to? :language %>
                 <div class="discussion-language-icon">
                   <%= language_icon(discussion.exercise.language) %>
                 </div>
               <% end %>
+              <%= discussion_messages_icon(discussion) %>
             </div>
           </div>
           <span class="discussion-description">

--- a/app/views/layouts/_discussions_list.html.erb
+++ b/app/views/layouts/_discussions_list.html.erb
@@ -26,6 +26,11 @@
             <span class="discussion-description">
               <%= discussion.description %>
             </span>
+            <span class="discussion-initiator">
+              <%= profile_picture_for(discussion.initiator, height: 20) %>
+              <strong><%= discussion_user_name discussion.initiator %></strong>
+              <%= t(:asked_time_since, time: time_ago_in_words(discussion.created_at)) %>
+            </span>
           </div>
         </div>
       </div>

--- a/app/views/layouts/_discussions_list.html.erb
+++ b/app/views/layouts/_discussions_list.html.erb
@@ -5,9 +5,9 @@
         <div class="discussion-row">
           <div class="d-flex justify-content-between">
             <div class="discussion-title">
-              <span class="discussion-status-icon">
-                <%= discussion_status_fa_icon(discussion) %>
-              </span>
+              <div class="discussion-language-icon">
+                <%= language_icon(discussion.exercise.language) %>
+              </div>
               <span class="d-none d-lg-inline"><%= discussion.exercise.guide.name %> -</span>
               <span><%= discussion.exercise.name %></span>
               <% if discussion.current_responsible_visible_for?(current_user) %>
@@ -17,11 +17,6 @@
               <% end %>
             </div>
             <div class="discussion-title-icons">
-              <% unless @debatable.respond_to? :language %>
-                <div class="discussion-language-icon">
-                  <%= language_icon(discussion.exercise.language) %>
-                </div>
-              <% end %>
               <%= discussion_messages_count(discussion) %>
               <%= discussion_validated_messages_count(discussion) %>
             </div>
@@ -30,7 +25,9 @@
             <%= discussion.description %>
           </span>
           <span class="discussion-initiator">
-            <%= profile_picture_for(discussion.initiator, height: 20) %>
+            <span class="discussion-status-icon">
+              <%= discussion_status_fa_icon(discussion) %>
+            </span>
             <strong><%= discussion_user_name discussion.initiator %></strong>
             <%= t(:asked_time_since, time: time_ago_in_words(discussion.created_at)) %>
           </span>

--- a/app/views/layouts/_discussions_list.html.erb
+++ b/app/views/layouts/_discussions_list.html.erb
@@ -3,13 +3,7 @@
     <%= link_to exercise_discussion_path(discussion.exercise.id, discussion) do %>
       <div class="discussion">
         <div class="discussion-row">
-          <%= discussion_messages_icon(discussion) %>
-          <% unless @debatable.respond_to? :language %>
-            <div class="discussion-language-icon">
-              <%= language_icon(discussion.exercise.language) %>
-            </div>
-          <% end %>
-          <div>
+          <div class="d-flex">
             <div class="discussion-title">
               <span class="discussion-status-icon">
                 <%= discussion_status_fa_icon(discussion) %>
@@ -21,17 +15,24 @@
                   <%= responsible_moderator_text_for(discussion, current_user)%>
                 </span>
               <% end %>
-
             </div>
-            <span class="discussion-description">
-              <%= discussion.description %>
-            </span>
-            <span class="discussion-initiator">
-              <%= profile_picture_for(discussion.initiator, height: 20) %>
-              <strong><%= discussion_user_name discussion.initiator %></strong>
-              <%= t(:asked_time_since, time: time_ago_in_words(discussion.created_at)) %>
-            </span>
+            <div class="discussion-title-icons">
+              <%= discussion_messages_icon(discussion) %>
+              <% unless @debatable.respond_to? :language %>
+                <div class="discussion-language-icon">
+                  <%= language_icon(discussion.exercise.language) %>
+                </div>
+              <% end %>
+            </div>
           </div>
+          <span class="discussion-description">
+            <%= discussion.description %>
+          </span>
+          <span class="discussion-initiator">
+            <%= profile_picture_for(discussion.initiator, height: 20) %>
+            <strong><%= discussion_user_name discussion.initiator %></strong>
+            <%= t(:asked_time_since, time: time_ago_in_words(discussion.created_at)) %>
+          </span>
         </div>
       </div>
     <% end %>

--- a/app/views/layouts/_discussions_list.html.erb
+++ b/app/views/layouts/_discussions_list.html.erb
@@ -25,11 +25,11 @@
             <%= discussion.description %>
           </span>
           <span class="discussion-initiator">
+            <strong><%= discussion_user_name discussion.initiator %></strong>
+            <%= t(:asked_time_since, time: time_ago_in_words(discussion.created_at)) %>
             <span class="discussion-status-icon">
               <%= discussion_status_fa_icon(discussion) %>
             </span>
-            <strong><%= discussion_user_name discussion.initiator %></strong>
-            <%= t(:asked_time_since, time: time_ago_in_words(discussion.created_at)) %>
           </span>
         </div>
       </div>

--- a/app/views/layouts/_discussions_list.html.erb
+++ b/app/views/layouts/_discussions_list.html.erb
@@ -17,12 +17,9 @@
               <span class="d-none d-lg-inline"><%= discussion.exercise.guide.name %> -</span>
               <span><%= discussion.exercise.name %></span>
               <% if discussion.current_responsible_visible_for?(current_user) %>
-                <div class="float-end discussion-moderator-access" >
-                  <%= profile_picture_for(discussion.responsible_moderator_by, height: 32) %>
-                  <span class="moderator-initials">
-                    <%= discussion.responsible_moderator_by.name_initials %>
-                  </span>
-                </div>
+                <span class="badge bg-light text-dark">
+                  <%= responsible_moderator_text_for(discussion, current_user)%>
+                </span>
               <% end %>
 
             </div>

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -261,7 +261,8 @@ en:
   processing_your_solution: We are processing you solution
   profile_of: Profile of %{username}
   programming_since: Started programming
-  progress: Progresss
+  progress: Progress
+  publish_discussion: Publish discussion
   read: Read
   refresh_or_wait: Please press F5 if results are not displayed after a few seconds
   reply_count:

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -322,7 +322,7 @@ en:
   terms_and_conditions_continue_disclaimer: By continuing you agree to %{terms_link}
   terms_and_conditions_must_be_accepted: You must accept the terms and conditions
   test_results: Test results
-  time_ago: "%{time} ago"
+  time_since: "%{time} ago"
   time_left: You have
   title: Title
   to_closed: Close

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -21,6 +21,7 @@ en:
   ask_community: Ask community for help
   ask_redirect: Do you want to go there?
   ask_the_first_question: Be the first one to ask!
+  asked_time_since: asked %{time} ago
   attempts_left:
     zero: "You've run out of attempts"
     one: "1 attempt remaining"

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -11,11 +11,11 @@ es-CL:
   and: y
   appendix: Apéndice
   appendix_teaser: ¿Quieres saber más? <a href="%{link}">Consulta el apéndice de este capítulo</a>
-  approved_message: Validado por mentor
+  approved_message: Validado por mentorías
   approved_messages:
     one: validado
     other: validados
-  are_you_sure: '¿Estás seguro que quieres %{action}?'
+  are_you_sure: '¿Confirmas que quieres %{action}?'
   ask_a_question: ¡Haz una pregunta!
   ask_community: Pregunta a la comunidad
   ask_redirect: ¿Quieres que te llevemos ahí?

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -20,6 +20,7 @@ es-CL:
   ask_community: Pregunta a la comunidad
   ask_redirect: ¿Quieres que te llevemos ahí?
   ask_the_first_question: ¡Haz la primera pregunta!
+  asked_time_since: "consultó hace %{time}"
   attempts_left:
     zero: 'Te quedaste sin intentos'
     one: '1 intento restante'

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -11,11 +11,12 @@ es-CL:
   and: y
   appendix: Apéndice
   appendix_teaser: ¿Quieres saber más? <a href="%{link}">Consulta el apéndice de este capítulo</a>
-  are_you_sure: '¿Estás seguro que quieres %{action}?'
-  ask_a_question: ¡Haz una pregunta!
+  approved_message: Validado por mentor
   approved_messages:
     one: validado
     other: validados
+  are_you_sure: '¿Estás seguro que quieres %{action}?'
+  ask_a_question: ¡Haz una pregunta!
   ask_community: Pregunta a la comunidad
   ask_redirect: ¿Quieres que te llevemos ahí?
   ask_the_first_question: ¡Haz la primera pregunta!

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -270,6 +270,7 @@ es-CL:
   processing_your_solution: Estamos procesando tu solución
   profile_of: Perfil de %{username}
   progress: Progreso
+  publish_discussion: Publicar consulta
   read: Leído
   read_messages: Ver mensajes
   refresh_or_wait: Si no se muestra automáticamente en unos segundos, presiona F5

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -280,6 +280,7 @@ es:
   profile_of: Perfil de %{username}
   programming_since: Programando desde
   progress: Progreso
+  publish_discussion: Publicar consulta
   read: Leido
   read_messages: Ver mensajes
   refresh_or_wait: Si no se muestra automáticamente en unos segundos, presioná F5

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -23,6 +23,7 @@ es:
   ask_community: Preguntá a la comunidad
   ask_redirect: ¿Querés que te llevemos ahí?
   ask_the_first_question: ¡Hacé la primera pregunta!
+  asked_time_since: "consultó hace %{time}"
   attempts_left:
     zero: 'Te quedaste sin intentos'
     one: '1 intento restante'

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -15,11 +15,11 @@ es:
   appendix: Apéndice
   appendix_teaser: ¿Querés saber más? <a href="%{link}">Consultá el apéndice de este capítulo</a>
   approved_message: Validado por mentor
-  are_you_sure: '¿Estás seguro que querés %{action}?'
-  ask_a_question: ¡Hacé una pregunta!
   approved_messages:
     one: validado
     other: validados
+  are_you_sure: '¿Estás seguro que querés %{action}?'
+  ask_a_question: ¡Hacé una pregunta!
   ask_community: Preguntá a la comunidad
   ask_redirect: ¿Querés que te llevemos ahí?
   ask_the_first_question: ¡Hacé la primera pregunta!

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -14,11 +14,11 @@ es:
   and: y
   appendix: Apéndice
   appendix_teaser: ¿Querés saber más? <a href="%{link}">Consultá el apéndice de este capítulo</a>
-  approved_message: Validado por mentor
+  approved_message: Validado por mentorías
   approved_messages:
     one: validado
     other: validados
-  are_you_sure: '¿Estás seguro que querés %{action}?'
+  are_you_sure: '¿Confirmás que querés %{action}?'
   ask_a_question: ¡Hacé una pregunta!
   ask_community: Preguntá a la comunidad
   ask_redirect: ¿Querés que te llevemos ahí?

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -22,6 +22,7 @@ pt:
   ask_community: Pergunte à comunidade
   ask_redirect: Você quer que nós o levemos para lá?
   ask_the_first_question: Faça a primeira pergunta!
+  asked_time_since: "consultou há %{time}"
   attempts_left:
     zero: 'Você ficou sem tentativas'
     one: '1 tentativa restante'

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -14,10 +14,10 @@ pt:
   appendix: Apêndice
   appendix_teaser: Você quer saber mais? <a href="%{link}"> Consulte o apêndice deste capítulo </a>
   approved_message: Validado pelo mentor
-  are_you_sure: 'Tem certeza de que deseja %{action}?'
   approved_messages:
     one: validado
     other: validados
+  are_you_sure: 'Tem certeza de que deseja %{action}?'
   ask_a_question: Faça uma pergunta!
   ask_community: Pergunte à comunidade
   ask_redirect: Você quer que nós o levemos para lá?

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -271,6 +271,7 @@ pt:
   profile_of: Perfil de %{username}
   programming_since: Sou programador
   progress: Progresso
+  publish_discussion: Postar consulta
   read: Ler
   read_messages: Ver mensagens
   refresh_or_wait: Se não mostrar automaticamente em alguns segundos, pressione F5


### PR DESCRIPTION
## :dart: Goal

Redesign the discussions index on forum.

## :memo: Details

* Information about who initiated the discussion (and when) are added to each card.

* We now show both total number of messages _and_ total number of verified messages, instead of an ambiguous icon which showed verified messages count only.

* Moderator avatar + initials are replaced by a `taking care of` badge.

* Better support for custom CSS, so we can easily avoid changing the color of everything in the index when we change link colors

* When creating a discussion, the submit button now says `Publicar consulta` instead of `Guardar`.

## :camera_flash: Screenshots

### Before

![image](https://user-images.githubusercontent.com/11304439/127320495-49a9f9ca-d058-45cb-a016-0dcecf022623.png)

_______

### After - General view

![image](https://user-images.githubusercontent.com/11304439/127319149-a94cc6c6-5db4-4673-84ff-834b93ddba6b.png)

_______

### After - Mobile view

![image](https://user-images.githubusercontent.com/11304439/127320293-a3a42909-f425-43e0-84b7-5d2a86fbf367.png)
______

### :spiral_notepad: Note to reviewers

Because I designed this on-the-fly, a couple of commits do stuff that was later reversed. I'd normally try to rebase and remove those but it didn't prove too easy.

I also moved the whole discussions index to a new file, so history is a little hard to follow. I'd suggest looking at the final result instead of reviewing on a commit-per-commit basis.