### PR TITLE
Introduce pristine flag

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/bridge.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/bridge.js
@@ -47,6 +47,12 @@
  */
 
 /**
+ * A submission, composed by:
+ *
+ *  * its actual contents
+ *  * the client results
+ *  * the _pristine flag, that tells whether the submission has been sent without previous results
+ *
  * @typedef {Contents & {client_result?: SubmissionClientResult, _pristine: boolean}} Submission
  */
 

--- a/app/assets/javascripts/mumuki_laboratory/application/bridge.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/bridge.js
@@ -83,10 +83,11 @@ mumuki.bridge = (() => {
      */
     _submitSolution(submission) {
       const lastSubmission = mumuki.SubmissionsStore.getSubmissionResultFor(mumuki.exercise.id, submission);
-      if (lastSubmission) {
+      if (!mumuki.submission.pristine && lastSubmission) {
         return $.Deferred().resolve(lastSubmission);
       } else {
         return this._sendNewSolution(submission).done((result) => {
+          mumuki.submission.pristine = false;
           mumuki.SubmissionsStore.setSubmissionResultFor(mumuki.exercise.id, {submission, result});
         });
       }

--- a/app/assets/javascripts/mumuki_laboratory/application/bridge.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/bridge.js
@@ -47,7 +47,7 @@
  */
 
 /**
- * @typedef {Contents & {client_result?: SubmissionClientResult}} Submission
+ * @typedef {Contents & {client_result?: SubmissionClientResult, _pristine: boolean}} Submission
  */
 
 /**
@@ -83,13 +83,12 @@ mumuki.bridge = (() => {
      */
     _submitSolution(submission) {
       const lastSubmission = mumuki.SubmissionsStore.getSubmissionResultFor(mumuki.exercise.id, submission);
-      if (!mumuki.submission.pristine && lastSubmission) {
-        return $.Deferred().resolve(lastSubmission);
-      } else {
+      if (submission._pristine || !lastSubmission) {
         return this._sendNewSolution(submission).done((result) => {
-          mumuki.submission.pristine = false;
           mumuki.SubmissionsStore.setSubmissionResultFor(mumuki.exercise.id, {submission, result});
         });
+      } else {
+        return $.Deferred().resolve(lastSubmission);
       }
     }
 

--- a/app/assets/javascripts/mumuki_laboratory/application/editors.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/editors.js
@@ -55,12 +55,14 @@ mumuki.editors = {
    * @returns {Submission}
    */
   getSubmission() {
-    let content = {};
+    let submission = {
+      _pristine: $('.submission-results').children().length === 0
+    };
     let contents = this.getContents();
     contents.forEach((it) => {
-      content[it.name] = it.value;
+      submission[it.name] = it.value;
     });
-    return content;
+    return submission;
   },
 
   /**

--- a/app/assets/javascripts/mumuki_laboratory/application/submission.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/submission.js
@@ -169,7 +169,6 @@ mumuki.submission = (() => {
     const buttonClass = mumuki.isKidsExercise() ? KidsSubmitButton : SubmitButton;
     const submitButton = new buttonClass($btnSubmit, $('.submission_control'));
     mumuki.submission._selectSolutionProcessor(submitButton, $submissionsResults);
-    mumuki.submission.pristine = !$submissionsResults.children().length;
 
     submitButton.start(() => {
       mumuki.submission.processSolution(mumuki.editors.getSubmission());

--- a/app/assets/javascripts/mumuki_laboratory/application/submission.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/submission.js
@@ -169,6 +169,7 @@ mumuki.submission = (() => {
     const buttonClass = mumuki.isKidsExercise() ? KidsSubmitButton : SubmitButton;
     const submitButton = new buttonClass($btnSubmit, $('.submission_control'));
     mumuki.submission._selectSolutionProcessor(submitButton, $submissionsResults);
+    mumuki.submission.pristine = !$submissionsResults.children().length;
 
     submitButton.start(() => {
       mumuki.submission.processSolution(mumuki.editors.getSubmission());

--- a/app/assets/javascripts/mumuki_laboratory/application/submissions-store.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/submissions-store.js
@@ -89,8 +89,14 @@ mumuki.SubmissionsStore = (() => {
 
     // private API
 
-    _asString(object) {
-      return JSON.stringify(object);
+    /**
+     * Serializes the submission and result.
+     * Private attributes are ignored
+     */
+    _asString(submissionAndResult) {
+      return JSON.stringify(submissionAndResult, (key, value) => {
+        if (!key.startsWith("_")) return value
+      });
     }
 
     _keyFor(exerciseId) {

--- a/spec/javascripts/editors-spec.js
+++ b/spec/javascripts/editors-spec.js
@@ -33,7 +33,7 @@ describe('editors', () => {
       }
     });
 
-    expect(mumuki.editors.getSubmission()).toEqual({"solution[content]":"the custom solution"});
+    expect(mumuki.editors.getSubmission()).toEqual({"_pristine": true, "solution[content]":"the custom solution"});
   });
 
   it('reads the form if no sources', () => {
@@ -43,7 +43,24 @@ describe('editors', () => {
         <textarea class="form-control editor" name="solution[content]" id="solution_content">the solution</textarea>
       </div>
     </form>`);
-    expect(mumuki.editors.getSubmission()).toEqual({"solution[content]":"the solution"});
+    expect(mumuki.editors.getSubmission()).toEqual({"_pristine": true, "solution[content]":"the solution"});
+  });
+
+  it('reads the form when it is not the first submission', () => {
+    $('body').html(`
+    <form role="form" class="new_solution">
+      <div class="editor-code">
+        <textarea class="form-control editor" name="solution[content]" id="solution_content">the solution</textarea>
+      </div>
+    </form>
+    <div class=" submission-results">
+      <div class="bs-callout bs-callout-success">
+        <h4 class="text-success">
+          <strong><i class="fas fa-check-circle"></i> ¡Muy bien!</strong>
+        </h4>
+      </div>
+    </div>`);
+    expect(mumuki.editors.getSubmission()).toEqual({"_pristine": false, "solution[content]":"the solution"});
   });
 
   it('reads the form if no sources and exercise is multifile', () => {
@@ -63,6 +80,7 @@ describe('editors', () => {
       </div>
     </form>`);
     expect(mumuki.editors.getSubmission()).toEqual({
+      "_pristine": true,
       "solution[content[index.html]]": "some html",
       "solution[content[receta.css]]": "some css"
     });
@@ -70,6 +88,6 @@ describe('editors', () => {
 
   it('produces empty submission if no form nor sources', () => {
     $('body').html(``);
-    expect(mumuki.editors.getSubmission()).toEqual({});
+    expect(mumuki.editors.getSubmission()).toEqual({_pristine: true});
   });
 });

--- a/spec/javascripts/submissions-store-spec.js
+++ b/spec/javascripts/submissions-store-spec.js
@@ -18,6 +18,17 @@ describe("SubmissionsStore", () => {
       mumuki.SubmissionsStore.setSubmissionResultFor(1, passedEmptyProgramSubmissionAndResult);
       expect(mumuki.SubmissionsStore.getLastSubmissionAndResult(1)).toEqual(passedEmptyProgramSubmissionAndResult);
     });
+
+    it("answers the last submission result, ignoring pristiness", () => {
+      mumuki.SubmissionsStore.setSubmissionResultFor(1, {
+        submission: {
+          ...emptyProgramSubmission,
+          _pristine: true
+        },
+        result: passedSubmissionResult
+      });
+      expect(mumuki.SubmissionsStore.getLastSubmissionAndResult(1)).toEqual(passedEmptyProgramSubmissionAndResult);
+    });
   });
 
   describe('getLastSubmissionStatus', () => {


### PR DESCRIPTION
## :dart: Goal

To avoid looking for cached results when a solution to a given exercise is sent for the time after a progress reset. 

## :memo: Details

Currently, when a submission is sent, `SubmissionStore` is always queried. However, when progress has been reset at server side, this may prevent solutions to been actually sent - since they are fetched from cache. 

This PR avoids this issue by introducing the `_pristine` flag, which reflects whether there are previous results at UI when a submission is sent. This has the following benefits: 

1. Application records reflect whether a submission is the first one at that assignment from a user-perspective: 

```
Started POST "/central/exercises/3952-fundamentos-primeros-programas-que-comience-el-movimiento/solutions" for 127.0.0.1 at 2021-08-11 17:43:05 -0300
Processing by ExerciseSolutionsController#create as */*
  Parameters: {"_pristine"=>"false", "utf8"=>"✓", "solution"=>{"content"=>"program { }"}, "tenant"=>"central", "exercise_id"=>"3952-fundamentos-primeros-programas-que-comience-el-movimiento"}
```

2. `_pristine` submissions are never looked-up into the submission-store, thus avoiding the original issue. 

Since `_pristine` flag should not be cached, I have introduced a default mechanism for ignoring transient attributes, which filters `_{attribute}` attributes from serialization. 

## :test_tube: Test steps

1. Solve the first 4 exercises of this guide: http://localhost:3000/central/lessons/153-fundamentos-primeros-programas
2. Delete all the assignments: `Assignment.delete_all` 
3. Refresh the page and try all the exercises again

## :back: Backwards compatibility

100% backward compatible

