### PR TITLE
Show only current organization notifications

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -56,7 +56,7 @@ class UsersController < ApplicationController
   end
 
   def notifications
-    @notifications = @user.notifications.order(created_at: :desc).page(params[:page])
+    @notifications = @user.notifications_in_organization.order(created_at: :desc).page(params[:page])
   end
 
   def toggle_read

--- a/app/views/users/manage_notifications.html.erb
+++ b/app/views/users/manage_notifications.html.erb
@@ -9,7 +9,7 @@
         <h1><%= t(:manage_notifications) %></h1>
         <div class="mu-profile-actions d-none d-md-block">
           <a class="btn btn-secondary" href="<%= notifications_user_path %>">Cancelar</a>
-          <button type="submit" class="btn btn-complementary"><%= t :submit %></button>
+          <button type="submit" class="btn btn-complementary"><%= t :save %></button>
         </div>
       </div>
 


### PR DESCRIPTION
## :dart: Goal
Showing notifications + previews only for current organization.

## :memo: Details
If user disables emails for a certain notification type this could make it hard to know if they've received a notification at all if they don't go into the proper organization. Thoughts @flbulgarelli ?

## :camera_flash: Screenshots
![Peek 2021-08-10 17-23](https://user-images.githubusercontent.com/11720274/128930088-1d842de9-852e-406c-8720-c4159c9390cd.gif)

## :warning: Dependencies
https://github.com/mumuki/mumuki-domain/pull/235.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.