### PR TITLE
Fix exam duration on book view

### DIFF
--- a/app/helpers/exams_helper.rb
+++ b/app/helpers/exams_helper.rb
@@ -2,9 +2,7 @@ module ExamsHelper
   def exam_information_for(user, exam)
     %Q{
       #{course_information_for(user, exam)}
-      #{fa_icon('calendar-alt', class: 'fa-fw',
-                text: "<strong>#{t :date_and_time}:</strong> #{local_time_without_time_zone(exam.start_time)} - #{local_time(exam.end_time)}".html_safe)}
-      <br>
+      #{date_information_for(exam)}
       #{duration_information_for(exam)}
     }.html_safe
   end
@@ -17,6 +15,12 @@ module ExamsHelper
                  text: "<strong>#{t :course}:</strong> #{exam.course.canonical_code}".html_safe)}
       <br>"
     end
+  end
+
+  def date_information_for(exam)
+    "#{fa_icon('calendar-alt', class: 'fa-fw',
+               text: "<strong>#{t :date_and_time}:</strong> #{local_time_without_time_zone(exam.start_time)} - #{local_time(exam.end_time)}".html_safe)}
+    <br>"
   end
 
   def duration_information_for(exam)

--- a/app/helpers/exams_helper.rb
+++ b/app/helpers/exams_helper.rb
@@ -5,9 +5,7 @@ module ExamsHelper
       #{fa_icon('calendar-alt', class: 'fa-fw',
                 text: "<strong>#{t :date_and_time}:</strong> #{local_time_without_time_zone(exam.start_time)} - #{local_time(exam.end_time)}".html_safe)}
       <br>
-      #{fa_icon(:stopwatch, class: 'fa-fw',
-                text: "<strong>#{t :available_time}:</strong> #{t :time_in_minutes, time: exam.duration}".html_safe)}
-      <br>
+      #{duration_information_for(exam)}
     }.html_safe
   end
 
@@ -17,6 +15,14 @@ module ExamsHelper
     if user.teacher_here?
       "#{fa_icon('graduation-cap', class: 'fa-fw',
                  text: "<strong>#{t :course}:</strong> #{exam.course.canonical_code}".html_safe)}
+      <br>"
+    end
+  end
+
+  def duration_information_for(exam)
+    if exam.duration?
+      "#{fa_icon(:stopwatch, class: 'fa-fw',
+                 text: "<strong>#{t :available_time}:</strong> #{t :time_in_minutes, time: exam.duration}".html_safe)}
       <br>"
     end
   end


### PR DESCRIPTION
## :dart: Goal

Do not show exam duration information on the book view if the exam doesn't have a duration, as it's an optional field.

## :memo: Details

Fixes bug introduced in #1689.

## :camera_flash: Screenshots

### Student view (no duration)
![image](https://user-images.githubusercontent.com/11304439/135181060-4a3071ec-f867-4b1a-854f-31ba11935ad1.png)


### Teacher view (no duration)
![image](https://user-images.githubusercontent.com/11304439/135181011-83532da0-a76c-4913-8274-f996a4725a90.png)

