### PR TITLE
Get languages via query instead of calculating in-memory

### DIFF
--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -122,7 +122,9 @@ module DiscussionsHelper
   #TODO: this one uses a long method chain in order to take advantage of eager load
   # Delegate it once again when polymorphic association is removed
   def discussions_languages(discussions)
-    @languages ||= discussions.map { |it| it.exercise.language.name }.uniq
+    @languages ||= discussions.distinct
+                              .joins(:exercise)
+                              .pluck('languages.name')
   end
 
   def discussion_status_filter_link(status, discussions)


### PR DESCRIPTION
## :dart: Goal
Improve performance of discussions view render.

## :memo: Details
We were calculating which languages should be shown on filters in-memory which caused all of the organization's discussions to have to be loaded, resulting in poor performance on discussions index view. Replacing the in-memory calculation with a single query.

Additionally, we've noticed with @felipecalvo that for the worst offenders on that view's loading time, postgres seems to be choosing execution plans which seem like they'd be worse performers than I'm getting in development (nested-loop in production vs hash join in development)... not really sure how to fix that; not yet at least.

## :camera_flash: Screenshots
Before:
![image](https://user-images.githubusercontent.com/11720274/139945578-4d4bebf1-48d0-42df-9def-a291f099cdba.png)
![image](https://user-images.githubusercontent.com/11720274/139945530-d62304f6-0635-43e0-80de-ab49a8fe023f.png)

After:
![image](https://user-images.githubusercontent.com/11720274/139945667-ff4daaf2-441b-4f42-a5e6-f428687a895c.png)
![image](https://user-images.githubusercontent.com/11720274/139945738-1a48195b-3fb5-4335-afec-c68e98768662.png)

Time difference doesn't seem massive on my machine, but I expect the problem is aggravated by the fact that we're running on pretty low memory, in production. We'll have to test this in production to see how much this improves things.

## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.
