### PR TITLE
Fix miscellaneous discussions issues

### DIFF
--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_faqs.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_faqs.scss
@@ -21,7 +21,7 @@
 
       @include media-breakpoint-down(md) {
         &:not(.active) {
-          h3, p {
+          h3, p, ul {
             display: none
           }
           h2 {

--- a/app/views/layouts/exercise_inputs/read_only_editors/_code.html.erb
+++ b/app/views/layouts/exercise_inputs/read_only_editors/_code.html.erb
@@ -1,3 +1,3 @@
 <div>
-  <%= read_only_editor content, exercise.language.name %>
+  <%= read_only_editor content, exercise.language.highlight_mode %>
 </div>

--- a/app/views/layouts/exercise_inputs/read_only_editors/_multiple_files.html.erb
+++ b/app/views/layouts/exercise_inputs/read_only_editors/_multiple_files.html.erb
@@ -4,10 +4,10 @@
 
   <div class="editor-files">
     <span class="files-tabs">
-      <ul class="nav nav-tabs">
+      <ul class="nav nav-tabs" role="tablist">
         <% files.each_with_index do |file, index| %>
-          <li role="presentation" class="file-tab <%= 'active' if index == 0 %>" data-bs-target="#editor-file-<%= index %>" tabindex='0' data-bs-toggle='tab'>
-            <a class="file-name" href="#"><%= file.name %></a>
+          <li role="presentation" class="nav-item file-tab">
+            <a class="file-name nav-link <%= 'active' if index == 0 %>" href="#" data-bs-target="#editor-file-<%= index %>" tabindex="0" data-bs-toggle="tab"><%= file.name %></a>
           </li>
         <% end %>
       </ul>
@@ -17,7 +17,7 @@
 
     <div class="tab-content">
       <% files.each_with_index do |file, index| %>
-        <div role="tabpanel" class="file-editor tab-pane mu-input-panel <%= 'fade in active' if index == 0 %>" id="editor-file-<%= index %>">
+        <div role="tabpanel" class="file-editor tab-pane mu-input-panel fade <%= 'show active' if index == 0 %>" id="editor-file-<%= index %>">
           <div class=<%="content[#{file.name}]"%>>
             <%= read_only_editor file.content, file.highlight_mode %>
           </div>

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -86,7 +86,7 @@ en:
   disabled_organization_explanation: This path has already finished.
   discussion_created_by: Created by
   discussion_description_placeholder: You can add more information regarding your doubt.
-  new_discussion_message: New message on %{title}
+  new_discussion_message: New reply on %{title}
   discussion_updated: Discussion updated
   discussions: Discussions
   discussions_read: Read

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -87,7 +87,7 @@ es-CL:
   details: Detalles
   disabled_explanation: Estás intentando acceder a un recurso que fue deshabilitado o eliminado de forma permanente
   disabled_organization_explanation: ¡Este recorrido ha finalizado!
-  new_discussion_message: Mensaje nuevo en %{title}
+  new_discussion_message: Respuesta nueva en %{title}
   discussion_created_by: Creada por
   discussion_updated: Consulta actualizada
   discussions: Consultas

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -95,7 +95,7 @@ es:
   discussion_created_by: Creada por
   discussion_description_placeholder: Podés agregar información para detallar más tu consulta
   discussion_updated: Consulta actualizada
-  new_discussion_message: Mensaje nuevo en %{title}
+  new_discussion_message: Respuesta nueva en %{title}
   discussions: Consultas
   discussions_read: Leídas
   discussions_unread: No leídas

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -89,7 +89,7 @@ pt:
   disabled_explanation: Você está tentando acessar um recurso que foi desativado ou removido permanentemente
   disabled_organization_explanation: Este curso terminou
   discussion_description_placeholder: Você pode adicionar mais informações sobre sua dúvida
-  new_discussion_message: Nova mensagem em %{title}
+  new_discussion_message: Nova resposta em %{title}
   discussion_created_by: Criada por
   discussion_updated: Consulta actualizada
   discussions: Consultas


### PR DESCRIPTION
## :dart: Goal

Close some discussions issues and a FAQs issue.

## :memo: Details

* The discussion view was broken for multifile exercises. This was an oversight after migrating to Bootstrap 5.
* Python3 (as well as SQLite, QSim and others as I discovered) syntax highlightning was not working on discussion editors.
* The notification for a new discussion message, `Mensaje nuevo en...`, was changed to `Respuesta nueva en...` to avoid confusion with the `Mensajes` section on the profile, which is actually reserved for raise-your-hand direct messages.
* Fix a bug where some FAQs content wouldn't hide properly on mobile screens. (Closes https://github.com/mumuki/mumuki-laboratory/issues/1651)

## :camera_flash: Screenshots

### Multifile discussion

![image](https://user-images.githubusercontent.com/11304439/128407955-6259278b-c9ad-4375-ae72-3bacd55d33e6.png)
![image](https://user-images.githubusercontent.com/11304439/128408108-109f4303-5509-4f9e-b4b3-ec8e2baa4ef4.png)
![image](https://user-images.githubusercontent.com/11304439/128408139-9b7f0f6f-5c22-4d88-a852-7316c47dc7bb.png)
______

### Python3 discussion
![image](https://user-images.githubusercontent.com/11304439/128407911-1496a0f7-410e-4540-a7d2-9f8cc1c02298.png)


