### PR TITLE
Fix hide choices results on exams

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/results-renderer.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/results-renderer.js
@@ -27,11 +27,12 @@ mumuki.renderers.results = (() => {
    */
   function classForStatus(status) {
     switch (status) {
-      case "errored":              return "broken";
-      case "failed":               return "danger";
-      case "passed_with_warnings": return "warning";
-      case "passed":               return "success";
-      case "pending":              return "muted";
+      case "errored":                   return "broken";
+      case "failed":                    return "danger";
+      case "manual_evaluation_pending": return "info";
+      case "passed_with_warnings":      return "warning";
+      case "passed":                    return "success";
+      case "pending":                   return "muted";
     }
   }
 

--- a/app/controllers/exercise_solutions_controller.rb
+++ b/app/controllers/exercise_solutions_controller.rb
@@ -8,7 +8,7 @@ class ExerciseSolutionsController < AjaxController
 
   def create
     assignment = @exercise.try_submit_solution!(current_user, solution_params)
-    render_results_json assignment, status: assignment.status
+    render_results_json assignment, status: assignment.visible_status
   end
 
   private


### PR DESCRIPTION
## :dart: Goal
Fix a bug where, on single or multiple choice exercises during exams with `results_hidden_for_choices: true`, the progress bar would still be colored red or green depending on the answer, revealing if it's right or not.

## :memo: Details
This would only occur right after the solution was sent; refreshing would actually render the progress bar with the correct color for pending, which is blue. This led me to think it was a bug with the results rendering controller, which responds to an AJAX request to render everything result-related, while a fresh page load (which shows the correct color) doesn't go through this controller.

Indeed, the response from a solution sent would be a JSON like

```
{
  "status": "failed",
  "guide_finished_by_solution": false,
  "html": "..."
  "remaining_attempts_html": null,
  "current_exp": 350,
  "in_gamified_context": true
}
```
with status `failed` when it should be pending, as to not reveal the correct answer (not only visually! The HTTP response itself shouldn't give away the answer either).

I changed the controller to not respond with an assignment's `status` but rather its `visible_status`. See how `visible_status` considers cases where the results are hidden, such as choices on exams (when configured like so): https://github.com/mumuki/mumuki-domain/blob/11c4ef924047606116705fe4c3b4701dfd1f7647/app/models/assignment.rb#L77-L83

## :camera_flash: Screenshots

### Now the progress bar is blue in all cases, including before refreshing.

![image](https://user-images.githubusercontent.com/11304439/131776224-a71d6cd1-ce16-499a-9312-cd5bb7a2a156.png)


### A side-bug that I fixed: manual evaluation pending exercises wouldn't update the progress bar when sending a solution, because it wasn't considered a possible status (like passed, failed, etc were). It'd stay gray, as it's the default color). Before:

![Screenshot 2021-09-01 at 23-48-31 Programación con Objetos Herencia - La defensa - Aprendé a programar](https://user-images.githubusercontent.com/11304439/131776522-84ed6e6f-aa27-4940-b3b0-3ccf90d74906.png)


### Now:

![Screenshot 2021-09-01 at 23-49-33 Programación con Objetos Herencia - La defensa - Aprendé a programar](https://user-images.githubusercontent.com/11304439/131776514-64806001-aee5-4e86-b101-4db8a365135d.png)


## :warning: Known issues
[#1669 Experience should not be awarded during exams](https://github.com/mumuki/mumuki-laboratory/issues/1669)

