### PR TITLE
Show solutions and results tabs on discussions even when no solution present

### DIFF
--- a/app/views/exercises/_read_only.html.erb
+++ b/app/views/exercises/_read_only.html.erb
@@ -73,17 +73,15 @@
         </ul>
 
         <div class="tab-content">
-          <div role="tabpanel" class="tab-pane active" id="solution">
+          <div role="tabpanel" class="tab-pane mu-input-panel fade show active" id="solution">
             <div class="mu-tab-body">
-              <div role="tabpanel" class="tab-pane mu-input-panel fade show active" id="editor">
-                <div class="mu-read-only-editor">
-                  <%= render_exercise_read_only_editor exercise, @discussion.solution %>
-                </div>
+              <div class="mu-read-only-editor">
+                <%= render_exercise_read_only_editor exercise, @discussion.solution %>
               </div>
             </div>
           </div>
 
-          <div role="tabpanel" class="tab-pane" id="results">
+          <div role="tabpanel" class="tab-pane fade" id="results">
             <div class="mu-tab-body">
               <%= render layout: 'exercise_solutions/contextualization_results_container', locals: { contextualization: @discussion } do %>
                 <div class="row">
@@ -96,7 +94,7 @@
             </div>
           </div>
 
-          <div role="tabpanel" class="tab-pane" id="content">
+          <div role="tabpanel" class="tab-pane fade" id="content">
             <div class="mu-tab-body">
               <div class="exercise-assignment">
                 <%= render partial: 'exercises/exercise_assignment', locals: { exercise: exercise } %>

--- a/app/views/exercises/_read_only.html.erb
+++ b/app/views/exercises/_read_only.html.erb
@@ -47,22 +47,18 @@
 
       <% if should_render_read_only_exercise_tabs?(@discussion) %>
         <ul class="nav nav-tabs discussion-tabs" role="tablist">
-
-          <% if @discussion.has_submission? %>
-            <li role="presentation">
-              <a class="editor-tab nav-link active" data-bs-target="#solution" aria-controls="solution" role="tab" data-bs-toggle="tab">
-                <%= t :solution %>
-              </a>
-            </li>
-            <li role="presentation">
-              <a class="editor-tab nav-link" data-bs-target="#results" aria-controls="results" role="tab" data-bs-toggle="tab">
-                <%= t :results %>
-              </a>
-            </li>
-          <% end %>
-
           <li role="presentation">
-            <a class="editor-tab nav-link <%= "active" unless @discussion.has_submission? %>" data-bs-target="#content" aria-controls="content" role="tab" data-bs-toggle="tab">
+            <a class="editor-tab nav-link active" data-bs-target="#solution" aria-controls="solution" role="tab" data-bs-toggle="tab">
+              <%= t :solution %>
+            </a>
+          </li>
+          <li role="presentation">
+            <a class="editor-tab nav-link" data-bs-target="#results" aria-controls="results" role="tab" data-bs-toggle="tab">
+              <%= t :results %>
+            </a>
+          </li>
+          <li role="presentation">
+            <a class="editor-tab nav-link" data-bs-target="#content" aria-controls="content" role="tab" data-bs-toggle="tab">
               <%= t :description %>
             </a>
           </li>
@@ -77,32 +73,30 @@
         </ul>
 
         <div class="tab-content">
-          <% if @discussion.has_submission? %>
-            <div role="tabpanel" class="tab-pane active" id="solution">
-              <div class="mu-tab-body">
-                <div role="tabpanel" class="tab-pane mu-input-panel fade show active" id="editor">
-                  <div class="mu-read-only-editor">
-                    <%= render_exercise_read_only_editor exercise, @discussion.solution %>
-                  </div>
+          <div role="tabpanel" class="tab-pane active" id="solution">
+            <div class="mu-tab-body">
+              <div role="tabpanel" class="tab-pane mu-input-panel fade show active" id="editor">
+                <div class="mu-read-only-editor">
+                  <%= render_exercise_read_only_editor exercise, @discussion.solution %>
                 </div>
               </div>
             </div>
+          </div>
 
-            <div role="tabpanel" class="tab-pane" id="results">
-              <div class="mu-tab-body">
-                <%= render layout: 'exercise_solutions/contextualization_results_container', locals: { contextualization: @discussion } do %>
-                  <div class="row">
-                    <div class="col-md-12 submission-results">
-                      <%= render partial: 'exercise_solutions/contextualization_results_body',
-                                 locals: { contextualization: @discussion, guide_finished_by_solution: false } %>
-                    </div>
+          <div role="tabpanel" class="tab-pane" id="results">
+            <div class="mu-tab-body">
+              <%= render layout: 'exercise_solutions/contextualization_results_container', locals: { contextualization: @discussion } do %>
+                <div class="row">
+                  <div class="col-md-12 submission-results">
+                    <%= render partial: 'exercise_solutions/contextualization_results_body',
+                               locals: { contextualization: @discussion, guide_finished_by_solution: false } %>
                   </div>
-                <% end %>
-              </div>
+                </div>
+              <% end %>
             </div>
-          <% end %>
+          </div>
 
-          <div role="tabpanel" class="tab-pane <%= 'active' unless @discussion.has_submission? %>" id="content">
+          <div role="tabpanel" class="tab-pane" id="content">
             <div class="mu-tab-body">
               <div class="exercise-assignment">
                 <%= render partial: 'exercises/exercise_assignment', locals: { exercise: exercise } %>


### PR DESCRIPTION
## :dart: Goal
Stop hiding solution and results tabs when discussion has no submission.

## :camera_flash: Screenshots
https://user-images.githubusercontent.com/11720274/132385417-31caeee7-3ff4-47f6-a0f3-1cd9864020fe.mp4

## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.
