### PR TITLE
Chore improve redirect after choosing exam

### DIFF
--- a/app/controllers/exam_authorization_requests_controller.rb
+++ b/app/controllers/exam_authorization_requests_controller.rb
@@ -7,17 +7,21 @@ class ExamAuthorizationRequestsController < ApplicationController
   def create
     authorization_request = @registration.request_authorization! current_user, @exam
     current_user.read_notification! @registration
-    flash.notice = I18n.t :exam_authorization_request_created
+    flash.notice = friendly_flash_notice(:exam_authorization_request_created)
     redirect_to exam_authorizations_user_path
   end
 
   def update
     @registration.update_authorization_request_by_id! params[:id], @exam
-    flash.notice = I18n.t :exam_authorization_request_saved
+    flash.notice = friendly_flash_notice(:exam_authorization_request_saved)
     redirect_to exam_authorizations_user_path
   end
 
   private
+
+  def friendly_flash_notice(key)
+    I18n.t key, friendly_date: helpers.local_time(@exam.start_time)
+  end
 
   def authorization_request_params
     params.require(:exam_authorization_request).permit(:exam_id, :exam_registration_id)

--- a/lib/mumuki/laboratory/locales/en.yml
+++ b/lib/mumuki/laboratory/locales/en.yml
@@ -121,9 +121,9 @@ en:
   errored: Oops, your solution didn't work
   exam_authorization_pending_explanation_html: You have until <strong>%{end_time}</strong> (%{location} time) to register. After that date, your request will be processed and you will receive a confirmation. <br> Don't forget to check the notifications!
   exam_authorization_request_approved_html: Your request was approved, don't forget to log in at <strong>%{date}</strong> (%{location} time). Good luck!
-  exam_authorization_request_created: Your registration to the exam has been saved!
+  exam_authorization_request_created: You registered for the exam on %{friendly_date}
   exam_authorization_request_rejected: Your request was rejected because you didn't meet the requirements.
-  exam_authorization_request_saved: Your registration to the exam has been updated!
+  exam_authorization_request_saved: You've changed your registration to the exam to %{friendly_date}
   exam_authorization_request_updated: Your registration to %{description} has been updated
   exam_registration_choose_exam: Choose date and time to attend to the exam
   exam_registration_explanation_html: You have until <strong>%{date}</strong> (%{location} time) to register. After that date, your request will be processed and you will receive a confirmation. <br> Don't forget to check the notifications!

--- a/lib/mumuki/laboratory/locales/es-CL.yml
+++ b/lib/mumuki/laboratory/locales/es-CL.yml
@@ -124,9 +124,9 @@ es-CL:
   exam_authorization_pending_change_date_html: Tienes tiempo hasta el <strong>%{end_time}</strong> (hora de %{location}) para cambiar el turno haciendo click <strong><a href="%{edit_path}">aquí</a></strong>. Pasada esa fecha, tu solicitud será evaluada y recibirás una confirmación. <br> ¡No olvides revisar las notificaciones!
   exam_authorization_pending_done_html: Ya te inscribiste a este examen. Luego del <strong>%{end_time}</strong> (hora de %{location}) se evaluará tu solicitud y recibirás una confirmación. <br> ¡No olvides de revisar las notificaciones!
   exam_authorization_request_approved_html: Tu solicitud fue aprobada, no olvides conectarte el <strong>%{date}</strong> (hora de %{location}). ¡Buena suerte!
-  exam_authorization_request_created: ¡Tu inscripción al examen se registró exitosamente!
+  exam_authorization_request_created: Te has inscripto al examen del día %{friendly_date}
   exam_authorization_request_rejected: Tu solicitud fue rechazada porque no cumpliste con los requisitos para rendir el examen.
-  exam_authorization_request_saved: ¡Tu inscripción al examen se modificó exitosamente!
+  exam_authorization_request_saved: Has cambiado tu inscripción al examen al día %{friendly_date}
   exam_authorization_request_updated: Hay novedades sobre tu inscripción a %{description}
   exam_registration_choose_exam: Seleccioná día y horario en el que te gustaría rendir el examen
   exam_registration_explanation_html: Tienes tiempo hasta el <strong>%{date}</strong> (hora de %{location}) para inscribirte. Pasada esa fecha, tu solicitud será evaluada y recibirás una confirmación. <br> ¡No olvides revisar las notificaciones!

--- a/lib/mumuki/laboratory/locales/es.yml
+++ b/lib/mumuki/laboratory/locales/es.yml
@@ -131,9 +131,9 @@ es:
   exam_authorization_pending_change_date_html: Tenés tiempo hasta el <strong>%{end_time}</strong> (hora de %{location}) para cambiar el turno haciendo click <strong><a href="%{edit_path}">acá</a></strong>. Pasada esa fecha, tu solicitud será evaluada y recibirás una confirmación. <br> ¡No te olvides de revisar las notificaciones!
   exam_authorization_pending_done_html: Ya te inscribiste a este examen. Luego del <strong>%{end_time}</strong> (hora de %{location}) se evaluará tu solicitud y recibirás una confirmación. <br> ¡No te olvides de revisar las notificaciones!
   exam_authorization_request_approved_html: Tu solicitud fue aprobada, no olvides conectarte el <strong>%{date}</strong> (hora de %{location}). ¡Buena suerte!
-  exam_authorization_request_created: ¡Tu inscripción al examen se registró exitosamente!
+  exam_authorization_request_created: Te inscribiste al examen del día %{friendly_date}
   exam_authorization_request_rejected: Tu solicitud fue rechazada porque no cumpliste con los requisitos para rendir el examen.
-  exam_authorization_request_saved: ¡Tu inscripción al examen se modificó exitosamente!
+  exam_authorization_request_saved: Cambiaste tu inscripción al examen al día %{friendly_date}
   exam_authorization_request_updated: Hay novedades sobre tu inscripción a %{description}
   exam_registration_choose_exam: Seleccioná día y horario en el que te gustaría rendir el examen
   exam_registration_explanation_html: Tenés tiempo hasta el <strong>%{date}</strong> (hora de %{location}) para inscribirte. Pasada esa fecha, tu solicitud será evaluada y recibirás una confirmación. <br> ¡No te olvides de revisar las notificaciones!

--- a/lib/mumuki/laboratory/locales/pt.yml
+++ b/lib/mumuki/laboratory/locales/pt.yml
@@ -124,9 +124,9 @@ pt:
   errored: Opa! Sua solução não pode ser executada
   exam_authorization_pending_explanation_html: Você tem tempo até <strong>%{date}</strong> (horário de %{location}) para se inscrever. Após essa data, sua inscrição será avaliada e você receberá uma confirmação. <br> Não se esqueça de verificar as notificações!
   exam_authorization_request_approved_html: Sua solicitação foi aprovada, não se esqueça de conectar em <strong>%{date}</strong> (horário de %{location}). Boa sorte!
-  exam_authorization_request_created: Seu registro de exame foi salvo com sucesso!
+  exam_authorization_request_created: Você se inscreveu para o exame do dia %{friendly_date}
   exam_authorization_request_rejected: Sua solicitação foi rejeitada porque você não atendeu aos requisitos.
-  exam_authorization_request_saved: Seu registro de exame foi modificado com sucesso!
+  exam_authorization_request_saved: Você alterou seu registro de exame para o dia %{friendly_date}
   exam_authorization_request_updated: Há notícias sobre seu registro para %{description}
   exam_registration_choose_exam: Selecione o dia e a hora em que gostaria de fazer o exame
   exam_registration_explanation_html: Você tem tempo até <strong>%{date}</strong> (horário de %{location}) para se inscrever. Após essa data, sua inscrição será avaliada e você receberá uma confirmação. <br> Não se esqueça de verificar as notificações!


### PR DESCRIPTION
## :dart: Goal
Make exam authorization request flow a little more friendly to prevent mis-choosing.

## :memo: Details
Changes consist of redirecting to exam authorizations view instead of root, so user will see the chosen shift for the exam after doing so, and also adding the exam date to the flash notice.

## :camera_flash: Screenshots
https://user-images.githubusercontent.com/11720274/137416843-c62a6b39-c7b1-4847-9302-08ff88735f47.mp4

## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.