### PR TITLE
Add spell checker to new message editor on discussions

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/codemirror-builder.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/codemirror-builder.js
@@ -71,6 +71,15 @@
       return this;
     }
 
+    setupSpellCheckedEditor() {
+      this.editor = this.createEditor({
+        inputStyle: 'contenteditable',
+        spellcheck: true
+      });
+
+      return this;
+    }
+
     setupLanguage(language) {
       var highlightMode = language || this.$textarea.data('editor-language');
       if (highlightMode === 'dynamic') {

--- a/app/assets/javascripts/mumuki_laboratory/application/discussions.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/discussions.js
@@ -9,12 +9,13 @@ mumuki.load(() => {
 
   function createNewMessageEditor() {
     var $textarea = $("#discussion-new-message");
-    var textarea = $textarea[0];
-    if (!textarea) return;
+    var editorContainer = $(".mu-spell-checked-editor")[0];
+    if (!editorContainer) return;
 
-    return new mumuki.editor.CodeMirrorBuilder(textarea)
-      .setupSimpleEditor()
+    return new mumuki.editor.CodeMirrorBuilder(editorContainer)
+      .setupSpellCheckedEditor()
       .setupMinLines($textarea.data('lines'))
+      .setupLanguage()
       .build();
   }
 

--- a/app/helpers/editor_helper.rb
+++ b/app/helpers/editor_helper.rb
@@ -10,4 +10,9 @@ module EditorHelper
     editor_options = editor_defaults(language, options, 'read-only-editor')
     text_area_tag :solution_content, content, editor_options
   end
+
+  def spell_checked_editor(name, options = {})
+    editor_options = editor_defaults('markdown', options, 'form-control mu-spell-checked-editor')
+    text_area_tag name, '', editor_options
+  end
 end

--- a/app/views/discussions/_new_message.html.erb
+++ b/app/views/discussions/_new_message.html.erb
@@ -10,7 +10,7 @@
         <div class="container-fluid">
           <div class="row">
             <div class="discussion-new-message-content">
-              <%= f.editor :content, '', { id: 'discussion-new-message', class: 'form-control', placeholder: t(:message) } %>
+              <%= spell_checked_editor 'message[content]', { id: 'discussion-new-message', placeholder: t(:message) } %>
             </div>
             <div class="discussion-message-content d-none" id="discussion-new-message-preview"></div>
           </div>


### PR DESCRIPTION
## :dart: Goal

Add spell checker capabilities to new discussion message textbox. This will only work if the user has their browser's spell checker enabled.
 
## :memo: Details

Also, now that markdown is explicitly set as the editor language, the new discussion message text area now features live formatting.

## :camera_flash: Screenshots
![Screenshot 2021-08-23 at 08-45-45 Student4 M - Aprendé a programar](https://user-images.githubusercontent.com/11304439/130460411-d87b061a-ae51-450a-801c-7fd78e54f9c5.png)
![Screenshot 2021-08-23 at 10-06-34 Student4 M - Aprendé a programar](https://user-images.githubusercontent.com/11304439/130460422-65898fe2-7f08-4c36-b34b-e43f8d189ad9.png)



## :warning: Known issues



