### PR TITLE
Group status count queries together to improve performance

### DIFF
--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -53,37 +53,37 @@ module DiscussionsHelper
   end
 
   def forum_terms_link
-    %Q{
+    <<~HTML.html_safe
       <span>
         #{ t(:forum_terms_link, terms_link: link_to_forum_terms).html_safe }
       </span>
-    }.html_safe
+    HTML
   end
 
   def discussion_messages_count(discussion)
-    %Q{
+    <<~HTML.html_safe
       <span class="discussion-messages-count">
         #{fa_icon :comments, type: :regular, text: discussion.messages_count}
       </span>
-    }.html_safe
+    HTML
   end
 
   def discussion_validated_messages_count(discussion)
-    %Q{
+    <<~HTML.html_safe
       <span class="discussion-validated-messages-count">
         #{fa_icon :comment, type: :regular}#{fa_icon :check, text: discussion.validated_messages_count}
       </span>
-    }.html_safe
+    HTML
   end
 
   def discussion_upvotes_icon(discussion)
     if discussion.upvotes_count > 0
-      %Q{
+      <<~HTML.html_safe
         <span class="discussion-icon fa-stack fa-xs">
           <i class="far fa-star fa-stack-2x"></i>
           <i class="fas fa-stack-1x">#{discussion.upvotes_count}</i>
         </span>
-      }.html_safe
+      HTML
     end
   end
 
@@ -99,12 +99,12 @@ module DiscussionsHelper
   end
 
   def new_discussion_link(teaser_text, link_text)
-    %Q{
+    <<~HTML.html_safe
       <h4>
         <span>#{t(teaser_text)}</span>
         #{link_to t(link_text), new_exercise_discussion_path(@debatable, anchor: 'new-discussion-description-container') }
       </h4>
-    }.html_safe
+    HTML
   end
 
   def discussion_count_for_status(status, discussions)
@@ -137,17 +137,17 @@ module DiscussionsHelper
   end
 
   def discussion_status_filter(status, discussions_count)
-    %Q{
-    #{discussion_status_fa_icon(status)}
+    <<~HTML.html_safe
+      #{discussion_status_fa_icon(status)}
       <span>
         #{t("#{status}_count", count: discussions_count)}
       </span>
-    }.html_safe
+    HTML
   end
 
   def discussion_dropdown_filter(label, filters, can_select_all = false, &block)
     if filters.present?
-      %Q{
+      <<~HTML.html_safe
         <div class="dropdown discussions-toolbar-filter">
           <a id="dropdown-#{label}" data-bs-toggle="dropdown" role="menu">
             #{t label} #{fa_icon :'caret-down', class: 'fa-xs'}
@@ -157,7 +157,7 @@ module DiscussionsHelper
             #{discussion_filter_list(label, filters, &block)}
           </ul>
         </div>
-      }.html_safe
+      HTML
     end
   end
 
@@ -246,7 +246,7 @@ module DiscussionsHelper
   end
 
   def discussion_delete_message_dropdown(discussion, message)
-    %Q{
+    <<~HTML.html_safe
       <span class="dropdown">
         #{content_tag :span, fa_icon('trash-alt', type: :regular, class: 'fa-lg'), role: 'menu', 'data-bs-toggle': 'dropdown',
                       class: 'discussion-delete-message', id: 'deleteDiscussionDropdown'}
@@ -256,17 +256,17 @@ module DiscussionsHelper
           #{discussion_delete_message_option discussion, message, :discloses_personal_information, 'user-tag'}
         </ul>
       </span>
-    }.html_safe
+    HTML
   end
 
   def discussion_delete_message_option(discussion, message, motive, icon)
-    %Q{
+    <<~HTML.html_safe
       <li>
         #{link_to fa_icon(icon, text: t("deletion_motive.#{motive}.present"), class: 'fa-fw fixed-icon'),
                   discussion_message_path(discussion, message, motive: motive), method: :delete, class: 'dropdown-item',
                   role: 'menuitem', data: { confirm: t(:are_you_sure, action: t(:destroy_message)) } }
       </li>
-    }.html_safe
+    HTML
   end
 
   def message_deleted_text(message)

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -122,7 +122,9 @@ module DiscussionsHelper
   #TODO: this one uses a long method chain in order to take advantage of eager load
   # Delegate it once again when polymorphic association is removed
   def discussions_languages(discussions)
-    @languages ||= discussions.map { |it| it.exercise.language.name }.uniq
+    @languages ||= discussions.distinct
+                              .joins(:exercise)
+                              .pluck('languages.name')
   end
 
   def discussion_status_filter_link(status, discussions)

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -141,7 +141,7 @@ module DiscussionsHelper
   end
 
   def discussion_status_filter_link(status, status_counts)
-    discussions_count = status_counts[status.to_sym]
+    discussions_count = status_counts[status.to_sym] || 0
     if status.should_be_shown?(discussions_count, current_user)
       discussion_filter_item(:status, status) do
         discussion_status_filter(status, discussions_count)

--- a/app/views/layouts/_discussions.html.erb
+++ b/app/views/layouts/_discussions.html.erb
@@ -3,9 +3,7 @@
   <div class="discussions-toolbar">
     <div class="discussions-toolbar-status">
       <div class="d-none d-lg-block">
-        <% discussions_statuses.each do |status| %>
-          <%= discussion_status_filter_link(status, @discussions) %>
-        <% end %>
+        <%= discussion_status_filter_links(@discussions) %>
       </div>
     </div>
     <div>


### PR DESCRIPTION
## :dart: Goal
Improve performance a little further on discussions view render by grouping status count queries which were not being cached for some reason.

## :memo: Details
Replacing uses of `%Q{}` syntax with squiggly heredocs too since some editors will pick up on the delimiter used and highlight the heredoc content accordingly.

## :camera_flash: Screenshots
Before:
![image](https://user-images.githubusercontent.com/11720274/139951986-4c6e8d95-784a-40b0-ad30-21f6f4cbb599.png)
![image](https://user-images.githubusercontent.com/11720274/139952022-1adca873-b4ae-463b-bee6-45728b1ff77a.png)

After:
![image](https://user-images.githubusercontent.com/11720274/139951869-ea7dad9f-196f-4410-a2a8-619ad0830a04.png)
![image](https://user-images.githubusercontent.com/11720274/139951824-6ed3c3ed-d1dd-4147-8fb6-50b9897d2dd2.png)

It ain't much, but it's honest work :farmer:

## :warning: Dependencies
Rebase after merging https://github.com/mumuki/mumuki-laboratory/pull/1714.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.