### PR TITLE
Fix email timezones

### DIFF
--- a/app/helpers/time_zone_helper.rb
+++ b/app/helpers/time_zone_helper.rb
@@ -1,0 +1,5 @@
+module TimeZoneHelper
+  def local_time(time, time_zone = Time.zone.name)
+    "#{l(time.in_time_zone(time_zone), format: :long)} (#{time_zone})"
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,8 @@
 class UserMailer < ApplicationMailer
   include WithCertificateRender
 
+  helper :time_zone
+
   def welcome_email(user, organization)
     with_locale(user, organization) do
       organization_name = organization.display_name || t(:your_new_organization)

--- a/app/views/user_mailer/notifications/_exam_registration.html.erb
+++ b/app/views/user_mailer/notifications/_exam_registration.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'user_mailer/mail_template', locals: {
   title: t("mailer.title.exam_registration"),
   subtitle: t("mailer.subtitle.exam_registration"),
-  text: t("mailer.text.exam_registration", exam_registration_deadline: l(@notification.target.end_time, format: :long)),
+  text: t("mailer.text.exam_registration", exam_registration_deadline: "#{l(@notification.target.end_time.in_time_zone(@organization.time_zone), format: :long)} (#{@organization.time_zone})"),
   button: t("mailer.button.exam_registration"),
   url: exam_registration_url(@organization, @notification.target)
 } %>

--- a/app/views/user_mailer/notifications/_exam_registration.html.erb
+++ b/app/views/user_mailer/notifications/_exam_registration.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'user_mailer/mail_template', locals: {
   title: t("mailer.title.exam_registration"),
   subtitle: t("mailer.subtitle.exam_registration"),
-  text: t("mailer.text.exam_registration", exam_registration_deadline: "#{l(@notification.target.end_time.in_time_zone(@organization.time_zone), format: :long)} (#{@organization.time_zone})"),
+  text: t("mailer.text.exam_registration", exam_registration_deadline: local_time(@notification.target.end_time, @organization.time_zone)),
   button: t("mailer.button.exam_registration"),
   url: exam_registration_url(@organization, @notification.target)
 } %>

--- a/app/views/user_mailer/notifications/exam_authorization_request_updated/_approved.html.erb
+++ b/app/views/user_mailer/notifications/exam_authorization_request_updated/_approved.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'user_mailer/mail_template', locals: {
   title: t(:congratulations),
   subtitle: t('mailer.subtitle.exam_authorization_request_approved'),
-  text: t('mailer.text.exam_authorization_request_approved', exam_start_date: l(@notification.target.exam.start_time, format: :long)),
+  text: t('mailer.text.exam_authorization_request_approved', exam_start_date: "#{l(@notification.target.exam.start_time.in_time_zone(@organization.time_zone), format: :long)} (#{@organization.time_zone})"),
   button: t('mailer.button.exam_authorization_request_approved'),
   url: @organization.url
 } %>

--- a/app/views/user_mailer/notifications/exam_authorization_request_updated/_approved.html.erb
+++ b/app/views/user_mailer/notifications/exam_authorization_request_updated/_approved.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'user_mailer/mail_template', locals: {
   title: t(:congratulations),
   subtitle: t('mailer.subtitle.exam_authorization_request_approved'),
-  text: t('mailer.text.exam_authorization_request_approved', exam_start_date: "#{l(@notification.target.exam.start_time.in_time_zone(@organization.time_zone), format: :long)} (#{@organization.time_zone})"),
+  text: t('mailer.text.exam_authorization_request_approved', exam_start_date: local_time(@notification.target.exam.start_time, @organization.time_zone)),
   button: t('mailer.button.exam_authorization_request_approved'),
   url: @organization.url
 } %>

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 5.1.6"
 
-  s.add_dependency 'mumuki-domain', '~> 9.11.0'
+  s.add_dependency 'mumuki-domain', '~> 9.12.0'
   s.add_dependency 'mumukit-bridge', '~> 4.1'
   s.add_dependency 'mumukit-login', '~> 7.6'
   s.add_dependency 'mumukit-nuntius', '~> 6.1'

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -7,18 +7,63 @@ class UserMailerPreview < ActionMailer::Preview
   end
 
   def custom_content_plain_text_notification
-    UserMailer.notification notification
+    UserMailer.notification notification subject: :custom,
+                                         custom_content_plain_text: 'This is the text of the mail. Awesome!',
+                                         custom_title: 'This is the title!'
   end
 
   def custom_content_html_notification
-    UserMailer.notification notification(custom_content_html: 'This is <em>the text</em> of the mail. <strong>Awesome!</strong>')
+    UserMailer.notification notification subject: :custom,
+                                         custom_content_html: 'This is <em>the text</em> of the mail. <strong>Awesome!</strong>',
+                                         custom_title: 'This is the title!'
   end
 
   def certificate_preview
     UserMailer.certificate certificate
   end
 
+  def exam_registration_preview
+    notification = notification target: exam_registration, subject: :exam_registration
+
+    UserMailer.notification notification
+  end
+
+  def exam_authorization_request_approved
+    notification = notification target: exam_authorization_request('approved'), subject: :exam_authorization_request_updated
+
+    UserMailer.notification notification
+  end
+
+  def exam_authorization_request_rejected
+    notification = notification target: exam_authorization_request('rejected'), subject: :exam_authorization_request_updated
+
+    UserMailer.notification notification
+  end
+
   private
+
+  def exam_registration
+    ExamRegistration.new id: 1,
+                         organization: organization,
+                         description: 'Some test description',
+                         start_time: 5.minute.ago,
+                         end_time: 5.minutes.since
+
+  end
+
+  def exam_authorization_request(status)
+    ExamAuthorizationRequest.new id: 1,
+                                 user: user,
+                                 status: status,
+                                 exam: exam,
+                                 organization: organization
+  end
+
+  def exam
+    Exam.new organization: organization,
+             start_time: 5.minute.ago,
+             end_time: 5.minutes.since
+  end
 
   def user
     User.new uid: 'some_user@gmail.com',
@@ -45,9 +90,6 @@ class UserMailerPreview < ActionMailer::Preview
 
   def notification(**hash)
     Notification.new({user: user,
-                     organization: organization,
-                     subject: :custom,
-                     custom_content_plain_text: 'This is the text of the mail. Awesome!',
-                     custom_title: 'This is the title!'}.merge hash)
+                     organization: organization}.merge hash)
   end
 end


### PR DESCRIPTION
## :dart: Goal
Fix time zone display for exam registration and exam authorization request emails.

## :memo: Details
None.

## :camera_flash: Screenshots
![image](https://user-images.githubusercontent.com/11720274/129091020-d0ae8839-b5ca-4e30-82c4-70b15a2070df.png)
![image](https://user-images.githubusercontent.com/11720274/129091065-2b7c66e1-4263-460d-bc73-823591278429.png)

## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.
