### PR TITLE
Chore reference message sender via id

### DIFF
--- a/app/views/discussions/show.html.erb
+++ b/app/views/discussions/show.html.erb
@@ -26,7 +26,7 @@
         <%= render partial: 'discussions/description_message', locals: { discussion: @discussion } %>
       <% end %>
       <% @discussion.visible_messages.each do |message| %>
-        <%= render partial: 'discussions/message', locals: { user: message.sender_user, message: message } %>
+        <%= render partial: 'discussions/message', locals: { user: message.sender, message: message } %>
       <% end %>
       <% if @discussion.commentable_by?(current_user) %>
         <hr class="message-divider">

--- a/mumuki-laboratory.gemspec
+++ b/mumuki-laboratory.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 5.1.6"
 
-  s.add_dependency 'mumuki-domain', '~> 9.21.0'
+  s.add_dependency 'mumuki-domain', '~> 9.22.0'
   s.add_dependency 'mumukit-bridge', '~> 4.1'
   s.add_dependency 'mumukit-login', '~> 7.7'
   s.add_dependency 'mumukit-nuntius', '~> 6.1'

--- a/spec/controllers/discussions_messages_controller_spec.rb
+++ b/spec/controllers/discussions_messages_controller_spec.rb
@@ -32,7 +32,7 @@ describe DiscussionsMessagesController, type: :controller, organization_workspac
   end
 
   describe 'delete' do
-    let(:message) { create(:message, discussion: discussion, sender: student.uid) }
+    let(:message) { create(:message, discussion: discussion, sender: student) }
 
     describe 'for student' do
       before { set_current_user! student }
@@ -64,7 +64,7 @@ describe DiscussionsMessagesController, type: :controller, organization_workspac
       end
 
       describe 'someone else\'s message' do
-        let(:message) { create(:message, discussion: discussion, sender: moderator.uid) }
+        let(:message) { create(:message, discussion: discussion, sender: moderator) }
         before do
           delete :destroy, params: {id: message.id, discussion_id: discussion.id, motive: :self_deleted}
           message.reload
@@ -94,7 +94,7 @@ describe DiscussionsMessagesController, type: :controller, organization_workspac
   end
 
   describe 'approve' do
-    let(:message) { create(:message, discussion: discussion, sender: student.uid) }
+    let(:message) { create(:message, discussion: discussion, sender: student) }
 
     describe 'for student' do
       before { set_current_user! student }
@@ -114,7 +114,7 @@ describe DiscussionsMessagesController, type: :controller, organization_workspac
   end
 
   describe 'question' do
-    let(:message) { create(:message, discussion: discussion, sender: student.uid) }
+    let(:message) { create(:message, discussion: discussion, sender: student) }
 
     describe 'for student' do
       before { set_current_user! student }
@@ -133,7 +133,7 @@ describe DiscussionsMessagesController, type: :controller, organization_workspac
     end
 
     describe 'preview' do
-      let(:message) { create(:message, content: 'Message in **bold** and _italics_', discussion: discussion, sender: student.uid) }
+      let(:message) { create(:message, content: 'Message in **bold** and _italics_', discussion: discussion, sender: student) }
 
       describe 'for student' do
         before { set_current_user! student }

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -11,10 +11,10 @@ describe MessagesController, organization_workspace: :test do
 
     it { expect(response.status).to eq 302 }
     it { expect(user.assignments.size).to eq 1 }
-    it { expect(user.messages.size).to eq 1 }
+    it { expect(user.direct_messages.size).to eq 1 }
 
     describe 'deleting exercises does delete all messages' do
-      before { @message_id = user.messages.first.id }
+      before { @message_id = user.direct_messages.first.id }
       before { exercise.destroy }
 
       it { expect { Message.find(@message_id) }.to raise_exception(ActiveRecord::RecordNotFound) }
@@ -27,6 +27,6 @@ describe MessagesController, organization_workspace: :test do
 
     it { expect(response.status).to eq 302 }
     it { expect(user.assignments.size).to eq 1 }
-    it { expect(user.messages.size).to eq 1 }
+    it { expect(user.direct_messages.size).to eq 1 }
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -387,10 +387,12 @@ ActiveRecord::Schema.define(version: 20211020224011) do
     t.datetime "deleted_at"
     t.bigint "deleted_by_id"
     t.bigint "assignment_id"
+    t.bigint "sender_id"
     t.boolean "from_moderator"
     t.index ["approved_by_id"], name: "index_messages_on_approved_by_id"
     t.index ["assignment_id"], name: "index_messages_on_assignment_id"
     t.index ["deleted_by_id"], name: "index_messages_on_deleted_by_id"
+    t.index ["sender_id"], name: "index_messages_on_sender_id"
   end
 
   create_table "notifications", force: :cascade do |t|

--- a/spec/features/discussion_flow_spec.rb
+++ b/spec/features/discussion_flow_spec.rb
@@ -162,8 +162,8 @@ feature 'Discussion Flow', organization_workspace: :test do
       end
 
       context 'and forum enabled' do
-        let!(:problem_2_discussion_message) { create(:message, discussion: problem_2_discussions.first, sender: another_student.uid) }
-        let!(:another_problem_2_discussion_message) { create(:message, discussion: problem_2_discussions.first, sender: another_student.uid) }
+        let!(:problem_2_discussion_message) { create(:message, discussion: problem_2_discussions.first, sender: another_student) }
+        let!(:another_problem_2_discussion_message) { create(:message, discussion: problem_2_discussions.first, sender: another_student) }
         before do
           Organization.current.update! forum_enabled: true
           another_problem_2_discussion_message.soft_delete! :inappropriate_content, moderator

--- a/spec/features/profile_flow_spec.rb
+++ b/spec/features/profile_flow_spec.rb
@@ -104,6 +104,8 @@ feature 'Profile Flow', organization_workspace: :test do
     end
 
     context 'with messages' do
+      before { create :user, uid: 'test-email@gmail.com' }
+
       scenario 'visit messages' do
         Organization.find_by_name('test').switch!
         problem.submit_solution! user, {content: 'something'}


### PR DESCRIPTION
## :dart: Goal
Stop referencing user via uid in messages.

## :memo: Details
None.

## :camera_flash: Screenshots
None.

## :warning: Dependencies
Requires https://github.com/mumuki/mumuki-domain/pull/248.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.