### PR TITLE
Fix progress loss on queries

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/codemirror-builder.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/codemirror-builder.js
@@ -27,7 +27,11 @@
       this.$textarea = $(textarea);
     }
 
-    setupEditor() {
+    setupEditor(readonly = false) {
+      return readonly ? this._setupReadOnlyEditor() : this._setupCommonEditor();
+    }
+
+    _setupCommonEditor() {
       this.editor = this.createEditor({
         lineNumbers: true,
         extraKeys: {
@@ -61,7 +65,7 @@
       return this;
     }
 
-    setupReadOnlyEditor() {
+    _setupReadOnlyEditor() {
       this.editor = this.createEditor({
         readOnly: true,
         cursorBlinkRate: -1, //Hides the cursor

--- a/app/assets/javascripts/mumuki_laboratory/application/codemirror.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/codemirror.js
@@ -6,10 +6,11 @@ mumuki.page.editors = [];
 (() => {
   function createCodeMirrors() {
     return $(".editor").map(function (index, textarea) {
-      var $textarea = $("#solution_content");
+      const $textarea = $("#solution_content");
+      const readonly = $textarea.data('readonly');
 
       return new mumuki.editor.CodeMirrorBuilder(textarea)
-        .setupEditor()
+        .setupEditor(readonly)
         .setupMinLines($textarea.data('lines'))
         .setupLanguage()
         .build();

--- a/app/assets/javascripts/mumuki_laboratory/application/console.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/console.js
@@ -87,7 +87,7 @@
     }
     get content() {
       var firstEditor = mumuki.page.editors[0];
-      if (firstEditor && $("#include_solution").prop("checked"))
+      if (firstEditor && this.includeSolution())
         return firstEditor.getValue();
       else
         return '';
@@ -141,6 +141,12 @@
     }
     get _requestData() {
       return {content: this.content, query: this.line, cookie: this.cookie};
+    }
+    includeSolution() {
+      return !this._includeSolutionCheckbox || this._includeSolutionCheckbox.checked;
+    }
+    get _includeSolutionCheckbox() {
+      return $("#include_solution")[0];
     }
   }
 

--- a/app/assets/javascripts/mumuki_laboratory/application/discussions.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/discussions.js
@@ -19,19 +19,6 @@ mumuki.load(() => {
       .build();
   }
 
-  function createReadOnlyEditors() {
-    return $(".read-only-editor").map(function (index, textarea) {
-      var $textarea = $("#solution_content");
-
-      return new mumuki.editor.CodeMirrorBuilder(textarea)
-        .setupReadOnlyEditor()
-        .setupMinLines($textarea.data('lines'))
-        .setupLanguage()
-        .build();
-    });
-  }
-
-  createReadOnlyEditors();
   let editor = createNewMessageEditor();
 
   var Forum = {

--- a/app/assets/javascripts/mumuki_laboratory/application/exercise.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/exercise.js
@@ -1,3 +1,23 @@
+(() => {
+  function solutionChangedSinceLastSubmission() {
+    return  mumuki.exercise.id &&
+            mumuki.SubmissionsStore.getLastSubmissionAndResult(mumuki.exercise.id) &&
+            !mumuki.SubmissionsStore.getSubmissionResultFor(mumuki.exercise.id, mumuki.editors.getSubmission());
+  }
+
+  window.addEventListener("beforeunload", (event) => {
+    if (solutionChangedSinceLastSubmission()) {
+      event.returnValue = 'unsaved_progress';
+    } else {
+      delete event['returnValue'];
+    }
+  });
+
+  window.addEventListener("turbolinks:before-visit", (event) => {
+    if (solutionChangedSinceLastSubmission() && !confirm(mumuki.I18n.t('unsaved_progress'))) event.preventDefault();
+  });
+})();
+
 /**
  * @typedef {"input_right" | "input_bottom" | "input_primary" | "input_kindergarten"} Layout
  * @typedef {{id: number, layout: Layout, settings: any}} Exercise

--- a/app/assets/javascripts/mumuki_laboratory/application/i18n.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/i18n.js
@@ -9,6 +9,7 @@ mumuki.I18n = (() => {
       passed_with_warnings: () => "Tu solución funcionó, pero hay cosas que mejorar",
       pending: () => "Pendiente",
       skipped: () => "Venís aprendiendo muy bien, por lo que aprobaste este ejercicio",
+      unsaved_progress: () => "Tu solución tiene cambios sin guardar, ¿Querés salir de todos modos?",
     },
     'es-CL': {
       aborted: () => "Ups, no pudimos evaluar tu solución",
@@ -18,6 +19,7 @@ mumuki.I18n = (() => {
       passed_with_warnings: () => "Tu solución funcionó, pero hay cosas que mejorar",
       pending: () => "Pendiente",
       skipped: () => "Vienes aprendiendo muy bien, por lo que aprobaste este ejercicio",
+      unsaved_progress: () => "Tu solución tiene cambios sin guardar, ¿Quieres salir de todos modos?",
     },
     'en': {
       aborted: () => "Oops, we couldn't evaluate your solution",
@@ -27,6 +29,7 @@ mumuki.I18n = (() => {
       passed_with_warnings: () => "It worked, but you can do better",
       pending: () => "Pending",
       skipped: () => "You are doing very well, so you've passed this exercise",
+      unsaved_progress: () => "Your solution has unsaved changes, leave anyways?",
     },
     'pt': {
       aborted: () => "Opa, não pudemos avaliar sua solução",
@@ -36,6 +39,7 @@ mumuki.I18n = (() => {
       passed_with_warnings: () => "Sua solução funcionou, mas há coisas para melhorar",
       pending: () => "Pendente",
       skipped: () => "Você está aprendendo muito bem e passou neste exercício",
+      unsaved_progress: () => "Sua solução tem alterações não salvas. Deseja sair mesmo assim?",
     }
   }
 

--- a/app/helpers/editor_helper.rb
+++ b/app/helpers/editor_helper.rb
@@ -7,7 +7,7 @@ module EditorHelper
   end
 
   def read_only_editor(content, language, options = {})
-    editor_options = editor_defaults(language, options, 'read-only-editor')
+    editor_options = editor_defaults(language, options.deep_merge(data: { readonly: true }), 'editor')
     text_area_tag :solution_content, content, editor_options
   end
 

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 5.1.6"
 
-  s.add_dependency 'mumuki-domain', '~> 9.14.1'
+  s.add_dependency 'mumuki-domain', '~> 9.15.0'
   s.add_dependency 'mumukit-bridge', '~> 4.1'
   s.add_dependency 'mumukit-login', '~> 7.7'
   s.add_dependency 'mumukit-nuntius', '~> 6.1'


### PR DESCRIPTION
## :dart: Goal
This is meant to be a permanent fix to the progress loss when sending queries on discussions / sending queries without including solution content.
This also fixes console on discussion never including the solution content, which was also part of the culprit in the progress loss bug.

## :memo: Details
Solution is now **always** included in discussion console. I think this behavior is preferrable to never including it, though IMO it would be nice to have an includeSolution checkbox there too.
A confirm is shown before switching exercises / views when solution has changed but hasn't been submitted with a nice, descriptive message.
A confirm is shown before closing tab / window when solution has changed but hasn't been submitted with a not so nice, descriptive message. Turns out for security reasons, modern browsers disallow setting a custom message for the tab closing confirm. Nothing we can do there.

## :camera_flash: Screenshots
https://user-images.githubusercontent.com/11720274/132376071-8ecc7a4e-f5d9-4ee9-8e63-f08617cb98fc.mp4

## :warning: Dependencies
Depends on https://github.com/mumuki/mumuki-domain/pull/238.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.
