### PR TITLE
Add notice on discussion creation

### DIFF
--- a/app/views/discussions/new.html.erb
+++ b/app/views/discussions/new.html.erb
@@ -22,7 +22,8 @@
         <div class="container-fluid">
           <div class="row">
             <div class="discussion-new-message-content">
-              <%= f.editor :description, '', {id: 'discussion-new-message', class: 'form-control', placeholder: t(:discussion_description_placeholder)} %>
+              <%= spell_checked_editor 'discussion[description]',
+                                       { id: 'discussion-new-message', placeholder: t(:discussion_description_placeholder) } %>
             </div>
           </div>
         </div>

--- a/app/views/discussions/new.html.erb
+++ b/app/views/discussions/new.html.erb
@@ -28,6 +28,11 @@
         </div>
       </div>
     </div>
+    <% if faqs_enabled_here? %>
+      <div class="fs-7">
+        <%= fa_icon('exclamation-triangle', text: t(:only_forum_questions_on_forum, link: link_to_faqs).html_safe) %>
+      </div>
+    <% end %>
     <%= f.submit t(:publish_discussion), class: 'btn btn-complementary w-100 discussion-new-message-button' %>
   <% end %>
 <% end %>

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -272,6 +272,7 @@ en:
   notifications_will_be_here: Notifications will be here
   notify_problem_with_exercise: Report a bug
   office: Office
+  only_forum_questions_on_forum: Remember that only exercise-related questions are answered on the forum. For any other kind of inquiries, please check the %{link}.
   only_landscape_support: Please, rotate your tablet or cellphone to continue practicing
   opened: Open
   opened_count: '%{count} opened'

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -280,6 +280,7 @@ es-CL:
   notifications_will_be_here: Tus notificaciones aparecerán aquí
   notify_problem_with_exercise: Reporta un bug
   office: Secretaría
+  only_forum_questions_on_forum: Recuerda que en el espacio de consultas se responden únicamente dudas relacionadas a los ejercicios. Para cualquier otro tipo de consulta, revisa la %{link}.
   only_landscape_support: Por favor, rota tu tablet o celular para realizar ejercicios
   opened: Abierta
   opened_count:

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -289,6 +289,7 @@ es:
   notifications_will_be_here: Tus notificaciones aparecerán aquí
   notify_problem_with_exercise: Reportá un bug
   office: Secretaría
+  only_forum_questions_on_forum: Recordá que en el espacio de consultas se responden únicamente dudas relacionadas a los ejercicios. Para cualquier otro tipo de consulta, revisá la %{link}.
   only_landscape_support: Por favor, rotá tu tablet o celular para realizar ejercicios
   opened: Abierta
   opened_count:

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -280,6 +280,7 @@ pt:
   notifications_will_be_here: Suas notificações aparecerão aqui
   notify_problem_with_exercise: Relatar um erro
   office: Secretariado
+  only_forum_questions_on_forum: Lembre-se que apenas as dúvidas relacionadas aos exercícios são respondidas no espaço de consulta. Para qualquer outro tipo de consulta, reveja a %{link}.
   only_landscape_support: Por favor, gire seu tablet ou celular para realizar exercícios
   opened: Aberto
   opened_count: '%{count} aberto'


### PR DESCRIPTION
## :dart: Goal

Add a notice to dissuade unrelated questions (such as technical or project-specific) on the forum.

Also, replace the insanely long new discussion textarea with our fancier, markdown-enabled editor.

## :camera_flash: Screenshots

### Before
![image](https://user-images.githubusercontent.com/11304439/134569710-8d1b1624-4d48-47a2-be30-bf51db50b52c.png)

### After
![image](https://user-images.githubusercontent.com/11304439/134569612-14e70d68-9df9-48b9-b582-6d78bfbaeee2.png)


