### PR TITLE
Get csrf token on request instead of on page load

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/csrf-token.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/csrf-token.js
@@ -1,12 +1,12 @@
 mumuki.CsrfToken =  (() => {
   class CsrfToken {
-    constructor() {
-      this.value = $('meta[name="csrf-token"]').attr('content');
+    get token() {
+      return $('meta[name="csrf-token"]').attr('content');
     }
+
     newRequest(data) {
-      var self = this;
-      data.beforeSend = function (xhr) {
-        xhr.setRequestHeader('X-CSRF-Token', self.value);
+      data.beforeSend = (xhr) => {
+        xhr.setRequestHeader('X-CSRF-Token', this.token);
       };
       return data;
     }


### PR DESCRIPTION
## :dart: Goal
Hopefully reduce instances of invalid authenticity token errors.

## :memo: Details
Lately we've been seeing an increased amount of invalid authenticity token errors in the application. Logs indicate that we seem to have 2 groups for these:
- the request either includes an `X-CSRF-Token`, but this token for some reason does not match the session token or
- the request does not include an `X-CSRF-Token` at all.

We do not know what the circumstances that are causing these errors are, and we haven't ever been able to reproduce the error ourselves be it in development or in production.

The point of all of this is to say that: this is a shot in the dark. I don't have the first clue as to whether this PR will help at all.

The theory behind it is that some browser could not be playing well with turbolinks, which could _maybe_ be causing the QueryConsole object to be created before the csrf token meta tag is merged by turbolinks, thereby causing requests to not include a csrf token?
Worst case scenario, this PR should have no effect at all.

## :camera_flash: Screenshots
No visual changes.

## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.