### PR TITLE
Show discussion tabs for non-queriable/non-extra-visible exercises too

### DIFF
--- a/app/helpers/exercise_input_helper.rb
+++ b/app/helpers/exercise_input_helper.rb
@@ -35,10 +35,6 @@ module ExerciseInputHelper
     should_render_exercise_tabs?(exercise) { exercise.has_messages_for? user }
   end
 
-  def should_render_read_only_exercise_tabs?(discussion)
-    should_render_exercise_tabs?(discussion.exercise) { discussion.has_submission? }
-  end
-
   def should_render_message_input?(exercise, organization = Organization.current)
     exercise.is_a?(Problem) && !exercise.hidden? && organization.raise_hand_enabled?
   end

--- a/app/views/exercises/_read_only.html.erb
+++ b/app/views/exercises/_read_only.html.erb
@@ -45,82 +45,76 @@
     <div class="accordion-body accordion-collapse collapse show" id="mu-discussion-accordion-body"
          aria-labelledby="#mu-discussion-accordion-header" data-bs-parent="#mu-discussion-accordion">
 
-      <% if should_render_read_only_exercise_tabs?(@discussion) %>
-        <ul class="nav nav-tabs discussion-tabs" role="tablist">
-          <li role="presentation">
-            <a class="editor-tab nav-link active" data-bs-target="#solution" aria-controls="solution" role="tab" data-bs-toggle="tab">
-              <%= t :solution %>
-            </a>
-          </li>
-          <li role="presentation">
-            <a class="editor-tab nav-link" data-bs-target="#results" aria-controls="results" role="tab" data-bs-toggle="tab">
-              <%= t :results %>
-            </a>
-          </li>
-          <li role="presentation">
-            <a class="editor-tab nav-link" data-bs-target="#content" aria-controls="content" role="tab" data-bs-toggle="tab">
-              <%= t :description %>
-            </a>
-          </li>
+      <ul class="nav nav-tabs discussion-tabs" role="tablist">
+        <li role="presentation">
+          <a class="editor-tab nav-link active" data-bs-target="#solution" aria-controls="solution" role="tab" data-bs-toggle="tab">
+            <%= t :solution %>
+          </a>
+        </li>
+        <li role="presentation">
+          <a class="editor-tab nav-link" data-bs-target="#results" aria-controls="results" role="tab" data-bs-toggle="tab">
+            <%= t :results %>
+          </a>
+        </li>
+        <li role="presentation">
+          <a class="editor-tab nav-link" data-bs-target="#content" aria-controls="content" role="tab" data-bs-toggle="tab">
+            <%= t :description %>
+          </a>
+        </li>
 
-          <% if exercise.extra_visible? %>
-            <%= extra_code_tab %>
-          <% end %>
+        <% if exercise.extra_visible? %>
+          <%= extra_code_tab %>
+        <% end %>
 
-          <% if exercise.queriable? %>
-            <%= console_tab %>
-          <% end %>
-        </ul>
+        <% if exercise.queriable? %>
+          <%= console_tab %>
+        <% end %>
+      </ul>
 
-        <div class="tab-content">
-          <div role="tabpanel" class="tab-pane mu-input-panel fade show active" id="solution">
-            <div class="mu-tab-body">
-              <div class="mu-read-only-editor">
-                <%= render_exercise_read_only_editor exercise, @discussion.solution %>
-              </div>
+      <div class="tab-content">
+        <div role="tabpanel" class="tab-pane mu-input-panel fade show active" id="solution">
+          <div class="mu-tab-body">
+            <div class="mu-read-only-editor">
+              <%= render_exercise_read_only_editor exercise, @discussion.solution %>
             </div>
           </div>
+        </div>
 
-          <div role="tabpanel" class="tab-pane fade" id="results">
-            <div class="mu-tab-body">
-              <%= render layout: 'exercise_solutions/contextualization_results_container', locals: { contextualization: @discussion } do %>
-                <div class="row">
-                  <div class="col-md-12 submission-results">
-                    <%= render partial: 'exercise_solutions/contextualization_results_body',
-                               locals: { contextualization: @discussion, guide_finished_by_solution: false } %>
-                  </div>
+        <div role="tabpanel" class="tab-pane fade" id="results">
+          <div class="mu-tab-body">
+            <%= render layout: 'exercise_solutions/contextualization_results_container', locals: { contextualization: @discussion } do %>
+              <div class="row">
+                <div class="col-md-12 submission-results">
+                  <%= render partial: 'exercise_solutions/contextualization_results_body',
+                             locals: { contextualization: @discussion, guide_finished_by_solution: false } %>
                 </div>
-              <% end %>
-            </div>
-          </div>
-
-          <div role="tabpanel" class="tab-pane fade" id="content">
-            <div class="mu-tab-body">
-              <div class="exercise-assignment">
-                <%= render partial: 'exercises/exercise_assignment', locals: { exercise: exercise } %>
               </div>
-            </div>
-          </div>
-
-          <div role="tabpanel" class="tab-pane mu-input-panel fade" id="console">
-            <div class="mu-overlapped-container">
-              <div class="console">
-              </div>
-              <div class="mu-overlapped">
-                <%= restart_icon %>
-              </div>
-            </div>
-          </div>
-
-          <div role="tabpanel" class="tab-pane mu-input-panel fade mu-elipsis" id="visible-extra">
-            <%= @discussion.extra_preview_html %>
+            <% end %>
           </div>
         </div>
-      <% else %>
-        <div class="exercise-assignment">
-          <%= render partial: 'exercises/exercise_assignment', locals: { exercise: exercise } %>
+
+        <div role="tabpanel" class="tab-pane fade" id="content">
+          <div class="mu-tab-body">
+            <div class="exercise-assignment">
+              <%= render partial: 'exercises/exercise_assignment', locals: { exercise: exercise } %>
+            </div>
+          </div>
         </div>
-      <% end %>
+
+        <div role="tabpanel" class="tab-pane mu-input-panel fade" id="console">
+          <div class="mu-overlapped-container">
+            <div class="console">
+            </div>
+            <div class="mu-overlapped">
+              <%= restart_icon %>
+            </div>
+          </div>
+        </div>
+
+        <div role="tabpanel" class="tab-pane mu-input-panel fade mu-elipsis" id="visible-extra">
+          <%= @discussion.extra_preview_html %>
+        </div>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## :dart: Goal
Show discussion tabs for non-queriable/non-extra-visible exercises too.

## :memo: Details
Previous PR on this still relied on some `exercise_inputs_helper` logic so it would only show tabs when exercise was queriable or had visible extra when solution was empty. Here I'm just ignoring that previous logic altogether and showing exercise tabs always!

## :camera_flash: Screenshots
![image](https://user-images.githubusercontent.com/11720274/134573503-f51f8f53-565d-48bc-b0f1-b74df431d74b.png)

## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.