### PR TITLE
Disable warning on read only mode and kids exercises

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/exercise.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/exercise.js
@@ -1,12 +1,20 @@
 (() => {
+  function shouldSkipChangesCheck() {
+    return mumuki.isKidsExercise() || mumuki.exercise.isReadOnly;
+  }
+
   function solutionChangedSinceLastSubmission() {
     return  mumuki.exercise.id &&
             mumuki.SubmissionsStore.getLastSubmissionAndResult(mumuki.exercise.id) &&
             !mumuki.SubmissionsStore.getSubmissionResultFor(mumuki.exercise.id, mumuki.editors.getSubmission());
   }
 
+  function shouldWarnOfChanges() {
+    return !shouldSkipChangesCheck() && solutionChangedSinceLastSubmission();
+  }
+
   window.addEventListener("beforeunload", (event) => {
-    if (solutionChangedSinceLastSubmission()) {
+    if (shouldWarnOfChanges()) {
       event.returnValue = 'unsaved_progress';
     } else {
       delete event['returnValue'];
@@ -14,7 +22,7 @@
   });
 
   window.addEventListener("turbolinks:before-visit", (event) => {
-    if (solutionChangedSinceLastSubmission() && !confirm(mumuki.I18n.t('unsaved_progress'))) event.preventDefault();
+    if (shouldWarnOfChanges() && !confirm(mumuki.I18n.t('unsaved_progress'))) event.preventDefault();
   });
 })();
 
@@ -64,6 +72,13 @@ mumuki.exercise = {
    */
   get current() {
     return this._current;
+  },
+
+  /**
+   * @type {Boolean?}
+   */
+  get isReadOnly() {
+    return $('#mu-exercise-read-only').val() === 'true';
   },
 
   /**

--- a/app/views/exercises/show.html.erb
+++ b/app/views/exercises/show.html.erb
@@ -45,6 +45,7 @@
 <%= hidden_field_tag "mu-exercise-id", @exercise.id %>
 <%= hidden_field_tag "mu-exercise-layout", @exercise.layout %>
 <%= hidden_field_tag "mu-exercise-settings", @exercise.settings.to_json %>
+<%= hidden_field_tag "mu-exercise-read-only", current_access_mode.read_only? %>
 
 <div class="d-none" id="processing-template">
   <div class="bs-callout bs-callout-info">


### PR DESCRIPTION
## :dart: Goal
Disable 'Your solution has changed' warning popup when on read only mode and for kids exercises.

## :memo: Details
Fixes #1682.

## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.
