### PR TITLE
Fix discussion message header on mobile view

### DIFF
--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
@@ -329,12 +329,11 @@ $moderator-badge-color: #dd9900;
     }
     .discussion-message-bubble-title {
       padding: 5px 15px;
-      display: block;
+      display: flex;
       .message-date {
         font-size: 15px;
       }
       .actions {
-        float: right;
         > a, .dropdown {
           margin-left: 20px;
           cursor: pointer;

--- a/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
+++ b/app/assets/stylesheets/mumuki_laboratory/application/modules/_discussion.scss
@@ -318,7 +318,6 @@ $moderator-badge-color: #dd9900;
   margin-bottom: 20px;
   .discussion-message-bubble-header {
     background-color: $mu-color-highlight-background;
-    height: 40px;
     &:before {
       position: absolute;
       top: calc(20px - #{$discussion-message-arrow-size + 2px} / 2);

--- a/app/views/discussions/_description_message.html.erb
+++ b/app/views/discussions/_description_message.html.erb
@@ -2,10 +2,12 @@
   <div class="discussion-message-bubble">
     <div class="discussion-message-bubble-header">
       <div class="discussion-message-bubble-title">
-        <%= linked_discussion_user_name(discussion.initiator) %>
-        <span class="message-date">
-          <%= friendly_time(discussion.created_at, :time_since) %>
-        </span>
+        <div class="flex-fill">
+          <%= linked_discussion_user_name(discussion.initiator) %>
+          <span class="message-date">
+            <%= friendly_time(discussion.created_at, :time_since) %>
+          </span>
+        </div>
       </div>
     </div>
     <div class="discussion-message-bubble-content">

--- a/app/views/discussions/_message.html.erb
+++ b/app/views/discussions/_message.html.erb
@@ -2,14 +2,16 @@
   <div class="discussion-message-bubble">
     <div class="discussion-message-bubble-header">
       <div class="discussion-message-bubble-title">
-        <%= linked_discussion_user_name user %>
-        <% if message.from_moderator? %>
-          <span class="moderator-badge"><%= t(:moderation) %></span>
-        <% end %>
-        <span class="message-date">
-          <%= friendly_time(message.created_at, :time_since) %>
-        </span>
-        <span class="actions">
+        <div class="flex-fill">
+          <%= linked_discussion_user_name user %>
+          <% if message.from_moderator? %>
+            <span class="moderator-badge"><%= t(:moderation) %></span>
+          <% end %>
+          <span class="message-date">
+            <%= friendly_time(message.created_at, :time_since) %>
+          </span>
+        </div>
+        <span class="actions flex-shrink-0">
           <% if message.authorized?(current_user) && !message.deleted? %>
             <% if current_user&.moderator_here? %>
               <a class="discussion-message-approved <%= 'selected' if message.approved? %>"


### PR DESCRIPTION
## :dart: Goal

Fix a discussion message's header, which had a fixed height and looked wrong on mobile.

## :memo: Details

Prefer flex over float.

## :camera_flash: Screenshots

### Before
![image](https://user-images.githubusercontent.com/11304439/140416485-2f728d8f-d424-4053-b1a1-cd59b46bdef6.png)

___

### After
![image](https://user-images.githubusercontent.com/11304439/140416545-b9f69685-9cd9-49ad-8bf7-17b0b1d46963.png)


## :soon: Future work

It kinda breaks a little on users with veeeeeeery long names, but I don't see it happening on real-use cases.
