### PR TITLE
Disable "take care of" button until confirmation toast is shown

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/discussions.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/discussions.js
@@ -38,6 +38,12 @@ mumuki.load(() => {
     toggleButton: function (elements) {
       elements.toggleClass('d-none');
     },
+    disableButton: function (elements) {
+      elements.attr('disabled', true);
+    },
+    reenableButton: function (elements) {
+      elements.attr('disabled', false);
+    },
     token: new mumuki.CsrfToken(),
     tokenRequest: function (data) {
       return $.ajax(Forum.token.newRequest(data));
@@ -56,6 +62,7 @@ mumuki.load(() => {
       Forum.discussionPostAndToggle(url, $upvoteButtons);
     },
     discussionResponsible: function (url) {
+      Forum.disableButton($responsibleButton);
       Forum.discussionPostToggleAndRenderToast(url, $responsibleButton);
       $('.responsible-moderator-badge').toggleClass('d-none');
     },
@@ -66,6 +73,7 @@ mumuki.load(() => {
       Forum.discussionPost(url)
         .done(function (response) {
           Forum.toggleButton(elem);
+          Forum.reenableButton(elem);
           mumuki.toast.addToast(response);
         })
         .fail(function (response) {


### PR DESCRIPTION
## :dart: Goal

Prevent multiple clicks on "I'll take care of it" button on discussions when the response is taking longer than usual.

## :memo: Details

We've seen cases where moderators would click the button multiple times before waiting for the server to actually mark them as responsible (could be slow internet, an unfortunate lock, too much load on our DB, or else). This would sometimes de-sync the button with the actual state of the discussion and/or with the message shown (i.e.: the button shows you could mark yourself as responsible, but you already are, and therefore clicking will show "you're no longer responsible" instead).

The simplest solution is to disable the button until the action is finished, as is usually done on forms, and as this 'Create pull request' button I'm about to click does. This avoids double-sending.

## :camera_flash: Screenshots
### About to click / clicked but waiting / response has been sent

![image](https://user-images.githubusercontent.com/11304439/132734052-51466675-1b8d-47f7-ac3c-bd5cef5f1654.png)
![image](https://user-images.githubusercontent.com/11304439/132734190-39bc851c-5178-447e-be2a-ab9e86cfb3db.png)
![image](https://user-images.githubusercontent.com/11304439/132734126-5e5bb511-4feb-49fe-abe3-9d7a5127c043.png)
