### PR TITLE
Map errors with names instead of http numbers

### DIFF
--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -8,12 +8,10 @@
         <%= t(:error_description, error: link_to_status_codes(403)).html_safe %>
       </p>
       <p class="mu-error-explanation-line">
-        <%= Organization.current.explain_error(403, explanation).html_safe %>
+        <%= Organization.current.explain_error(error_code, explanation).html_safe %>
       </p>
       <p class="mu-error-contact-line mu-maybe">
         <%= t(:contact_administrator, link: mail_to_administrator).html_safe %>
       </p>
     </div>
 <% end %>
-
-

--- a/app/views/errors/gone.html.erb
+++ b/app/views/errors/gone.html.erb
@@ -8,8 +8,7 @@
         <%= t(:error_description, error: link_to_status_codes(410)).html_safe %>
       </p>
       <p class="mu-error-explanation-line">
-        <%= Organization.current.explain_error(410, explanation).html_safe %>
+        <%= Organization.current.explain_error(error_code, explanation).html_safe %>
       </p>
     </div>
 <% end %>
-

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -8,7 +8,7 @@
         <%= t(:error_description, error: link_to_error_404).html_safe %>
       </p>
       <p class="mu-error-explanation-line">
-        <%= Organization.current.explain_error(404, :not_found_explanation).html_safe %>
+        <%= Organization.current.explain_error(:not_found, :not_found_explanation).html_safe %>
       </p>
     </div>
 <% end %>

--- a/lib/mumuki/laboratory/controllers/dynamic_errors.rb
+++ b/lib/mumuki/laboratory/controllers/dynamic_errors.rb
@@ -41,27 +41,27 @@ module Mumuki::Laboratory::Controllers::DynamicErrors
   def forbidden
     message = "The operation on organization #{Organization.current} was forbidden to user #{current_user.uid} with permissions #{current_user.permissions}"
     Rails.logger.info message
-    render_error 'forbidden', 403, locals: { explanation: :forbidden_explanation }, error_message: message
+    render_error 'forbidden', 403, locals: { error_code: :forbidden, explanation: :forbidden_explanation }, error_message: message
   end
 
   def disabled
-    render_error 'forbidden', 403, locals: { explanation: :disabled_explanation }
+    render_error 'forbidden', 403, locals: { error_code: :disabled, explanation: :disabled_explanation }
   end
 
   def blocked_forum
-    render_error 'forbidden', 403, locals: { explanation: :blocked_forum_explanation }
+    render_error 'forbidden', 403, locals: { error_code: :blocked_forum, explanation: :blocked_forum_explanation }
   end
 
   def gone
-    render_error 'gone', 410, locals: { explanation: :gone_explanation }
+    render_error 'gone', 410, locals: { error_code: :gone, explanation: :gone_explanation }
   end
 
   def unprepared_organization
-    render_error 'forbidden', 403, locals: { explanation: :unprepared_organization_explanation }
+    render_error 'forbidden', 403, locals: { error_code: :unprepared_organization, explanation: :unprepared_organization_explanation }
   end
 
   def disabled_organization
-    render_error 'gone', 410, locals: { explanation: :disabled_organization_explanation }
+    render_error 'gone', 410, locals: { error_code: :disabled_organization, explanation: :disabled_organization_explanation }
   end
 
   def render_error(template, status, options={})

--- a/spec/features/not_found_public_flow_spec.rb
+++ b/spec/features/not_found_public_flow_spec.rb
@@ -6,7 +6,14 @@ feature 'not found public on app' do
   let!(:some_orga) { create(:public_organization, name: 'someorga', profile: profile) }
 
   let(:profile) { Mumuki::Domain::Organization::Profile.parse json  }
-  let(:json) { { contact_email: 'some@email.com', locale: 'en', time_zone: 'Brasilia', errors_explanations: { 404 => 'Some explanation'} } }
+  let(:json) do
+     {
+      contact_email: 'some@email.com',
+      locale: 'en',
+      time_zone: 'Brasilia',
+      errors_explanations: { "not_found" => 'Some explanation'}
+    }
+  end
 
   scenario 'when route does not exist in explicit central' do
     set_subdomain_host! 'test'


### PR DESCRIPTION
# :dart: Goal

To allow more fine-grained customization of error messages, since HTTP code are ambiguous and more than one error code maps to the same HTTP code. 

# :memo: Details

I have just changed HTTP code numbers by symbols.   I did not change `unauthorized` nor `internal_server_error` since they were not customizable in first place. 

# :back: Backwards compatibility

This PR is NOT backwards compatible. Data migration may be required. 

