### PR TITLE
Feature tooltip on verified messages

### DIFF
--- a/app/assets/javascripts/mumuki_laboratory/application/discussions.js
+++ b/app/assets/javascripts/mumuki_laboratory/application/discussions.js
@@ -70,6 +70,7 @@ mumuki.load(() => {
     discussionMessageToggleApprove: function (url, elem) {
       Forum.discussionPost(url).done(function () {
         elem.toggleClass("selected");
+        elem.attr('data-bs-original-title', '');
       });
     },
     discussionMessageToggleNotActuallyAQuestion: function (url, elem) {

--- a/app/views/discussions/_message.html.erb
+++ b/app/views/discussions/_message.html.erb
@@ -13,6 +13,10 @@
           <% if message.authorized?(current_user) && !message.deleted? %>
             <% if current_user&.moderator_here? %>
               <a class="discussion-message-approved <%= 'selected' if message.approved? %>"
+                 <% if message.approved? && current_user&.forum_supervisor_here? %>
+                   data-bs-toggle="tooltip" data-bs-placement="left"
+                   title="<%= t :approved_by, validator: message.approved_by.name, date: local_time(message.approved_at) %>"
+                 <% end %>
                  onclick="mumuki.Forum.discussionMessageToggleApprove('<%= approve_discussion_message_url(@discussion, message) %>', $(this))">
                 <%= fa_icon(:check, class: 'fa-lg') %>
               </a>

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -13,6 +13,7 @@ en:
   all: All
   appendix: Appendix
   appendix_teaser: Do you want to learn more? <a href="%{link}">Check this chapter's appendix</a>"
+  approved_by: Validated by %{validator} at %{date}
   approved_message: Validated by mentor
   approved_messages:
     other: validated

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -11,6 +11,7 @@ es-CL:
   and: y
   appendix: Apéndice
   appendix_teaser: ¿Quieres saber más? <a href="%{link}">Consulta el apéndice de este capítulo</a>
+  approved_by: Validado por %{validator} el %{date}
   approved_message: Validado por mentorías
   approved_messages:
     one: validado

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -14,6 +14,7 @@ es:
   and: y
   appendix: Apéndice
   appendix_teaser: ¿Querés saber más? <a href="%{link}">Consultá el apéndice de este capítulo</a>
+  approved_by: Validado por %{validator} el %{date}
   approved_message: Validado por mentorías
   approved_messages:
     one: validado

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -13,6 +13,7 @@ pt:
   and: e
   appendix: Apêndice
   appendix_teaser: Você quer saber mais? <a href="%{link}"> Consulte o apêndice deste capítulo </a>
+  approved_by: Validado pelo %{validator} em %{date}
   approved_message: Validado pelo mentor
   approved_messages:
     one: validado


### PR DESCRIPTION
## :dart: Goal

Show a tooltip when hovering over an approved message's :heavy_check_mark: to show who validated it and when.

## :memo: Details

I'm showing the full validator name as this feature is intended for forum supervisors, who are trusted users.

## :camera_flash: Screenshots

![image](https://user-images.githubusercontent.com/11304439/135342878-f61b8923-b912-44b8-a485-befef3cf50f9.png)
