### PR TITLE
New exam registration notices

### DIFF
--- a/app/controllers/exam_authorization_requests_controller.rb
+++ b/app/controllers/exam_authorization_requests_controller.rb
@@ -31,6 +31,6 @@ class ExamAuthorizationRequestsController < ApplicationController
 
   def verify_registration_opened!
     exam_registration = ExamRegistration.find(authorization_request_params[:exam_registration_id])
-    raise Mumuki::Domain::GoneError if exam_registration.end_time.past?
+    raise Mumuki::Domain::GoneError if exam_registration.ended?
   end
 end

--- a/app/helpers/exam_registration_helper.rb
+++ b/app/helpers/exam_registration_helper.rb
@@ -1,6 +1,6 @@
 module ExamRegistrationHelper
   def exam_registration_view
-    if @registration.end_time.past?
+    if @registration.ended?
       { icon: :times_circle, class: :danger, t: :exam_registration_finished_html }
     else
       { icon: :info_circle, class: :info, t: :exam_registration_explanation_html }

--- a/app/views/exam_authorization_requests/_pending.html.erb
+++ b/app/views/exam_authorization_requests/_pending.html.erb
@@ -5,4 +5,8 @@
         end_time: l(authorization_request.exam_registration.end_time, format: :long),
         location: Organization.current.time_zone,
         edit_path: url_for(authorization_request.exam_registration) %>
+<% else %>
+  <%= t :exam_authorization_pending_done_html,
+        end_time: l(authorization_request.exam_registration.end_time, format: :long),
+        location: Organization.current.time_zone %>
 <% end %>

--- a/app/views/exam_authorization_requests/_pending.html.erb
+++ b/app/views/exam_authorization_requests/_pending.html.erb
@@ -1,5 +1,4 @@
 <%= t :exam_authorization_pending_explanation_html,
-      date: l(authorization_request.exam.start_time, format: :long),
       end_time: l(authorization_request.exam_registration.end_time, format: :long),
       location: Organization.current.time_zone,
       edit_path: url_for(authorization_request.exam_registration) %>

--- a/app/views/exam_authorization_requests/_pending.html.erb
+++ b/app/views/exam_authorization_requests/_pending.html.erb
@@ -1,7 +1,7 @@
 <% if authorization_request.exam_registration.ended? %>
   <%= t :exam_authorization_pending_confirmation_soon_html %>
-<% else %>
-  <%= t :exam_authorization_pending_explanation_html,
+<% elsif authorization_request.exam_registration.multiple_options? %>
+  <%= t :exam_authorization_pending_change_date_html,
         end_time: l(authorization_request.exam_registration.end_time, format: :long),
         location: Organization.current.time_zone,
         edit_path: url_for(authorization_request.exam_registration) %>

--- a/app/views/exam_authorization_requests/_pending.html.erb
+++ b/app/views/exam_authorization_requests/_pending.html.erb
@@ -1,4 +1,8 @@
-<%= t :exam_authorization_pending_explanation_html,
-      end_time: l(authorization_request.exam_registration.end_time, format: :long),
-      location: Organization.current.time_zone,
-      edit_path: url_for(authorization_request.exam_registration) %>
+<% if authorization_request.exam_registration.ended? %>
+  <%= t :exam_authorization_pending_confirmation_soon_html %>
+<% else %>
+  <%= t :exam_authorization_pending_explanation_html,
+        end_time: l(authorization_request.exam_registration.end_time, format: :long),
+        location: Organization.current.time_zone,
+        edit_path: url_for(authorization_request.exam_registration) %>
+<% end %>

--- a/app/views/exam_registrations/show.html.erb
+++ b/app/views/exam_registrations/show.html.erb
@@ -20,7 +20,7 @@
         <%= t exam_registration_view[:t], date: l(@registration.end_time, format: :long), location: Organization.current.time_zone %>
       </p>
     </div>
-    <% unless @registration.end_time.past? %>
+    <% unless @registration.ended? %>
       <%= form_for @authorization_request, html: {class: 'mu-form'} do |f| %>
         <%= f.hidden_field :exam_registration_id, value: @registration.id %>
         <div class="mb-4">

--- a/app/views/exam_registrations/show.html.erb
+++ b/app/views/exam_registrations/show.html.erb
@@ -23,14 +23,16 @@
     <% unless @registration.end_time.past? %>
       <%= form_for @authorization_request, html: {class: 'mu-form'} do |f| %>
         <%= f.hidden_field :exam_registration_id, value: @registration.id %>
-        <%= f.label :exam_id, t(:exam_registration_choose_exam) %>
-        <% @registration.exams.each do |exam| %>
-          <div class="form-check">
-            <%= f.radio_button(:exam_id, exam.id, id: exam.id, required: true, class: 'form-check-input mu-read-only-input',
-                               checked: @authorization_request.exam_id == exam.id) %>
-            <%= label_tag exam.id, "#{l(exam.start_time, format: :long)} #{current_time_zone_html}".html_safe, class: 'form-check-label' %>
-          </div>
-        <% end %>
+        <div class="mb-4">
+          <%= f.label :exam_id, t(:exam_registration_choose_exam) %>
+          <% @registration.exams.each do |exam| %>
+            <div class="form-check">
+              <%= f.radio_button(:exam_id, exam.id, id: exam.id, required: true, class: 'form-check-input mu-read-only-input',
+                                 checked: @authorization_request.exam_id == exam.id) %>
+              <%= label_tag exam.id, "#{l(exam.start_time, format: :long)} #{current_time_zone_html}".html_safe, class: 'form-check-label' %>
+            </div>
+          <% end %>
+        </div>
         <button class="btn btn-complementary"> <%= t :save %> </button>
       <% end %>
     <% end %>

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -118,6 +118,7 @@ es-CL:
   errored: ¡Ups! Tu solución no se puede ejecutar
   exam_authorization_pending_confirmation_soon_html: El período de inscripción a este examen ha finalizado. Tu solicitud será evaluada pronto y recibirás una confirmación. <br> ¡No olvides revisar las notificaciones!
   exam_authorization_pending_change_date_html: Tienes tiempo hasta el <strong>%{end_time}</strong> (hora de %{location}) para cambiar el turno haciendo click <strong><a href="%{edit_path}">aquí</a></strong>. Pasada esa fecha, tu solicitud será evaluada y recibirás una confirmación. <br> ¡No olvides revisar las notificaciones!
+  exam_authorization_pending_done_html: Ya te inscribiste a este examen. Luego del <strong>%{end_time}</strong> (hora de %{location}) se evaluará tu solicitud y recibirás una confirmación. <br> ¡No olvides de revisar las notificaciones!
   exam_authorization_request_approved_html: Tu solicitud fue aprobada, no olvides conectarte el <strong>%{date}</strong> (hora de %{location}). ¡Buena suerte!
   exam_authorization_request_created: ¡Tu inscripción al examen se registró exitosamente!
   exam_authorization_request_rejected: Tu solicitud fue rechazada porque no cumpliste con los requisitos para rendir el examen.

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -116,7 +116,7 @@ es-CL:
       internal_server_error: ¡Ups! Algo no anduvo bien
       not_found: ¡Ups!  La página no existe
   errored: ¡Ups! Tu solución no se puede ejecutar
-  exam_authorization_pending_explanation_html: Tienes tiempo hasta el <strong>%{end_time}</strong> (hora de %{location}) para inscribirte. Pasada esa fecha, tu solicitud será evaluada y recibirás una confirmación. <br> ¡No olvides revisar las notificaciones!
+  exam_authorization_pending_explanation_html: Tienes tiempo hasta el <strong>%{end_time}</strong> (hora de %{location}) para cambiar el turno haciendo click <strong><a href="%{edit_path}">aquí</a></strong>. Pasada esa fecha, tu solicitud será evaluada y recibirás una confirmación. <br> ¡No olvides revisar las notificaciones!
   exam_authorization_request_approved_html: Tu solicitud fue aprobada, no olvides conectarte el <strong>%{date}</strong> (hora de %{location}). ¡Buena suerte!
   exam_authorization_request_created: ¡Tu inscripción al examen se registró exitosamente!
   exam_authorization_request_rejected: Tu solicitud fue rechazada porque no cumpliste con los requisitos para rendir el examen.

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -117,7 +117,7 @@ es-CL:
       not_found: ¡Ups!  La página no existe
   errored: ¡Ups! Tu solución no se puede ejecutar
   exam_authorization_pending_confirmation_soon_html: El período de inscripción a este examen ha finalizado. Tu solicitud será evaluada pronto y recibirás una confirmación. <br> ¡No olvides revisar las notificaciones!
-  exam_authorization_pending_explanation_html: Tienes tiempo hasta el <strong>%{end_time}</strong> (hora de %{location}) para cambiar el turno haciendo click <strong><a href="%{edit_path}">aquí</a></strong>. Pasada esa fecha, tu solicitud será evaluada y recibirás una confirmación. <br> ¡No olvides revisar las notificaciones!
+  exam_authorization_pending_change_date_html: Tienes tiempo hasta el <strong>%{end_time}</strong> (hora de %{location}) para cambiar el turno haciendo click <strong><a href="%{edit_path}">aquí</a></strong>. Pasada esa fecha, tu solicitud será evaluada y recibirás una confirmación. <br> ¡No olvides revisar las notificaciones!
   exam_authorization_request_approved_html: Tu solicitud fue aprobada, no olvides conectarte el <strong>%{date}</strong> (hora de %{location}). ¡Buena suerte!
   exam_authorization_request_created: ¡Tu inscripción al examen se registró exitosamente!
   exam_authorization_request_rejected: Tu solicitud fue rechazada porque no cumpliste con los requisitos para rendir el examen.

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -118,11 +118,11 @@ es-CL:
   errored: ¡Ups! Tu solución no se puede ejecutar
   exam_authorization_pending_explanation_html: Tienes tiempo hasta el <strong>%{end_time}</strong> (hora de %{location}) para inscribirte. Pasada esa fecha, tu solicitud será evaluada y recibirás una confirmación. <br> ¡No olvides revisar las notificaciones!
   exam_authorization_request_approved_html: Tu solicitud fue aprobada, no olvides conectarte el <strong>%{date}</strong> (hora de %{location}). ¡Buena suerte!
-  exam_authorization_request_created: ¡Tu inscripción al exámen se registró exitosamente!
+  exam_authorization_request_created: ¡Tu inscripción al examen se registró exitosamente!
   exam_authorization_request_rejected: Tu solicitud fue rechazada porque no cumpliste con los requisitos para rendir el examen.
-  exam_authorization_request_saved: ¡Tu inscripción al exámen se modificó exitosamente!
+  exam_authorization_request_saved: ¡Tu inscripción al examen se modificó exitosamente!
   exam_authorization_request_updated: Hay novedades sobre tu inscripción a %{description}
-  exam_registration_choose_exam: Seleccioná día y horario en el que te gustaría rendir el exámen
+  exam_registration_choose_exam: Seleccioná día y horario en el que te gustaría rendir el examen
   exam_registration_explanation_html: Tienes tiempo hasta el <strong>%{date}</strong> (hora de %{location}) para inscribirte. Pasada esa fecha, tu solicitud será evaluada y recibirás una confirmación. <br> ¡No olvides revisar las notificaciones!
   exam_registration_finished_html: La inscripción a este examen finalizó el <strong>%{date}</strong> (hora de %{location})
   exam_registration_open: ¡Ya puedes inscribirte a %{description}!

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -116,6 +116,7 @@ es-CL:
       internal_server_error: ¡Ups! Algo no anduvo bien
       not_found: ¡Ups!  La página no existe
   errored: ¡Ups! Tu solución no se puede ejecutar
+  exam_authorization_pending_confirmation_soon_html: El período de inscripción a este examen ha finalizado. Tu solicitud será evaluada pronto y recibirás una confirmación. <br> ¡No olvides revisar las notificaciones!
   exam_authorization_pending_explanation_html: Tienes tiempo hasta el <strong>%{end_time}</strong> (hora de %{location}) para cambiar el turno haciendo click <strong><a href="%{edit_path}">aquí</a></strong>. Pasada esa fecha, tu solicitud será evaluada y recibirás una confirmación. <br> ¡No olvides revisar las notificaciones!
   exam_authorization_request_approved_html: Tu solicitud fue aprobada, no olvides conectarte el <strong>%{date}</strong> (hora de %{location}). ¡Buena suerte!
   exam_authorization_request_created: ¡Tu inscripción al examen se registró exitosamente!

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -123,6 +123,7 @@ es:
       internal_server_error: ¡Ups! Algo no anduvo bien
       not_found: ¡Ups!  La página no existe
   errored: ¡Ups! Tu solución no se puede ejecutar
+  exam_authorization_pending_confirmation_soon_html: El período de inscripción a este examen ha finalizado. Tu solicitud será evaluada pronto y recibirás una confirmación. <br> ¡No te olvides de revisar las notificaciones!
   exam_authorization_pending_explanation_html: Tenés tiempo hasta el <strong>%{end_time}</strong> (hora de %{location}) para cambiar el turno haciendo click <strong><a href="%{edit_path}">acá</a></strong>. Pasada esa fecha, tu solicitud será evaluada y recibirás una confirmación. <br> ¡No te olvides de revisar las notificaciones!
   exam_authorization_request_approved_html: Tu solicitud fue aprobada, no olvides conectarte el <strong>%{date}</strong> (hora de %{location}). ¡Buena suerte!
   exam_authorization_request_created: ¡Tu inscripción al examen se registró exitosamente!

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -125,11 +125,11 @@ es:
   errored: ¡Ups! Tu solución no se puede ejecutar
   exam_authorization_pending_explanation_html: Tenés tiempo hasta el <strong>%{end_time}</strong> (hora de %{location}) para cambiar el turno haciendo click <strong><a href="%{edit_path}">acá</a></strong>. Pasada esa fecha, tu solicitud será evaluada y recibirás una confirmación. <br> ¡No te olvides de revisar las notificaciones!
   exam_authorization_request_approved_html: Tu solicitud fue aprobada, no olvides conectarte el <strong>%{date}</strong> (hora de %{location}). ¡Buena suerte!
-  exam_authorization_request_created: ¡Tu inscripción al exámen se registró exitosamente!
+  exam_authorization_request_created: ¡Tu inscripción al examen se registró exitosamente!
   exam_authorization_request_rejected: Tu solicitud fue rechazada porque no cumpliste con los requisitos para rendir el examen.
-  exam_authorization_request_saved: ¡Tu inscripción al exámen se modificó exitosamente!
+  exam_authorization_request_saved: ¡Tu inscripción al examen se modificó exitosamente!
   exam_authorization_request_updated: Hay novedades sobre tu inscripción a %{description}
-  exam_registration_choose_exam: Seleccioná día y horario en el que te gustaría rendir el exámen
+  exam_registration_choose_exam: Seleccioná día y horario en el que te gustaría rendir el examen
   exam_registration_explanation_html: Tenés tiempo hasta el <strong>%{date}</strong> (hora de %{location}) para inscribirte. Pasada esa fecha, tu solicitud será evaluada y recibirás una confirmación. <br> ¡No te olvides de revisar las notificaciones!
   exam_registration_finished_html: La inscripción a este examen finalizó el <strong>%{date}</strong> (hora de %{location})
   exam_registration_open: ¡Ya podés inscribirte a %{description}!

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -125,6 +125,7 @@ es:
   errored: ¡Ups! Tu solución no se puede ejecutar
   exam_authorization_pending_confirmation_soon_html: El período de inscripción a este examen ha finalizado. Tu solicitud será evaluada pronto y recibirás una confirmación. <br> ¡No te olvides de revisar las notificaciones!
   exam_authorization_pending_change_date_html: Tenés tiempo hasta el <strong>%{end_time}</strong> (hora de %{location}) para cambiar el turno haciendo click <strong><a href="%{edit_path}">acá</a></strong>. Pasada esa fecha, tu solicitud será evaluada y recibirás una confirmación. <br> ¡No te olvides de revisar las notificaciones!
+  exam_authorization_pending_done_html: Ya te inscribiste a este examen. Luego del <strong>%{end_time}</strong> (hora de %{location}) se evaluará tu solicitud y recibirás una confirmación. <br> ¡No te olvides de revisar las notificaciones!
   exam_authorization_request_approved_html: Tu solicitud fue aprobada, no olvides conectarte el <strong>%{date}</strong> (hora de %{location}). ¡Buena suerte!
   exam_authorization_request_created: ¡Tu inscripción al examen se registró exitosamente!
   exam_authorization_request_rejected: Tu solicitud fue rechazada porque no cumpliste con los requisitos para rendir el examen.

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -124,7 +124,7 @@ es:
       not_found: ¡Ups!  La página no existe
   errored: ¡Ups! Tu solución no se puede ejecutar
   exam_authorization_pending_confirmation_soon_html: El período de inscripción a este examen ha finalizado. Tu solicitud será evaluada pronto y recibirás una confirmación. <br> ¡No te olvides de revisar las notificaciones!
-  exam_authorization_pending_explanation_html: Tenés tiempo hasta el <strong>%{end_time}</strong> (hora de %{location}) para cambiar el turno haciendo click <strong><a href="%{edit_path}">acá</a></strong>. Pasada esa fecha, tu solicitud será evaluada y recibirás una confirmación. <br> ¡No te olvides de revisar las notificaciones!
+  exam_authorization_pending_change_date_html: Tenés tiempo hasta el <strong>%{end_time}</strong> (hora de %{location}) para cambiar el turno haciendo click <strong><a href="%{edit_path}">acá</a></strong>. Pasada esa fecha, tu solicitud será evaluada y recibirás una confirmación. <br> ¡No te olvides de revisar las notificaciones!
   exam_authorization_request_approved_html: Tu solicitud fue aprobada, no olvides conectarte el <strong>%{date}</strong> (hora de %{location}). ¡Buena suerte!
   exam_authorization_request_created: ¡Tu inscripción al examen se registró exitosamente!
   exam_authorization_request_rejected: Tu solicitud fue rechazada porque no cumpliste con los requisitos para rendir el examen.

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 5.1.6"
 
-  s.add_dependency 'mumuki-domain', '~> 9.13.1'
+  s.add_dependency 'mumuki-domain', '~> 9.14.0'
   s.add_dependency 'mumukit-bridge', '~> 4.1'
   s.add_dependency 'mumukit-login', '~> 7.7'
   s.add_dependency 'mumukit-nuntius', '~> 6.1'


### PR DESCRIPTION
## :dart: Goal

Show clearer notices regarding exam registrations. 

## :memo: Details

The option to change exam date is no longer available if there's only one possible option.

Also, show a different notice for those small time windows where the inscription time is over but the results haven't been processed yet. It shouldn't occur for more than a couple minutes with our current configuration, but it'll be clearer for anxious students who want to know their result as soon as the inscription time is over.

## :camera_flash: Screenshots
### Exam with multiple options
Nothing changed in this case
![Screenshot 2021-08-30 at 09-12-39 Aprendé a programar](https://user-images.githubusercontent.com/11304439/131344312-92391ed4-ba0f-4305-b2ae-0b176684b926.png)
____
### Exam with single option
The link to change option is not shown
![Screenshot 2021-08-30 at 09-05-07 Aprendé a programar](https://user-images.githubusercontent.com/11304439/131344467-36590e6d-68da-4391-9c6d-a4419684e5e9.png)
____
### Exam registration time is over (regardless of # of options)
![Screenshot 2021-08-30 at 09-06-46 Aprendé a programar](https://user-images.githubusercontent.com/11304439/131344716-22d5b6c2-6143-4cff-bb1b-a5818e8eff11.png)

## :warning: Dependencies

https://github.com/mumuki/mumuki-domain/pull/239

## :back: Backwards compatibility
Yes

