### PR TITLE
Fix toggle read tooltip

### DIFF
--- a/app/views/users/notifications.html.erb
+++ b/app/views/users/notifications.html.erb
@@ -32,7 +32,7 @@
           <% @notifications.each do |notification| %>
             <tr class="<%= background_for_notification notification %>" >
               <td class="col-md-1">
-                <%= link_to icon_for_read(notification.read?), "notifications/#{notification.id}/toggle_read", tooltip_options(:read).merge(method: :post, role: :button) %>
+                <%= link_to icon_for_read(notification.read?), "notifications/#{notification.id}/toggle_read", tooltip_options(:toggle_read).merge(method: :post, role: :button) %>
               </td>
               <td class="col-md-8 text-break">
                 <%= render partial: "notifications/#{notification.subject}", locals: { notification: notification } %>

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -366,6 +366,7 @@ en:
   to_opened: Reopen
   to_pending_review: Mark as solved
   to_solved: Mark as solved
+  toggle_read: "Toggle read/unread"
   unauthorized_explanation: You have no permissions for this content. Maybe you logged in with another account.
   total: Total
   undo_upvote: Undo upvote

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -378,6 +378,7 @@ es-CL:
   to_opened: Reabrir
   to_pending_review: Resolver
   to_solved: Resolver
+  toggle_read: "Marcar como leído/no leído"
   unauthorized_explanation: ¡Ups! Esto es lo que se conoce como %{error}, es decir que no iniciaste sesión.
   total: Total
   uncategorized: No categorizado

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -392,6 +392,7 @@ es:
   to_opened: Reabrir
   to_pending_review: Resolver
   to_solved: Resolver
+  toggle_read: "Marcar como leído/no leído"
   unauthorized_explanation: ¡Ups! Esto es lo que se conoce como %{error}, es decir que no iniciaste sesión.
   total: Total
   uncategorized: No categorizado

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -379,6 +379,7 @@ pt:
   to_opened: Reabrir
   to_pending_review: Marcar como resolvida
   to_solved: Marcar como resolvida
+  toggle_read: "Marcar como lido / não lido"
   unauthorized_explanation: Opa! Isso é o que é conhecido como %{error}, ou seja, você não fez logon.
   total: Total
   uncategorized: Não classificado


### PR DESCRIPTION
## :dart: Goal
Add missing toggle read translation.

## :memo: Details
Fixes https://github.com/mumuki/mumuki-laboratory/issues/1653.

## :camera_flash: Screenshots
![image](https://user-images.githubusercontent.com/11720274/128536144-78b26e1c-f344-45dd-bbd1-019e6e7d839c.png)

## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.
