### PR TITLE
Redirect after confirmation

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/bridge.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/bridge.js
@@ -13,7 +13,9 @@
  * @typedef {{
   *  status: SubmissionStatus,
   *  class_for_progress_list_item?: string,
-  *  guide_finished_by_solution?: boolean
+  *  guide_finished_by_solution?: boolean,
+  *  title_html?: string,
+  *  in_gamified_context?: boolean
   * }} SubmissionResult
   */
 
@@ -107,14 +109,12 @@ mumuki.bridge = (() => {
     }
 
     /**
-     * Pre-renders some html parts of submission UI, adding them to the given result
-     *
      * @param {SubmissionResult} result
      * @returns {SubmissionResult}
+     * @see mumuki.renderers.results.preRenderResult
      */
     _preRenderResult(result) {
-      result.class_for_progress_list_item = mumuki.renderers.results.progressListItemClassForStatus(result.status, true);
-      result.title_html = mumuki.renderers.results.translatedTitleHtml(result.status, result.in_gamified_context);
+      mumuki.renderers.results.preRenderResult(result);
       return result;
     }
   }

--- a/app/assets/javascripts/mumuki_laboratory/application/confirmation.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/confirmation.js
@@ -1,17 +1,19 @@
 mumuki.load(() => {
-  $('.btn-confirmation').on('click change', function (_evt) {
-    var token = new mumuki.CsrfToken();
+  $('.btn-confirmation').on('click change', function (_event) {
+    const token = new mumuki.CsrfToken();
+    const $element = $(this);
 
     $.ajax(token.newRequest({
       method: 'POST',
-      url: $(this).data('confirmation-url'),
+      url: $element.data('confirmation-url'),
       xhrFields: {withCredentials: true},
-      success: function(data){
-        mumuki.updateProgressBarAndShowModal(data);
+      success: function(result) {
+        result.status = "passed";
+        mumuki.renderers.results.preRenderResult(result)
+        mumuki.updateProgressBarAndShowModal(result);
+        window.location = $element.attr("href");
       }
     }));
-
-    return true;
+    return false;
   });
 });
-

--- a/app/assets/javascripts/mumuki_laboratory/application/progress.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/progress.js
@@ -2,11 +2,11 @@ mumuki.progress = (() => {
   /**
    * Updates the current exercise progress indicator
    *
-   * @param {SubmissionResult} data
+   * @param {SubmissionResult} result
    * */
-  function updateProgressBarAndShowModal(data) {
-    $('.progress-list-item.active').attr('class', data.class_for_progress_list_item);
-    if(data.guide_finished_by_solution) new bootstrap.Modal('#guide-done').show();
+  function updateProgressBarAndShowModal(result) {
+    $('.progress-list-item.active').attr('class', result.class_for_progress_list_item);
+    if(result.guide_finished_by_solution) new bootstrap.Modal('#guide-done').show();
   }
 
   /**

--- a/app/assets/javascripts/mumuki_laboratory/application/results-renderer.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/results-renderer.js
@@ -71,11 +71,22 @@ mumuki.renderers.results = (() => {
     return `progress-list-item text-center ${classForStatus(status)} ${active ? 'active' : ''}`;
   }
 
+  /**
+   * Pre-renders some html parts of submission UI, adding them to the given result
+   *
+   * @param {SubmissionResult} result
+   */
+  function preRenderResult(result) {
+    result.class_for_progress_list_item = progressListItemClassForStatus(result.status, true);
+    result.title_html = translatedTitleHtml(result.status, result.in_gamified_context);
+  }
+
   return {
     classForStatus,
     iconForStatus,
     progressListItemClassForStatus,
-    translatedTitleHtml
+    translatedTitleHtml,
+    preRenderResult
   };
 })();
 


### PR DESCRIPTION
## :dart: Goal

To fix the confirmation button, which redirected to the next exercise before it was actually confirmed.  

## :memo: Details

I refactored the prerender logic to make available to the `confirmation` module and manually generated the `passed` status, since status bar was not being updated. Finally, redirection is now performed manually. 

## :movie_camera:  Videos


### Before

https://user-images.githubusercontent.com/677436/129109694-4464a229-9dc2-4bed-9201-15bf63c1068e.mp4

### After

https://user-images.githubusercontent.com/677436/129109756-167602d4-c9f6-47a7-be83-1126b96be343.mp4

## :back: Backwards compatibility

100% backwards compatible


