### PR TITLE
Fix warning popping up always on read only mode

### DIFF
--- a/app/helpers/editor_helper.rb
+++ b/app/helpers/editor_helper.rb
@@ -8,7 +8,7 @@ module EditorHelper
 
   def read_only_editor(content, language, options = {})
     editor_options = editor_defaults(language, options.deep_merge(data: { readonly: true }), 'editor')
-    text_area_tag :solution_content, content, editor_options
+    text_area_tag 'solution[content]', content, editor_options
   end
 
   def spell_checked_editor(name, options = {})


### PR DESCRIPTION
## :dart: Goal
Fixes bug where 'Your solution has unsaved changes' popup would always show on read only mode.

## :memo: Details
Tested discussions + console and this change does not break them.
Fixes #1682.

## :camera_flash: Screenshots
https://user-images.githubusercontent.com/11720274/133647381-0c375fa2-572f-4f9c-9537-4530c74b09de.mp4

## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.