### PR TITLE
Include organization query param on logout url

### DIFF
--- a/app/helpers/menu_bar_helper.rb
+++ b/app/helpers/menu_bar_helper.rb
@@ -36,7 +36,7 @@ module MenuBarHelper
   end
 
   def logout_menu_link
-    li_tag menu_item('sign-out-alt', :sign_out, logout_path(origin: url_for))
+    li_tag menu_item('sign-out-alt', :sign_out, logout_path(origin: url_for, organization: Organization.current))
   end
 
   def menu_item(icon, name, url, css_class = nil, **translation_params)

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'mumuki-domain', '~> 9.12.0'
   s.add_dependency 'mumukit-bridge', '~> 4.1'
-  s.add_dependency 'mumukit-login', '~> 7.6'
+  s.add_dependency 'mumukit-login', '~> 7.7'
   s.add_dependency 'mumukit-nuntius', '~> 6.1'
   s.add_dependency 'mumukit-auth', '~> 7.8'
   s.add_dependency 'mumukit-content-type', '~> 1.9'


### PR DESCRIPTION
## :dart: Goal
Logout logic requires obtaining proper login_provider, but organization is currently unobtainable in logout request.

## :warning: Dependencies
https://github.com/mumuki/mumukit-login/pull/49. (Not really _dependent_ on it, but it's related)

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.
