### PR TITLE
Add timestamp tooltips to datetimes

### DIFF
--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -185,11 +185,7 @@ module DiscussionsHelper
 
   def discussion_info(discussion)
     <<~HTML.html_safe
-      <span>
-        <time title="#{discussion.created_at}">
-          #{t(:time_since, time: time_ago_in_words(discussion.created_at))}
-        </time>
-      </span>
+      <span>#{friendly_time(discussion.created_at, :time_since)}</span>
       <span> · #{t(:reply_count, count: discussion.visible_messages.size)}</span>
     HTML
   end

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -184,7 +184,14 @@ module DiscussionsHelper
   end
 
   def discussion_info(discussion)
-    "#{t(:time_since, time: time_ago_in_words(discussion.created_at))} · #{t(:reply_count, count: discussion.visible_messages.size)}"
+    <<~HTML.html_safe
+      <span>
+        <time title="#{discussion.created_at}">
+          #{t(:time_since, time: time_ago_in_words(discussion.created_at))}
+        </time>
+      </span>
+      <span> · #{t(:reply_count, count: discussion.visible_messages.size)}</span>
+    HTML
   end
 
   def discussion_filter_params_without_page

--- a/app/helpers/time_helper.rb
+++ b/app/helpers/time_helper.rb
@@ -1,0 +1,12 @@
+module TimeHelper
+  def friendly_time(time, t_key = nil)
+    friendly_time = time_ago_in_words time
+    friendly_time_t = t_key ? t(t_key, time: friendly_time) : friendly_time
+
+    <<~HTML.html_safe
+      <time title="#{time}">
+        #{friendly_time_t}
+      </time>
+    HTML
+  end
+end

--- a/app/helpers/user_discussions_helper.rb
+++ b/app/helpers/user_discussions_helper.rb
@@ -31,7 +31,11 @@ module UserDiscussionsHelper
         </td>
         <td>#{link_to discussion.item.name, item_discussion_path(discussion)}</td>
         <td>#{discussion_user_name discussion.initiator}</td>
-        <td>#{t(:time_since, time: time_ago_in_words(discussion.last_message_date))}</td>
+        <td>
+          <time title="#{discussion.last_message_date}">
+            #{t(:time_since, time: time_ago_in_words(discussion.last_message_date))}
+          </time>
+        </td>
       </tr>
     HTML
   end

--- a/app/helpers/user_discussions_helper.rb
+++ b/app/helpers/user_discussions_helper.rb
@@ -31,11 +31,7 @@ module UserDiscussionsHelper
         </td>
         <td>#{link_to discussion.item.name, item_discussion_path(discussion)}</td>
         <td>#{discussion_user_name discussion.initiator}</td>
-        <td>
-          <time title="#{discussion.last_message_date}">
-            #{t(:time_since, time: time_ago_in_words(discussion.last_message_date))}
-          </time>
-        </td>
+        <td>#{friendly_time(discussion.last_message_date, :time_since)}</td>
       </tr>
     HTML
   end

--- a/app/helpers/user_discussions_helper.rb
+++ b/app/helpers/user_discussions_helper.rb
@@ -1,6 +1,6 @@
 module UserDiscussionsHelper
   def user_discussions_table_title(discussion, user, last_read)
-    %Q{
+    <<~HTML.html_safe
       <tr></tr>
       <thead>
         <tr>
@@ -9,22 +9,22 @@ module UserDiscussionsHelper
           </td>
         </tr>
       </thead>
-    }.html_safe
+    HTML
   end
 
   def user_discussions_table_header
-    %Q{
+    <<~HTML.html_safe
       <tr class="fw-bold">
         <td></td>
         <td>#{t(:exercise)}</td>
         <td>#{t(:discussion_created_by)}</td>
         <td>#{t(:last_message)}</td>
       </tr>
-    }.html_safe
+    HTML
   end
 
   def user_discussions_table_item(discussion, user)
-    %Q{
+    <<~HTML.html_safe
       <tr>
         <td class="text-center">
           #{icon_for_read(discussion.read_by?(user))}
@@ -33,6 +33,6 @@ module UserDiscussionsHelper
         <td>#{discussion_user_name discussion.initiator}</td>
         <td>#{t(:time_since, time: time_ago_in_words(discussion.last_message_date))}</td>
       </tr>
-    }.html_safe
+    HTML
   end
 end

--- a/app/views/discussions/_description_message.html.erb
+++ b/app/views/discussions/_description_message.html.erb
@@ -4,9 +4,7 @@
       <div class="discussion-message-bubble-title">
         <%= linked_discussion_user_name(discussion.initiator) %>
         <span class="message-date">
-          <time title="<%= discussion.created_at %>">
-            <%= t(:time_since, time: time_ago_in_words(discussion.created_at)) %>
-          </time>
+          <%= friendly_time(discussion.created_at, :time_since) %>
         </span>
       </div>
     </div>

--- a/app/views/discussions/_description_message.html.erb
+++ b/app/views/discussions/_description_message.html.erb
@@ -4,7 +4,9 @@
       <div class="discussion-message-bubble-title">
         <%= linked_discussion_user_name(discussion.initiator) %>
         <span class="message-date">
-          <%= t(:time_since, time: time_ago_in_words(discussion.created_at)) %>
+          <time title="<%= discussion.created_at %>">
+            <%= t(:time_since, time: time_ago_in_words(discussion.created_at)) %>
+          </time>
         </span>
       </div>
     </div>

--- a/app/views/discussions/_message.html.erb
+++ b/app/views/discussions/_message.html.erb
@@ -7,7 +7,9 @@
           <span class="moderator-badge"><%= t(:moderation) %></span>
         <% end %>
         <span class="message-date">
-          <%= t(:time_since, time: time_ago_in_words(message.created_at)) %>
+          <time title="<%= message.created_at %>">
+            <%= t(:time_since, time: time_ago_in_words(message.created_at)) %>
+          </time>
         </span>
         <span class="actions">
           <% if message.authorized?(current_user) && !message.deleted? %>
@@ -47,7 +49,9 @@
           <% if current_user&.moderator_here? %>
             <hr>
             <%= t :deleted_by, deleter: message.deleted_by.name %>
-            <%= t(:time_since, time: time_ago_in_words(message.deleted_at)) %>.
+            <time title="<%= message.created_at %>">
+              <%= t(:time_since, time: time_ago_in_words(message.deleted_at)) %>.
+            </time>
             <a href='<%= "#deletedMessage#{message.id}" %>' data-bs-toggle="collapse">
               <%= t :show_message %>
             </a>

--- a/app/views/discussions/_message.html.erb
+++ b/app/views/discussions/_message.html.erb
@@ -7,9 +7,7 @@
           <span class="moderator-badge"><%= t(:moderation) %></span>
         <% end %>
         <span class="message-date">
-          <time title="<%= message.created_at %>">
-            <%= t(:time_since, time: time_ago_in_words(message.created_at)) %>
-          </time>
+          <%= friendly_time(message.created_at, :time_since) %>
         </span>
         <span class="actions">
           <% if message.authorized?(current_user) && !message.deleted? %>
@@ -49,9 +47,7 @@
           <% if current_user&.moderator_here? %>
             <hr>
             <%= t :deleted_by, deleter: message.deleted_by.name %>
-            <time title="<%= message.created_at %>">
-              <%= t(:time_since, time: time_ago_in_words(message.deleted_at)) %>.
-            </time>
+            <%= friendly_time(message.deleted_at, :time_since) %>
             <a href='<%= "#deletedMessage#{message.id}" %>' data-bs-toggle="collapse">
               <%= t :show_message %>
             </a>

--- a/app/views/layouts/_discussions_list.html.erb
+++ b/app/views/layouts/_discussions_list.html.erb
@@ -26,7 +26,9 @@
           </span>
           <span class="discussion-initiator">
             <strong><%= discussion_user_name discussion.initiator %></strong>
-            <%= t(:asked_time_since, time: time_ago_in_words(discussion.created_at)) %>
+            <time title="<%= discussion.created_at %>">
+              <%= t(:asked_time_since, time: time_ago_in_words(discussion.created_at)) %>
+            </time>
             <span class="discussion-status-icon">
               <%= discussion_status_fa_icon(discussion) %>
             </span>

--- a/app/views/layouts/_discussions_list.html.erb
+++ b/app/views/layouts/_discussions_list.html.erb
@@ -26,9 +26,7 @@
           </span>
           <span class="discussion-initiator">
             <strong><%= discussion_user_name discussion.initiator %></strong>
-            <time title="<%= discussion.created_at %>">
-              <%= t(:asked_time_since, time: time_ago_in_words(discussion.created_at)) %>
-            </time>
+            <%= friendly_time(discussion.created_at, :asked_time_since) %>
             <span class="discussion-status-icon">
               <%= discussion_status_fa_icon(discussion) %>
             </span>

--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -6,7 +6,9 @@
             <div class="message">
               <p> <%= message.content_html %></p>
               <div class="sender"><%= message.sender unless message.sender == current_user_uid %></div>
-              <time><%= time_ago_in_words message.created_at %></time>
+              <time title="<%= message.created_at %>">
+                <%= time_ago_in_words message.created_at %>
+              </time>
             </div>
           </li>
       <% end %>

--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -6,9 +6,7 @@
             <div class="message">
               <p> <%= message.content_html %></p>
               <div class="sender"><%= message.sender unless message.sender == current_user_uid %></div>
-              <time title="<%= message.created_at %>">
-                <%= time_ago_in_words message.created_at %>
-              </time>
+              <%= friendly_time(message.created_at) %>
             </div>
           </li>
       <% end %>

--- a/app/views/users/_user_form.html.erb
+++ b/app/views/users/_user_form.html.erb
@@ -31,11 +31,7 @@
       <span> <strong><%= t :email %>:</strong> <%= @user.email %> </span>
     </div>
     <div>
-      <span> <strong><%= t :programming_since %>:</strong>
-        <time title="<%= @user.created_at %>">
-          <%= t(:time_since, time: time_ago_in_words(@user.created_at)) %>
-        </time>
-      </span>
+      <span> <strong><%= t :programming_since %>:</strong> <%= friendly_time(@user.created_at, :time_since) %> </span>
     </div>
   </div>
 </div>

--- a/app/views/users/_user_form.html.erb
+++ b/app/views/users/_user_form.html.erb
@@ -31,7 +31,11 @@
       <span> <strong><%= t :email %>:</strong> <%= @user.email %> </span>
     </div>
     <div>
-      <span> <strong><%= t :programming_since %>:</strong> <%= t(:time_since, time: time_ago_in_words(@user.created_at)) %> </span>
+      <span> <strong><%= t :programming_since %>:</strong>
+        <time title="<%= @user.created_at %>">
+          <%= t(:time_since, time: time_ago_in_words(@user.created_at)) %>
+        </time>
+      </span>
     </div>
   </div>
 </div>

--- a/app/views/users/messages.html.erb
+++ b/app/views/users/messages.html.erb
@@ -20,7 +20,11 @@
             <td><%= icon_for_read(message.read?) %></td>
             <td><%= link_to message.exercise.name, exercise_path(message.exercise.id) %></td>
             <td><%= mail_to message.sender %></td>
-            <td><%= time_ago_in_words message.created_at %></td>
+            <td>
+              <time title="<%= message.created_at %>">
+                <%= time_ago_in_words message.created_at %>
+              </time>
+            </td>
           </tr>
         <% end %>
       </table>

--- a/app/views/users/messages.html.erb
+++ b/app/views/users/messages.html.erb
@@ -20,11 +20,7 @@
             <td><%= icon_for_read(message.read?) %></td>
             <td><%= link_to message.exercise.name, exercise_path(message.exercise.id) %></td>
             <td><%= mail_to message.sender %></td>
-            <td>
-              <time title="<%= message.created_at %>">
-                <%= time_ago_in_words message.created_at %>
-              </time>
-            </td>
+            <td><%= friendly_time(message.created_at) %></td>
           </tr>
         <% end %>
       </table>

--- a/app/views/users/notifications.html.erb
+++ b/app/views/users/notifications.html.erb
@@ -38,7 +38,9 @@
                 <%= render partial: "notifications/#{notification.subject}", locals: { notification: notification } %>
               </td>
               <td class="col-md-3">
-                <%= t(:time_since, time: time_ago_in_words(notification.created_at)) %>
+                <time title="<%= notification.created_at %>">
+                  <%= t(:time_since, time: time_ago_in_words(notification.created_at)) %>
+                </time>
               </td>
             </tr>
           <% end %>

--- a/app/views/users/notifications.html.erb
+++ b/app/views/users/notifications.html.erb
@@ -38,9 +38,7 @@
                 <%= render partial: "notifications/#{notification.subject}", locals: { notification: notification } %>
               </td>
               <td class="col-md-3">
-                <time title="<%= notification.created_at %>">
-                  <%= t(:time_since, time: time_ago_in_words(notification.created_at)) %>
-                </time>
+                <%= friendly_time(notification.created_at, :time_since) %>
               </td>
             </tr>
           <% end %>


### PR DESCRIPTION
## :dart: Goal
Add a tooltip with non user friendly date format to all dates in order to ease cross checking for logs.

## :memo: Details
Not sure if the spans in discussion_info are alright? I don't know what the proper use of tag are ¯\\\_(ツ)_/¯.
Fixes https://github.com/mumuki/mumuki-laboratory/issues/1648.

## :camera_flash: Screenshots
![Screenshot from 2021-09-14 18-18-09](https://user-images.githubusercontent.com/11720274/133335586-0a480e32-6abd-48b8-8717-e7de303fe557.png)
![Screenshot from 2021-09-14 18-18-12](https://user-images.githubusercontent.com/11720274/133335593-2b0f47d0-8143-4671-8468-baec84be6bd2.png)
![Screenshot from 2021-09-14 18-18-34](https://user-images.githubusercontent.com/11720274/133335594-10cf962e-21e6-4e97-a3e6-83650a69bf8f.png)
![Screenshot from 2021-09-14 18-18-37](https://user-images.githubusercontent.com/11720274/133335596-ba5e0b64-211e-479d-80e9-84329748d712.png)
![Screenshot from 2021-09-14 18-18-47](https://user-images.githubusercontent.com/11720274/133335598-8b7a7a31-e358-4a54-bf29-4892f4f2e18e.png)
![Screenshot from 2021-09-14 18-18-58](https://user-images.githubusercontent.com/11720274/133335603-fffc8190-eca3-4f6c-b2b6-11257eed0908.png)
![Screenshot from 2021-09-14 18-19-02](https://user-images.githubusercontent.com/11720274/133335605-88a0a0a7-5c31-4c49-943c-2025b1029010.png)
![Screenshot from 2021-09-14 18-19-06](https://user-images.githubusercontent.com/11720274/133335606-0b25ed3d-7778-4529-9425-71fd624775f2.png)
![Screenshot from 2021-09-14 18-19-13](https://user-images.githubusercontent.com/11720274/133335610-add21d9c-9121-41ff-b203-837f2c34191f.png)


## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.

## :soon: Future work
~Hopefully extract all the repeated logic to a helper.~ Done!
~Need to do the same in classroom!~ Done!