### PR TITLE
Show exam information on book view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ ruby '~> 2.3'
 
 gem 'puma'
 
+gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'master'
+
 gem 'execjs'
 gem 'therubyracer', platforms: :ruby
 gem 'uglifier', '~> 2.7'

--- a/app/helpers/exams_helper.rb
+++ b/app/helpers/exams_helper.rb
@@ -1,0 +1,15 @@
+module ExamsHelper
+  def exam_information_for(user, exam)
+    %Q{
+      #{fa_icon('graduation-cap', class: 'fa-fw',
+                text: "<strong>#{t :course}:</strong> #{exam.course.canonical_code}".html_safe)}
+      <br>
+      #{fa_icon('calendar-alt', class: 'fa-fw',
+                text: "<strong>#{t :date_and_time}:</strong> #{local_time_without_time_zone(exam.start_time)} - #{local_time(exam.end_time)}".html_safe)}
+      <br>
+      #{fa_icon(:stopwatch, class: 'fa-fw',
+                text: "<strong>#{t :available_time}:</strong> #{t :time_in_minutes, time: exam.duration}".html_safe)}
+      <br>
+    }.html_safe
+  end
+end

--- a/app/helpers/exams_helper.rb
+++ b/app/helpers/exams_helper.rb
@@ -1,9 +1,7 @@
 module ExamsHelper
   def exam_information_for(user, exam)
     %Q{
-      #{fa_icon('graduation-cap', class: 'fa-fw',
-                text: "<strong>#{t :course}:</strong> #{exam.course.canonical_code}".html_safe)}
-      <br>
+      #{course_information_for(user, exam)}
       #{fa_icon('calendar-alt', class: 'fa-fw',
                 text: "<strong>#{t :date_and_time}:</strong> #{local_time_without_time_zone(exam.start_time)} - #{local_time(exam.end_time)}".html_safe)}
       <br>
@@ -11,5 +9,15 @@ module ExamsHelper
                 text: "<strong>#{t :available_time}:</strong> #{t :time_in_minutes, time: exam.duration}".html_safe)}
       <br>
     }.html_safe
+  end
+
+  private
+
+  def course_information_for(user, exam)
+    if user.teacher_here?
+      "#{fa_icon('graduation-cap', class: 'fa-fw',
+                 text: "<strong>#{t :course}:</strong> #{exam.course.canonical_code}".html_safe)}
+      <br>"
+    end
   end
 end

--- a/app/helpers/time_zone_helper.rb
+++ b/app/helpers/time_zone_helper.rb
@@ -1,5 +1,9 @@
 module TimeZoneHelper
   def local_time(time, time_zone = Time.zone.name)
-    "#{l(time.in_time_zone(time_zone), format: :long)} (#{time_zone})"
+    "#{local_time_without_time_zone(time, time_zone)} (#{time_zone})"
+  end
+
+  def local_time_without_time_zone(time, time_zone = Time.zone.name)
+    l(time.in_time_zone(time_zone), format: :long)
   end
 end

--- a/app/views/book/show.html.erb
+++ b/app/views/book/show.html.erb
@@ -45,7 +45,7 @@
     <h2><%= t(:exams) %></h2>
     <% @exams.each_with_index do |it, index| %>
       <div class="chapter">
-        <h3> <%= index + 1 %>. <%= link_to_path_element it, mode: :plain %></h3>
+        <h3><%= link_to_path_element it, mode: :plain %></h3>
 
         <div class="text-box">
           <%= it.guide.description_teaser_html %>

--- a/app/views/book/show.html.erb
+++ b/app/views/book/show.html.erb
@@ -46,7 +46,9 @@
     <% @exams.each_with_index do |it, index| %>
       <div class="chapter">
         <h3><%= link_to_path_element it, mode: :plain %></h3>
-
+        <div class="fs-7">
+          <%= exam_information_for(current_user, it) %>
+        </div>
         <div class="text-box">
           <%= it.guide.description_teaser_html %>
         </div>

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -30,6 +30,7 @@ en:
   authoring: Authoring
   authoring_note_html: This guide's content was developed by %{authors} under the terms of <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons License Share-Alike, 4.0</a>
   authoring_note_with_collaborators_html: This guide's content was developed by %{authors} and <a href="%{collaborators}" target="_blank">many others</a>, under the terms of <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons License Share-Alike, 4.0</a>
+  available_time: Available time
   back_to_mumuki: Back to Mumuki!
   bibliotheca_ui: Bibliotheca
   birthdate: Birthdate
@@ -67,9 +68,11 @@ en:
   continue_practicing: Continue practicing!
   corollary: To think about
   correct_answer: The answer is correct!
+  course: Course
   create_submission: Submit
   created_at: Created at
   date: Date
+  date_and_time: Date and time
   deleted_by: Deleted by %{deleter}
   deleted_message_warning: If you repeateadly violate these or other rules, you may be prohibited from accessing the forum or you may suffer more severe consequences, such as being expulsed from the course.
   deletion_motive:
@@ -360,6 +363,7 @@ en:
   terms_and_conditions_continue_disclaimer: By continuing you agree to %{terms_link}
   terms_and_conditions_must_be_accepted: You must accept the terms and conditions
   test_results: Test results
+  time_in_minutes: "%{time} minutes"
   time_since: "%{time} ago"
   time_left: You have
   title: Title

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -29,6 +29,7 @@ es-CL:
   authoring: Autores
   authoring_note_html: Esta guía fue desarrollada por %{authors} bajo los términos de la <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Licencia Creative Commons Compartir-Igual, 4.0</a>.
   authoring_note_with_collaborators_html: Esta guía fue desarrollada por %{authors} y <a href="%{collaborators}" target="_blank">muchas personas más</a>, bajo los términos de la <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Licencia Creative Commons Compartir-Igual, 4.0</a>.
+  available_time: Tiempo disponible
   back_to_mumuki: ¡Vuelve a Mumuki!
   bibliotheca_ui: Biblioteca
   birthdate: Fecha de nacimiento
@@ -65,11 +66,13 @@ es-CL:
   continue_lesson: ¡Continúa esta lección!
   continue_practicing: ¡Sigue aprendiendo!
   correct_answer: ¡La respuesta es correcta!
+  course: Curso
   create_submission: Enviar
   created_at: Creado
   created_exercises: Ejercicios Creados
   created_guides: Lecciones Creadas
   date: Fecha
+  date_and_time: Fecha y hora
   deleted_by: Eliminado por %{deleter}
   deleted_message_warning: Si infringes reiteradamente estas u otras reglas del Espacio de Consultas, se te puede prohibir el acceso al mismo o podrás sufrir consecuencias más severas, como la expulsión del curso.
   deletion_motive:
@@ -374,6 +377,7 @@ es-CL:
   terms_and_conditions_continue_disclaimer: Al continuar aceptas los %{terms_link}
   terms_and_conditions_must_be_accepted: Tienes que aceptar los términos y condiciones
   test_results: Resultados de las pruebas
+  time_in_minutes: "%{time} minutos"
   time_since: "hace %{time}"
   time_left: Te quedan
   title: Título

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -32,6 +32,7 @@ es:
   authoring: Autores
   authoring_note_html: Esta guía fue desarrollada por %{authors} bajo los términos de la <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Licencia Creative Commons Compartir-Igual, 4.0</a>.
   authoring_note_with_collaborators_html: Esta guía fue desarrollada por %{authors} y <a href="%{collaborators}" target="_blank">muchas personas más</a>, bajo los términos de la <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Licencia Creative Commons Compartir-Igual, 4.0</a>.
+  available_time: Tiempo disponible
   back_to_mumuki: ¡Volvé a Mumuki!
   bibliotheca_ui: Biblioteca
   birthdate: Fecha de nacimiento
@@ -68,6 +69,7 @@ es:
   continue_lesson: ¡Continuá esta lección!
   continue_practicing: ¡Seguí aprendiendo!
   correct_answer: ¡La respuesta es correcta!
+  course: Curso
   create_submission: Enviar
   created_at: Creado
   created_at_asc: Antiguas
@@ -75,6 +77,7 @@ es:
   created_exercises: Ejercicios Creados
   created_guides: Lecciones Creadas
   date: Fecha
+  date_and_time: Fecha y hora
   deleted_by: Eliminado por %{deleter}
   deleted_message_warning: Si infringís reiteradamente estas u otras reglas del Espacio de Consultas, se te puede prohibir el acceso al mismo o podrás sufrir consecuencias más severas, como la expulsión del curso.
   deletion_motive:
@@ -388,6 +391,7 @@ es:
   terms_and_conditions_continue_disclaimer: Al continuar estás aceptando los %{terms_link}
   terms_and_conditions_must_be_accepted: Tenés que aceptar los términos y condiciones
   test_results: Resultados de las pruebas
+  time_in_minutes: "%{time} minutos"
   time_since: "hace %{time}"
   time_left: Te quedan
   title: Título

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -31,6 +31,7 @@ pt:
   authoring: Autores
   authoring_note_html: 'Este guia foi desenvolvido por %{authors} nos termos do <a href = "https://creativecommons.org/licenses/by-sa/4.0/" target="_blank"> Creative Commons License Share-Equal, 4.0 </a>.'
   authoring_note_with_collaborators_html: 'Este guia foi desenvolvido por %{authors} e <a href="%{collaborators}" target="_blank">muitas outras pessoas </a>, nos termos do <a href = "https://creativecommons.org/licenses/by-sa/4.0/" target="_blank"> Creative Commons License Share-Equal, 4.0 </a>.'
+  available_time: Tempo disponível
   back_to_mumuki: Voltei para Mumuki!
   bibliotheca_ui: Biblioteca
   birthdate: Fecha de nacimiento
@@ -64,6 +65,7 @@ pt:
   continue_lesson: Continue esta lição!
   continue_practicing: Continue aprendendo!
   correct_answer: A resposta está correta!
+  course: Curso
   create_submission: Enviar
   created_at: Criado
   created_at_asc: Antigo
@@ -71,6 +73,7 @@ pt:
   created_exercises: Exercícios criados
   created_guides: Lições criadas
   date: Data
+  date_and_time: Data e hora
   deleted_by: Removido pelo
   deleted_message_warning: Se você violar repetidamente essas ou outras regras da Área de Consulta, seu acesso a ela pode ser proibido ou você pode sofrer consequências mais graves, como a expulsão do curso.
   deletion_motive:
@@ -373,6 +376,7 @@ pt:
   terms_and_conditions_continue_disclaimer: Ao continuar, você concorda %{terms_link}
   terms_and_conditions_must_be_accepted: Você deve aceitar os Termos e Condições
   test_results: Resultados do teste
+  time_in_minutes: "%{time} minutos"
   time_since: "há %{time}"
   time_left: Te deixam
   title: Título


### PR DESCRIPTION
## :dart: Goal

Show course, start and end date, and available time for an exam on book view.

## :memo: Details

Course is only visible for teachers.

I'm also removing the indexing (`1. Examen`) on exam listing as students should see only one exam at a time, and while teachers could see many, they don't have a natural order anyway.

## :camera_flash: Screenshots

### Student view
![image](https://user-images.githubusercontent.com/11304439/134439046-4be53822-8f38-41c3-8263-dd30b034a4c1.png)

### Teacher view
![image](https://user-images.githubusercontent.com/11304439/134439095-dda0ca2e-e696-432f-9dc1-097d1103fce1.png)

## :warning: Dependencies

https://github.com/mumuki/mumuki-domain/pull/245, as that PR allows teachers to access exams through navigation.

## :back: Backwards compatibility

Yes

## :soon: Future work

None